### PR TITLE
si ricorda di essere incazzata

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -164,5 +164,11 @@
         "spontaneous_probability": 0.15,
         "spontaneous_min_silence": 3600,
         "spontaneous_min_activity": 3
+    },
+    "affect": {
+        "enabled": true,
+        "half_life_minutes": 25,
+        "person_half_life_hours": 60,
+        "memory_ttl_hours": 6
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,7 @@ reactive chat path — the consciousness is the only mind.
 | `Expression` | `src/core/expression/voice.py` | the **only** voice/visual output sink |
 | `TextHumanizer` | `src/core/expression/humanizer.py` | written output: one line = one message, with typing |
 | `Attention` | `src/core/attention/` | the gate: what wakes the mind vs what she merely notices |
+| `AffectState` | `src/core/affect/` | how she feels, and who put her there |
 | `MemoryStore` | `src/core/memory/` | everything she remembers, in one SQLite file |
 | `Consciousness` | `src/core/consciousness.py` | the mind: one context, one loop |
 | `EventManager` | `src/core/events.py` | 200-event ring buffer for the dashboard |
@@ -280,7 +281,9 @@ single transaction, and "who have I seen most" is a query rather than a scan.
 | Person cards | `people` + `facts` | only those present, max 5 | auto-promotion + `remember_person` + dreamer + profiler |
 | Conversations | `messages` + `summaries` | per conversation turn | the platform skills |
 | Self-lore | `self_facts` + `self_profile` | yes (last 15 facts) | the dreamer only |
-| Hot facts | `hot_facts` (TTL) | yes (max 6) | dreamer + morning pass |
+| Hot facts | `hot_facts` (TTL) | yes (max 6) | dreamer + morning pass + a strong reaction |
+| Standing mood | `settings` (`affect.state`) | only past a threshold | every line she speaks |
+| Standing with a person | `people.warmth` | with their card | a strong reaction |
 | Sessions | `sessions` | never | the brain + the dreamer |
 
 Re-ranking is `similarity*0.7 + recency*0.3` with `1/(1+days*0.1)` decay. Every
@@ -325,6 +328,62 @@ whether to answer someone who just spoke to you is what makes a bot feel broken.
 Every decision is published as a `system` event with `reaction`, `score` and
 `reason`, and shown in Brain Activity. That is not optional instrumentation:
 without seeing *why* something was ignored, tuning the thresholds is guesswork.
+
+## Mood
+
+`src/core/affect/`. Everything that happened to her either lasted under two
+minutes (a cooldown, an activity window) or became a fact in a prompt. Nothing
+lived on the scale of the last half hour, which is the scale on which people
+read someone's mood.
+
+There is **no new sense and no new tool**. She already picks a mood for every
+line she speaks, and until now that mood only ever reached a PNG. It is the
+signal, so this costs no extra model call and no extra prompt.
+
+- `rules.py` is **pure** — `Affect` is `(valence, arousal, updated_at)`, and
+  the two axes are two rather than one because angry and sad are both negative
+  and sound nothing alike.
+- `state.py` holds it, persists it in `settings` and decides who caused it.
+
+**It decays on read, not on a tick.** The value carries the moment it was
+written and is aged when someone asks for it — the same reason `hot_facts` has
+no sweeper. No background task, and a restart comes back correctly aged for
+free: crash while furious and she reboots furious, sleep on it and she does not.
+
+One strong line lands on three clocks:
+
+| | Where | Half-life |
+|---|---|---|
+| the mood itself | `settings` | ~25 min |
+| how she stands with whoever caused it | `people.warmth` | ~2.5 days |
+| what it was about | `hot_facts` (`source='live'`) | 6h TTL |
+
+**Attribution is one clear author or nothing.** In a busy room the mood is the
+room's, and picking a face out of it would be inventing a grudge. Someone who
+did get a real reaction out of her earns a card, through the promotion rule that
+already exists — `marked_by_bea` — rather than a new one.
+
+Two rules keep it honest:
+
+- **It never touches `is_addressed`.** That gate is deterministic so that
+  answering someone who just spoke to you is not a dice roll. A mood may colour
+  the probabilistic side; it may not make her ignore her own name.
+- **It describes, it never prescribes.** `[HOW YOU FEEL]` says how she feels and
+  stops. How a person like her *acts* on that is the soul's business, and the
+  soul is a file the owner writes — an instruction here would be the engine
+  overwriting somebody's character.
+
+Where it is audible: `expression/prosody.py` turns a mood into a deviation from
+the configured voice (rate, pitch, volume), which each TTS wrapper translates as
+far as it can — Edge does all three, Kokoro only rate, Orpheus none. `Prosody()`
+is neutral and byte-identical to no prosody at all, so switching the feature off
+really does leave her voice alone.
+
+Scoped conversation turns **read** the mood and never write it: a written reply
+has no mood to pick, so the mood forms on stage and merely colours what she
+types.
+
+---
 
 ## Models
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,12 @@ This is `config.example.json` verbatim; it matches the dataclass defaults in
         "spontaneous_probability": 0.15,
         "spontaneous_min_silence": 3600,
         "spontaneous_min_activity": 3
+    },
+    "affect": {
+        "enabled": true,
+        "half_life_minutes": 25,
+        "person_half_life_hours": 60,
+        "memory_ttl_hours": 6
     }
 }
 ```
@@ -289,6 +295,22 @@ A day rather than an event loop.
 | `spontaneous_probability` | `0.15` | Even when eligible, usually she does not |
 | `spontaneous_min_silence` | `3600` | She spoke there recently: more is noise, not presence |
 | `spontaneous_min_activity` | `3` | Below this the room is dead and she would be talking to nobody |
+
+---
+
+## affect
+
+Whether what happens to her sticks, and for how long. [How it works →](architecture.md#mood)
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `true` | Off, every line starts from neutral and nothing carries over |
+| `half_life_minutes` | `25` | Minutes until a mood is half of what it was |
+| `person_half_life_hours` | `60` | Hours until how she stands with someone is half of what it was |
+| `memory_ttl_hours` | `6` | How long she can still say what put her in that mood |
+
+Nothing here tells her how to *behave* when she feels something — that is the
+soul's job, and the soul is a file you write.
 
 ---
 

--- a/src/core/affect/__init__.py
+++ b/src/core/affect/__init__.py
@@ -1,0 +1,3 @@
+from src.core.affect.rules import Affect, decay, is_strong, render, stir, warmth_phrase
+
+__all__ = ["Affect", "decay", "stir", "render", "is_strong", "warmth_phrase"]

--- a/src/core/affect/__init__.py
+++ b/src/core/affect/__init__.py
@@ -1,4 +1,5 @@
+# only the pure half is re-exported here: `memory.store` imports `affect.rules`,
+# and pulling `state` in from this file would close the loop back through it
 from src.core.affect.rules import Affect, decay, is_strong, render, stir, warmth_phrase
-from src.core.affect.state import AffectState
 
-__all__ = ["AffectState", "Affect", "decay", "stir", "render", "is_strong", "warmth_phrase"]
+__all__ = ["Affect", "decay", "stir", "render", "is_strong", "warmth_phrase"]

--- a/src/core/affect/__init__.py
+++ b/src/core/affect/__init__.py
@@ -1,3 +1,4 @@
 from src.core.affect.rules import Affect, decay, is_strong, render, stir, warmth_phrase
+from src.core.affect.state import AffectState
 
-__all__ = ["Affect", "decay", "stir", "render", "is_strong", "warmth_phrase"]
+__all__ = ["AffectState", "Affect", "decay", "stir", "render", "is_strong", "warmth_phrase"]

--- a/src/core/affect/rules.py
+++ b/src/core/affect/rules.py
@@ -1,0 +1,135 @@
+"""How she feels, as pure functions over two numbers and a timestamp.
+
+It decays on read, not on a tick: the value carries when it was written, so a
+restart comes back correctly aged and a test can stand at a fixed instant.
+`render` describes a state and never prescribes behaviour — how she acts on it
+is the soul's job, and the soul is a file the owner writes.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Tuple
+
+# long enough to survive a few exchanges, short enough not to own the stream
+HALF_LIFE_SECONDS = 25 * 60.0
+
+# a rancour outlives a mood: days, not minutes
+PERSON_HALF_LIFE_SECONDS = 60 * 3600.0
+
+# one sharp line is a blip, two in a row are a mood
+WEIGHT = 0.35
+
+# under this, saying how she feels would be noise on every turn
+FELT = 0.30
+
+# where a mood stops being weather and starts being somebody's doing
+STRONG_VALENCE = 0.60
+
+WARMTH_SHOWN = 0.25
+
+
+@dataclass(frozen=True)
+class Affect:
+    """Where she is on the two axes, and when that was last true."""
+
+    valence: float = 0.0
+    arousal: float = 0.0
+    updated_at: float = 0.0
+
+    @property
+    def strength(self) -> float:
+        return max(abs(self.valence), abs(self.arousal))
+
+    @property
+    def felt(self) -> bool:
+        return self.strength >= FELT
+
+
+def clamp(x: float, low: float = -1.0, high: float = 1.0) -> float:
+    return max(low, min(high, float(x)))
+
+
+def faded(value: float, elapsed: float, half_life: float) -> float:
+    """`value` after `elapsed` seconds. Toward zero, never past it."""
+    if half_life <= 0 or elapsed <= 0 or value == 0.0:
+        return value if elapsed <= 0 else 0.0
+    return value * math.pow(0.5, elapsed / half_life)
+
+
+def decay(affect: Affect, now: float, half_life: float = HALF_LIFE_SECONDS) -> Affect:
+    """Her state as it stands `now`."""
+    elapsed = now - affect.updated_at
+    if elapsed <= 0:
+        return affect
+    return Affect(
+        valence=faded(affect.valence, elapsed, half_life),
+        arousal=faded(affect.arousal, elapsed, half_life),
+        updated_at=now,
+    )
+
+
+def stir(affect: Affect, vector: Tuple[float, float], *, now: float,
+         half_life: float = HALF_LIFE_SECONDS, weight: float = WEIGHT) -> Affect:
+    """What she feels after expressing `vector`, on top of what she already felt.
+
+    Additive rather than a slide toward the new mood: a neutral line has a zero
+    vector, and under a slide every ordinary sentence would scrub the mood away.
+    Time is what clears a mood, not talking.
+    """
+    base = decay(affect, now, half_life)
+    return Affect(
+        valence=clamp(base.valence + vector[0] * weight),
+        arousal=clamp(base.arousal + vector[1] * weight),
+        updated_at=now,
+    )
+
+
+def is_strong(vector: Tuple[float, float]) -> bool:
+    """Did that land hard enough to be somebody's doing?
+
+    Valence alone decides: a loud surprise has plenty of arousal without anyone
+    having done anything to her.
+    """
+    return abs(vector[0]) >= STRONG_VALENCE
+
+
+def render(affect: Affect) -> str:
+    """`[HOW YOU FEEL]`, or nothing at all — which is most of the time.
+
+    Every line is a state, never an instruction.
+    """
+    if not affect.felt:
+        return ""
+
+    valence, arousal = affect.valence, affect.arousal
+    if valence <= -FELT:
+        if arousal >= FELT:
+            line = "Something got under your skin earlier and it hasn't worn off."
+        elif arousal <= -FELT:
+            line = "You feel flat. Nothing has gone your way for a while."
+        else:
+            line = "You're in a bad mood, and it has been going on a while."
+    elif valence >= FELT:
+        if arousal >= FELT:
+            line = "You're still riding something that went well."
+        else:
+            line = "You're in a good mood, and have been for a while."
+    elif arousal >= FELT:
+        line = "You're wound up, without anything in particular behind it."
+    else:
+        line = "You're running out of steam."
+
+    return f"[HOW YOU FEEL]\n{line}"
+
+
+def warmth_phrase(warmth: float) -> str:
+    """How she stands with one person, as words. A number would get recited."""
+    if warmth >= 0.6:
+        return "you're fond of them right now"
+    if warmth >= WARMTH_SHOWN:
+        return "they're in your good books lately"
+    if warmth <= -0.6:
+        return "you're still annoyed with them"
+    if warmth <= -WARMTH_SHOWN:
+        return "they've rubbed you the wrong way lately"
+    return ""

--- a/src/core/affect/state.py
+++ b/src/core/affect/state.py
@@ -1,0 +1,241 @@
+"""What she feels, kept between turns and written down when someone caused it.
+
+The state lives here and the decisions stay pure in `rules.py`, the same split
+as `attention/`. There is no new sense and no new tool: the mood she already
+picks for every line she speaks is the signal, and until now it only reached a
+PNG.
+
+Three things come out of one strong line, on three different clocks: the mood
+itself (minutes), how she stands with whoever caused it (days), and a hot fact
+so she can say what it was about.
+"""
+
+import json
+import time
+from typing import Callable, List, Optional
+
+from src.core.affect.rules import (
+    HALF_LIFE_SECONDS,
+    PERSON_HALF_LIFE_SECONDS,
+    Affect,
+    decay,
+    is_strong,
+    render,
+    stir,
+)
+from src.core.events import EventCategory
+from src.core.mind.moods import vector_for
+from src.core.skills.social.people import promotion_reason, should_promote
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.affect")
+
+SETTINGS_KEY = "affect.state"
+
+# how far one strong line moves her standing with the person who caused it
+WARMTH_WEIGHT = 0.40
+
+# how much of the line goes into the hot fact: enough to know what it was about
+QUOTED_CHARS = 100
+
+
+class AffectState:
+    """Her standing mood: read decayed, written when she speaks."""
+
+    def __init__(self, config, memory, *, events=None,
+                 clock: Optional[Callable[[], float]] = None):
+        self.config = config
+        self.memory = memory
+        self.events = events
+        self._clock = clock or time.time
+        self._affect = self._load()
+        self._shown = render(self._affect)
+
+    # --- config -------------------------------------------------------------
+
+    @property
+    def _cfg(self) -> dict:
+        return getattr(self.config, "affect", {}) or {}
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._cfg.get("enabled", True))
+
+    @property
+    def half_life(self) -> float:
+        return float(self._cfg.get("half_life_minutes", HALF_LIFE_SECONDS / 60.0)) * 60.0
+
+    @property
+    def person_half_life(self) -> float:
+        return float(
+            self._cfg.get("person_half_life_hours", PERSON_HALF_LIFE_SECONDS / 3600.0)
+        ) * 3600.0
+
+    @property
+    def memory_ttl(self) -> float:
+        return float(self._cfg.get("memory_ttl_hours", 6.0)) * 3600.0
+
+    # --- reading ------------------------------------------------------------
+
+    @property
+    def current(self) -> Affect:
+        """Where she is now, with the time since the last line applied."""
+        if not self.enabled:
+            return Affect()
+        return decay(self._affect, self._clock(), self.half_life)
+
+    def render(self) -> str:
+        return render(self.current) if self.enabled else ""
+
+    # --- writing ------------------------------------------------------------
+
+    def spoke(self, mood: str, batch: Optional[List] = None) -> Affect:
+        """She just said something in `mood`. Returns where that leaves her."""
+        if not self.enabled:
+            return Affect()
+
+        now = self._clock()
+        vector = vector_for(mood)
+        self._affect = stir(self._affect, vector, now=now, half_life=self.half_life)
+        self._save()
+
+        if is_strong(vector):
+            self._blame(vector, batch or [], now)
+
+        self._announce()
+        return self._affect
+
+    def _blame(self, vector, batch: List, now: float) -> None:
+        """Pins a strong line on whoever caused it, when that is not a guess.
+
+        One clear author or nothing: in a busy room the mood is the room's, and
+        picking a face out of it would be inventing a grudge.
+        """
+        author = _lone_author(batch)
+        if author is None:
+            return
+        card = self._card_for(author)
+        if card is None:
+            return
+
+        delta = vector[0] * WARMTH_WEIGHT
+        try:
+            self.memory.people.nudge_warmth(
+                card.person_id, delta, half_life=self.person_half_life, now=now
+            )
+            self.memory.hot.add(
+                _what_happened(author.display_name or card.primary_name, batch, delta),
+                self.memory_ttl, source="live",
+            )
+        except Exception as e:
+            logger.warning(f"Could not record how {author.display_name} left her: {e}")
+            return
+        logger.info(f"affect: {author.display_name} moved her by {delta:+.2f}")
+
+    def _card_for(self, author):
+        """Their card, minting one if this is what made them worth remembering.
+
+        Someone who got a real reaction out of her has made themselves matter,
+        which is already what earns a card — so this marks them and lets the
+        existing thresholds agree.
+        """
+        people, roster = self.memory.people, self.memory.roster
+        card = people.get_by_identity(author.identity)
+        if card is not None:
+            return card
+
+        entry = roster.mark(author.identity)
+        if entry is None or entry.promoted or not should_promote(entry):
+            return None
+        card = people.create_from_entry(entry, reason=promotion_reason(entry))
+        roster.set_promoted(entry.identity, card.person_id)
+        logger.info(f"affect: {author.display_name} got a card ({promotion_reason(entry)}).")
+        return card
+
+    # --- persistence --------------------------------------------------------
+
+    def _load(self) -> Affect:
+        try:
+            raw = self.memory.db.scalar(
+                "SELECT value FROM settings WHERE key = ?", (SETTINGS_KEY,), default="",
+            )
+            data = json.loads(raw) if raw else {}
+            return Affect(
+                float(data.get("valence", 0.0)),
+                float(data.get("arousal", 0.0)),
+                float(data.get("updated_at", 0.0)),
+            )
+        except Exception as e:
+            # a mood is not worth failing to start over
+            logger.warning(f"Could not read her last mood ({e}); starting neutral.")
+            return Affect()
+
+    def _save(self) -> None:
+        payload = json.dumps({
+            "valence": round(self._affect.valence, 4),
+            "arousal": round(self._affect.arousal, 4),
+            "updated_at": self._affect.updated_at,
+        })
+        try:
+            self.memory.db.execute(
+                "INSERT INTO settings (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (SETTINGS_KEY, payload),
+            )
+        except Exception as e:
+            logger.warning(f"Could not save her mood: {e}")
+
+    # --- the dashboard ------------------------------------------------------
+
+    def _announce(self) -> None:
+        """Only when it changed: a drifting value nobody can see is a bug farm."""
+        line = self.render()
+        if line == self._shown:
+            return
+        self._shown = line
+        if self.events is None:
+            return
+        current = self.current
+        self.events.publish(
+            EventCategory.SYSTEM, "affect",
+            line.replace("\n", " ") if line else "back to normal",
+            metadata={
+                "valence": round(current.valence, 3),
+                "arousal": round(current.arousal, 3),
+            },
+        )
+
+
+def _lone_author(batch: List):
+    """The one person this batch is from, or None if it is a room."""
+    authors = {}
+    for p in batch:
+        author = getattr(p, "author", None)
+        if author is None or author.is_owner:
+            continue
+        authors[author.identity] = author
+    return next(iter(authors.values())) if len(authors) == 1 else None
+
+
+def _what_happened(name: str, batch: List, delta: float) -> str:
+    """The hot fact, as a plain statement of what was said and by whom."""
+    line = _last_line(batch)
+    quoted = f' — "{line}"' if line else ""
+    verb = "made your day" if delta > 0 else "got to you"
+    return f"something {name} said {verb}{quoted}"
+
+
+def _last_line(batch: List) -> str:
+    for p in reversed(batch):
+        text = " ".join(str(getattr(p, "content", "") or "").split())
+        if not text:
+            continue
+        # perceptions arrive already rendered as "[marco] ..."; the name is
+        # already in the sentence around this quote
+        if text.startswith("["):
+            _, sep, rest = text.partition("] ")
+            text = rest if sep else text
+        if len(text) > QUOTED_CHARS:
+            text = text[: QUOTED_CHARS - 1] + "…"
+        return text
+    return ""

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List, Optional, Tuple
 
-from src.core.affect import AffectState
+from src.core.affect.state import AffectState
 from src.core.agent.registry import BACKGROUND, MIND, ModelRegistry
 from src.core.attention import Attention
 from src.core.config import BrainConfig

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import List, Optional, Tuple
 
+from src.core.affect import AffectState
 from src.core.agent.registry import BACKGROUND, MIND, ModelRegistry
 from src.core.attention import Attention
 from src.core.config import BrainConfig
@@ -91,6 +92,7 @@ class AIVtuberBrain:
         self.perception_bus: Optional[PerceptionBus] = None
         self.skill_registry: Optional[SkillRegistry] = None
         self.attention: Optional[Attention] = None
+        self.affect: Optional[AffectState] = None
         self.profiler: Optional[Profiler] = None
         self.conversations: Optional[ConversationMind] = None
         self.spontaneous: Optional[SpontaneousPresence] = None
@@ -246,6 +248,10 @@ class AIVtuberBrain:
         # background passes that keep the cards and summaries fresh between dreams
         self.profiler = Profiler(self.model_for(BACKGROUND), self.memory)
 
+        # how she has been feeling, read by the prompt and by her voice alike
+        self.affect = AffectState(self.config, self.memory, events=self.event_manager)
+        self.expression.set_affect(self.affect)
+
         social = self.skill_registry.get("social")
         self.attention = Attention(
             self.config,
@@ -265,6 +271,7 @@ class AIVtuberBrain:
             soul_getter=lambda: self.soul,
             operating_getter=self._load_operating_rules,
             attention=self.attention,
+            affect=self.affect,
         )
 
         # written conversations run beside the live loop: one turn at a time per
@@ -282,6 +289,7 @@ class AIVtuberBrain:
             event_manager=self.event_manager,
             profiler=self.profiler,
             attention=self.attention,
+            affect=self.affect,
             now_line=self.consciousness.now_line,
         )
         self.consciousness.conversations = self.conversations

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -225,6 +225,15 @@ class BrainConfig:
         "digest_max_lines": 8,
     })
 
+    # how she feels, and how long it lasts. The mood colours her voice and her
+    # prompt; how she *acts* on it is the soul's business, not this block's.
+    affect: Dict[str, Any] = field(default_factory=lambda: {
+        "enabled": True,
+        "half_life_minutes": 25,       # long enough to survive a few exchanges
+        "person_half_life_hours": 60,  # a rancour outlives a mood
+        "memory_ttl_hours": 6,         # how long she remembers what caused it
+    })
+
     # her clock. Empty follows the machine, which is fine on a laptop and wrong
     # in a UTC container where the quiet hours would silently shift
     timezone: str = ""

--- a/src/core/consciousness.py
+++ b/src/core/consciousness.py
@@ -35,7 +35,7 @@ class Consciousness:
 
     def __init__(self, *, config, llm, bus, expression, surfaces, history_manager,
                  event_manager, soul_getter, operating_getter, attention=None,
-                 conversations=None):
+                 conversations=None, affect=None):
         self.config = config
         self.llm = llm
         self.bus = bus
@@ -45,6 +45,7 @@ class Consciousness:
         self.events = event_manager
         self.attention = attention
         self.conversations = conversations
+        self.affect = affect
         self._get_soul = soul_getter
         self._get_operating = operating_getter
         # what scrolled out of the rolling context, in one line she keeps
@@ -60,6 +61,9 @@ class Consciousness:
         self.correlation_timeout = cc.get("correlation_timeout", 30.0)
 
         self.context: List[Dict[str, Any]] = []
+        # what provoked the turn in flight: `speak` needs it to know who to pin
+        # a strong reaction on, and a tool handler is not handed the batch
+        self._batch: List[Perception] = []
         self.total_tokens = 0
         self.total_calls = 0
         self.alive = False
@@ -186,6 +190,7 @@ class Consciousness:
                 if not is_idle:
                     logger.info(f"context built in {(time.perf_counter() - t_ctx) * 1000:.0f}ms")
                 self.context.append(self._frame(batch))
+                self._batch = list(batch)
 
                 t_turn = time.perf_counter()
                 steps = 0
@@ -202,6 +207,7 @@ class Consciousness:
                         steer = self._route(steer)
                     if steer:
                         self.context.append(self._frame(steer, steering=True))
+                        self._batch.extend(steer)
 
                     steps += 1
                     t_llm = time.perf_counter()
@@ -329,7 +335,11 @@ class Consciousness:
             dynamic = self.surfaces.dynamic_context(batch) if batch else []
         digest = self.attention.digest() if self.attention else ""
         elsewhere = self.conversations.recent_lines() if self.conversations else ""
-        parts = [f"CURRENT DATE: {today}", soul, operating, *sections, *live, *dynamic]
+        feeling = self.affect.render() if self.affect else ""
+        parts = [f"CURRENT DATE: {today}", soul, operating, *sections, *live]
+        if feeling:
+            parts.append(feeling)
+        parts.extend(dynamic)
         recap = self.recap.render()
         if recap:
             parts.append(recap)
@@ -425,6 +435,8 @@ class Consciousness:
             return await self._stay_silent("nothing sayable")
         if self.attention:
             self.attention.mark_spoke()
+        if self.affect:
+            self.affect.spoke(mood, self._batch)
         self.history.add_message("assistant", message, mood=mood, source="consciousness")
         self.events.publish(EventCategory.OUTPUT, "consciousness", message, metadata={"mood": mood})
 

--- a/src/core/consciousness.py
+++ b/src/core/consciousness.py
@@ -435,27 +435,32 @@ class Consciousness:
             return await self._stay_silent("nothing sayable")
         if self.attention:
             self.attention.mark_spoke()
-        if self.affect:
-            self.affect.spoke(mood, self._batch)
         self.history.add_message("assistant", message, mood=mood, source="consciousness")
         self.events.publish(EventCategory.OUTPUT, "consciousness", message, metadata={"mood": mood})
 
         latency = self._voice_latency
+        # how she felt when she decided on this line, before it moves her
+        feeling = self.affect.current if self.affect else None
 
         if self.expression.call_is_live:
             # every sentence of a turn goes to the room, not just the first: the
             # call is a sink she pushes into, not one reply she hands back
             if latency:
                 latency.mark(MIND)
-            await self.expression.speak(mood, message, route="call")
+            await self.expression.speak(mood, message, route="call", feeling=feeling)
             if latency:
                 latency.mark(TTS)
         else:
             # fire-and-forget so reasoning keeps going
-            asyncio.create_task(self._speak_local_safe(mood, message))
+            asyncio.create_task(self._speak_local_safe(mood, message, feeling))
 
         # whoever is blocked on a written answer gets one either way
         self.correlations.resolve(lambda r: True, {"mood": mood, "message": message})
+
+        # after the voice, not before: this line is already coloured by its own
+        # mood, and counting it twice would make the first sharp remark shout
+        if self.affect:
+            self.affect.spoke(mood, self._batch)
 
         return "Spoken."
 
@@ -464,10 +469,10 @@ class Consciousness:
         """The stopwatch of the voice turn in flight, when there is a call."""
         return getattr(self.surfaces.get("voice:discord"), "latency", None)
 
-    async def _speak_local_safe(self, mood: str, message: str) -> None:
+    async def _speak_local_safe(self, mood: str, message: str, feeling=None) -> None:
         """Local speech in a task: a playback error must not go unretrieved."""
         try:
-            await self.expression.speak(mood, message, route="local")
+            await self.expression.speak(mood, message, route="local", feeling=feeling)
         except Exception as e:
             logger.error(f"Local speech failed: {e}")
 

--- a/src/core/expression/prosody.py
+++ b/src/core/expression/prosody.py
@@ -1,0 +1,108 @@
+"""How a line is said, as opposed to what it says.
+
+She already picks a mood for every line and until now it only reached a PNG.
+Engines spell the same intent differently and most can only do part of it, so
+the intent is written once here and each wrapper translates what it can — the
+same shape as `llm/reasoning.py`. `Prosody()` is neutral and must stay
+byte-identical to no prosody at all.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from src.core.affect.rules import Affect, clamp
+from src.core.mind.moods import vector_for
+
+# small on purpose: a line that sounds annoyed, not a cartoon
+RATE_PER_AROUSAL = 0.15
+PITCH_HZ_PER_AROUSAL = 12.0
+PITCH_HZ_PER_VALENCE = 8.0
+VOLUME_PER_AROUSAL = 0.10
+
+# a standing mood makes a matching line land harder and a contradicting one softer
+AGREEMENT_GAIN = 0.40
+
+# something ordinary said while furious still comes out clipped
+NEUTRAL_LEAK = 0.50
+
+RATE_LIMITS = (0.80, 1.25)
+PITCH_LIMITS = (-25.0, 25.0)
+VOLUME_LIMITS = (0.85, 1.15)
+
+
+@dataclass(frozen=True)
+class Prosody:
+    """A deviation from however the voice is configured, never an absolute.
+
+    Multipliers for rate and volume, an offset in Hz for pitch: mixed units,
+    because that is what the engines that can do anything actually accept.
+    """
+
+    rate: float = 1.0
+    pitch_hz: float = 0.0
+    volume: float = 1.0
+
+    @property
+    def neutral(self) -> bool:
+        return self.rate == 1.0 and self.pitch_hz == 0.0 and self.volume == 1.0
+
+
+NEUTRAL = Prosody()
+
+
+def for_mood(mood: str, affect: Optional[Affect] = None) -> Prosody:
+    """How this line should sound: its own mood, coloured by the standing one.
+
+    The mood decides the direction — a single furious line must not come out
+    flat while the slow state catches up. The state decides how far it goes.
+    """
+    valence, arousal = _coloured(vector_for(mood), affect)
+    return Prosody(
+        rate=clamp(1.0 + arousal * RATE_PER_AROUSAL, *RATE_LIMITS),
+        pitch_hz=clamp(
+            arousal * PITCH_HZ_PER_AROUSAL + valence * PITCH_HZ_PER_VALENCE, *PITCH_LIMITS
+        ),
+        volume=clamp(1.0 + arousal * VOLUME_PER_AROUSAL, *VOLUME_LIMITS),
+    )
+
+
+def _coloured(vector: Tuple[float, float], affect: Optional[Affect]) -> Tuple[float, float]:
+    if affect is None or not affect.felt:
+        return vector
+    if vector == (0.0, 0.0):
+        return affect.valence * NEUTRAL_LEAK, affect.arousal * NEUTRAL_LEAK
+    gain = 1.0 + AGREEMENT_GAIN * clamp(
+        vector[0] * affect.valence + vector[1] * affect.arousal
+    )
+    return clamp(vector[0] * gain), clamp(vector[1] * gain)
+
+
+# --- translation for the SSML-shaped engines --------------------------------
+
+
+def as_percent(multiplier: float) -> str:
+    return f"{round((multiplier - 1.0) * 100):+d}%"
+
+
+def as_hz(offset: float) -> str:
+    return f"{round(offset):+d}Hz"
+
+
+def combine_percent(base: str, multiplier: float) -> str:
+    """The configured voice and the mood compose; neither replaces the other."""
+    return as_percent((1.0 + _number(base, "%") / 100.0) * multiplier)
+
+
+def combine_hz(base: str, offset: float) -> str:
+    return as_hz(_number(base, "Hz") + offset)
+
+
+def _number(raw: str, suffix: str) -> float:
+    """The number out of `+10%`. A malformed value is simply no change."""
+    text = str(raw or "").strip()
+    if text.lower().endswith(suffix.lower()):
+        text = text[: -len(suffix)]
+    try:
+        return float(text)
+    except ValueError:
+        return 0.0

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -124,10 +124,12 @@ class Expression:
 
     async def _play_audio(self, audio_data, sample_rate, device_id):
         """Plays audio via sounddevice while tracking playback for barge-in."""
-        import sounddevice as sd
-
+        # nothing to play needs no audio library: a failed synthesis hands back
+        # an empty array, and on a headless box importing this raises
         if len(audio_data) == 0:
             return
+
+        import sounddevice as sd
 
         self.current_audio_buffer = audio_data
         self.playback_sample_rate = sample_rate

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -97,22 +97,29 @@ class Expression:
         """Hands over what her standing mood is read from."""
         self.affect = affect
 
-    def _prosody(self, mood: str):
-        """How this line should sound, or None when nothing should colour it."""
+    def _prosody(self, mood: str, feeling=None):
+        """How this line should sound, or None when nothing should colour it.
+
+        `feeling` is how she felt when she decided to say it. The mind hands it
+        down because local speech is rendered in a task that starts after the
+        turn has already moved on — reading it here would colour the line with
+        its own mood and flatten the difference between a first sharp remark and
+        twenty minutes of being furious.
+        """
         if self.affect is None or not self.affect.enabled:
             return None
-        return for_mood(mood, self.affect.current)
+        return for_mood(mood, self.affect.current if feeling is None else feeling)
 
     @property
     def call_is_live(self) -> bool:
         """Whether sound she makes right now would be heard in a room."""
         return bool(self.call is not None and self.call.live)
 
-    async def speak(self, mood: str, message: str, *, route: str = "local"):
+    async def speak(self, mood: str, message: str, *, route: str = "local", feeling=None):
         """Renders a spoken turn. Returns the Utterance when route='call'."""
         if route == "call":
-            return await self._speak_call(mood, message)
-        await self._speak_local(mood, message)
+            return await self._speak_call(mood, message, feeling)
+        await self._speak_local(mood, message, feeling)
         return None
 
     async def _play_audio(self, audio_data, sample_rate, device_id):
@@ -220,7 +227,7 @@ class Expression:
             return audio_data.mean(axis=1)
         return audio_data[:, :channels]
 
-    async def _speak_local(self, mood: str, message: str):
+    async def _speak_local(self, mood: str, message: str, feeling=None):
         """Audio + visual output on the local device (stream/OBS)."""
         self.is_speaking = True
         font_used = self.config.text_font_size
@@ -257,7 +264,8 @@ class Expression:
                 )
 
                 if message:
-                    audio_data, fs = await self.tts.generate_audio(message, self._prosody(mood))
+                    audio_data, fs = await self.tts.generate_audio(
+                        message, self._prosody(mood, feeling))
                     self.current_speech_task = asyncio.create_task(
                         self._play_audio(audio_data, fs, self.config.audio_device_id)
                     )
@@ -279,7 +287,7 @@ class Expression:
         finally:
             self.is_speaking = False
 
-    async def _speak_call(self, mood: str, message: str):
+    async def _speak_call(self, mood: str, message: str, feeling=None):
         """Synthesises piece by piece and pushes each one as it is ready.
 
         The room hears the first sentence while the second is still being
@@ -300,7 +308,7 @@ class Expression:
         spoken_ms = 0
         # read once per turn: the second half of a sentence must not drift into
         # a different mood from the first
-        prosody = self._prosody(mood)
+        prosody = self._prosody(mood, feeling)
         for sentence in split_for_speech(message):
             async for audio_data, sample_rate in self.tts.generate_stream(sentence, prosody):
                 if self._call_moved_on(utterance_id, seq):

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -8,6 +8,7 @@ from src.core.config import BrainConfig
 from src.core.events import EventCategory, EventManager
 from src.core.expression.chunking import split_for_speech
 from src.core.expression.pcm import duration_ms, to_call_pcm
+from src.core.expression.prosody import for_mood
 from src.core.resources import resolve_mood_paths
 from src.interfaces.base_interfaces import OBSInterface, TTSInterface
 from src.utils.logger import get_logger
@@ -54,6 +55,8 @@ class Expression:
 
         # the live call, when there is one; the voice skill hands it over
         self.call = None
+        # how she has been feeling; the brain hands it over, None means neutral
+        self.affect = None
         # the last utterance a barge-in cut short, for the mind to be told about
         self.interrupted = None
 
@@ -89,6 +92,16 @@ class Expression:
     def set_call(self, call) -> None:
         """Hands over the live voice call, or None when there is none."""
         self.call = call
+
+    def set_affect(self, affect) -> None:
+        """Hands over what her standing mood is read from."""
+        self.affect = affect
+
+    def _prosody(self, mood: str):
+        """How this line should sound, or None when nothing should colour it."""
+        if self.affect is None or not self.affect.enabled:
+            return None
+        return for_mood(mood, self.affect.current)
 
     @property
     def call_is_live(self) -> bool:
@@ -244,7 +257,7 @@ class Expression:
                 )
 
                 if message:
-                    audio_data, fs = await self.tts.generate_audio(message)
+                    audio_data, fs = await self.tts.generate_audio(message, self._prosody(mood))
                     self.current_speech_task = asyncio.create_task(
                         self._play_audio(audio_data, fs, self.config.audio_device_id)
                     )
@@ -285,8 +298,11 @@ class Expression:
 
         seq = 0
         spoken_ms = 0
+        # read once per turn: the second half of a sentence must not drift into
+        # a different mood from the first
+        prosody = self._prosody(mood)
         for sentence in split_for_speech(message):
-            async for audio_data, sample_rate in self.tts.generate_stream(sentence):
+            async for audio_data, sample_rate in self.tts.generate_stream(sentence, prosody):
                 if self._call_moved_on(utterance_id, seq):
                     return self.call.utterances.get(utterance_id)
                 pcm = to_call_pcm(audio_data, sample_rate)

--- a/src/core/memory/db.py
+++ b/src/core/memory/db.py
@@ -21,6 +21,9 @@ SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 # CREATE TABLE IF NOT EXISTS will not add them, so they need a guarded ALTER
 _MIGRATIONS: List[tuple] = [
     ("messages", "addressee_identity", "TEXT NOT NULL DEFAULT ''"),
+    # in the schema but never here, so any database older than it crashed the
+    # profiler on every conversation turn
+    ("people", "profiled_count", "INTEGER NOT NULL DEFAULT 0"),
     ("people", "warmth", "REAL NOT NULL DEFAULT 0"),
     ("people", "warmth_at", "REAL NOT NULL DEFAULT 0"),
 ]

--- a/src/core/memory/db.py
+++ b/src/core/memory/db.py
@@ -21,6 +21,8 @@ SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 # CREATE TABLE IF NOT EXISTS will not add them, so they need a guarded ALTER
 _MIGRATIONS: List[tuple] = [
     ("messages", "addressee_identity", "TEXT NOT NULL DEFAULT ''"),
+    ("people", "warmth", "REAL NOT NULL DEFAULT 0"),
+    ("people", "warmth_at", "REAL NOT NULL DEFAULT 0"),
 ]
 
 

--- a/src/core/memory/schema.sql
+++ b/src/core/memory/schema.sql
@@ -14,6 +14,10 @@ CREATE TABLE IF NOT EXISTS people (
     promoted_reason TEXT NOT NULL DEFAULT '',
     -- their message count at the last profiling pass
     profiled_count  INTEGER NOT NULL DEFAULT 0,
+    -- how she stands with them right now, and when that was last true. Decays
+    -- toward neutral on read, so a grudge fades without anyone sweeping it.
+    warmth          REAL NOT NULL DEFAULT 0,
+    warmth_at       REAL NOT NULL DEFAULT 0,
     created_at      REAL NOT NULL,
     updated_at      REAL NOT NULL
 );

--- a/src/core/memory/store.py
+++ b/src/core/memory/store.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from src.core.affect.rules import PERSON_HALF_LIFE_SECONDS, clamp, faded, warmth_phrase
 from src.core.attention.followup import Turn
 from src.core.memory.db import Database
 from src.core.memory.plan import StreamPlan
@@ -57,6 +58,8 @@ class PersonCard:
     facts: List[str] = field(default_factory=list)
     bea_attitude: str = ""
     promoted_reason: str = ""
+    # how she stands with them right now, already decayed
+    warmth: float = 0.0
     created_at: float = field(default_factory=time.time)
     last_updated: float = field(default_factory=time.time)
 
@@ -66,8 +69,11 @@ class PersonCard:
 
     def render(self) -> str:
         line = f"- **{self.primary_name}**"
-        if self.bea_attitude:
-            line += f" (you: {self.bea_attitude})"
+        # the settled attitude and the recent one, in that order: what she
+        # thinks of them, then how the last few days went
+        feelings = [f for f in (self.bea_attitude, warmth_phrase(self.warmth)) if f]
+        if feelings:
+            line += " (you: " + "; ".join(feelings) + ")"
         if self.facts:
             line += ": " + "; ".join(self.facts[-MAX_FACTS_SHOWN:])
         return line
@@ -281,6 +287,23 @@ class PeopleStore:
             )
             cur.execute("UPDATE people SET updated_at = ? WHERE person_id = ?", (now, person_id))
 
+    def nudge_warmth(self, person_id: str, delta: float, *,
+                     half_life: float = PERSON_HALF_LIFE_SECONDS,
+                     now: Optional[float] = None) -> float:
+        """Moves how she stands with someone, on top of whatever is left of before."""
+        row = self.db.query_one(
+            "SELECT warmth, warmth_at FROM people WHERE person_id = ?", (person_id,)
+        )
+        if row is None:
+            return 0.0
+        now = time.time() if now is None else now
+        value = clamp(self._warmth(row, half_life, now) + delta)
+        self.db.execute(
+            "UPDATE people SET warmth = ?, warmth_at = ?, updated_at = ? WHERE person_id = ?",
+            (value, now, now, person_id),
+        )
+        return value
+
     def set_attitude(self, person_id: str, attitude: str) -> None:
         self.db.execute("UPDATE people SET attitude = ?, updated_at = ? WHERE person_id = ?",
                         (attitude, time.time(), person_id))
@@ -333,9 +356,22 @@ class PeopleStore:
             facts=[f["text"] for f in facts],
             bea_attitude=row["attitude"] or "",
             promoted_reason=row["promoted_reason"] or "",
+            warmth=self._warmth(row),
             created_at=float(row["created_at"]),
             last_updated=float(row["updated_at"]),
         )
+
+    @staticmethod
+    def _warmth(row, half_life: float = PERSON_HALF_LIFE_SECONDS,
+                now: Optional[float] = None) -> float:
+        """Decayed on read, so a grudge fades with no sweeper to forget to run."""
+        try:
+            value, since = float(row["warmth"]), float(row["warmth_at"])
+        except (KeyError, IndexError, TypeError):
+            return 0.0
+        if not value or not since:
+            return 0.0
+        return faded(value, (now if now is not None else time.time()) - since, half_life)
 
 
 # --- hot facts --------------------------------------------------------------

--- a/src/core/mind/conversation.py
+++ b/src/core/mind/conversation.py
@@ -58,7 +58,7 @@ class ConversationMind:
 
     def __init__(self, *, config, llm, memory, surfaces, soul_getter, operating_getter,
                  scheduler, event_manager=None, profiler=None, now_line=None,
-                 attention=None):
+                 attention=None, affect=None):
         self.config = config
         self.llm = llm
         self.memory = memory
@@ -67,6 +67,9 @@ class ConversationMind:
         self.events = event_manager
         self.profiler = profiler
         self.attention = attention
+        # read, never written: a scoped reply has no mood to pick, so the mood
+        # forms on stage and merely colours what she types
+        self.affect = affect
         self._get_soul = soul_getter
         self._get_operating = operating_getter
         # one line describing what the live loop is up to, injected into a turn
@@ -203,6 +206,10 @@ class ConversationMind:
             self._get_operating(),
             CONVERSATION_RULES,
         ]
+
+        feeling = self.affect.render() if self.affect else ""
+        if feeling:
+            parts.append(feeling)
 
         who = self._who(incoming)
         if who:

--- a/src/core/mind/moods.py
+++ b/src/core/mind/moods.py
@@ -24,6 +24,24 @@ WHEN: Dict[str, str] = {
     "bored": "When someone writes too much, or the topic is uninteresting.",
 }
 
+# Where each mood sits on the two axes that matter: valence (how good it feels)
+# and arousal (how activated it is). Two axes rather than one because angry and
+# sad are both negative and sound nothing alike — separating them is the whole
+# reason prosody can tell them apart.
+VECTORS: Dict[str, Tuple[float, float]] = {
+    "normal": (0.0, 0.0),
+    "shock": (-0.15, 0.85),
+    "love": (0.90, 0.50),
+    "cry": (-0.70, -0.25),
+    "angry": (-0.80, 0.85),
+    "ew": (-0.50, 0.15),
+    "bored": (-0.30, -0.70),
+}
+
+# a mood without a vector would silently stop colouring her voice
+assert set(VECTORS) == set(MOODS), "every mood needs a valence/arousal vector"
+
+
 # a model asked for a mood will invent one. An avatar that silently fails to
 # change is worse than landing on the nearest thing she actually has.
 _NEAR_MISSES: Dict[str, str] = {
@@ -43,6 +61,11 @@ def normalize_mood(raw: Optional[str]) -> str:
     if mood in MOODS:
         return mood
     return _NEAR_MISSES.get(mood, DEFAULT_MOOD)
+
+
+def vector_for(raw: Optional[str]) -> Tuple[float, float]:
+    """The (valence, arousal) of a mood, normalising whatever the model said."""
+    return VECTORS[normalize_mood(raw)]
 
 
 def mood_table() -> str:

--- a/src/core/settings_schema.py
+++ b/src/core/settings_schema.py
@@ -344,6 +344,26 @@ RHYTHM = Section(
     ],
 )
 
+AFFECT = Section(
+    key="affect", label="Mood", scope="root",
+    blurb="Whether what happens to her sticks, and for how long.",
+    settings=[
+        Setting("enabled", "On", "bool",
+                "Off, every line starts from neutral and nothing carries over.", True),
+        Setting("half_life_minutes", "A mood lasts", "float",
+                "Minutes until a mood is half of what it was. Short and she is "
+                "unflappable; long and one bad exchange colours the evening.",
+                25.0, minimum=1.0, maximum=600.0),
+        Setting("person_half_life_hours", "She holds a grudge for", "float",
+                "Hours until how she stands with someone is half of what it was. "
+                "Days, not minutes: being cold with somebody outlasts a mood.",
+                60.0, minimum=1.0, maximum=720.0),
+        Setting("memory_ttl_hours", "Remembers what caused it for", "float",
+                "How long she can still say what put her in that mood.",
+                6.0, minimum=0.5, maximum=168.0),
+    ],
+)
+
 MODELS = Section(
     key="models", label="Models", scope="root",
     blurb="Which models she thinks with, and how fast they answer.",
@@ -385,7 +405,7 @@ CONSCIOUSNESS = Section(
 
 SECTIONS: List[Section] = [
     TELEGRAM, DISCORD, TWITCH, MINECRAFT, DONATIONS,
-    ATTENTION, RHYTHM, MODELS, CONSCIOUSNESS, MEMORY, DREAM,
+    ATTENTION, RHYTHM, AFFECT, MODELS, CONSCIOUSNESS, MEMORY, DREAM,
 ]
 
 _BY_KEY = {s.key: s for s in SECTIONS}

--- a/src/interfaces/base_interfaces.py
+++ b/src/interfaces/base_interfaces.py
@@ -42,15 +42,17 @@ class TTSInterface(ABC):
         pass
 
     @abstractmethod
-    async def generate_audio(self, text: str) -> Tuple[Any, int]:
+    async def generate_audio(self, text: str, prosody=None) -> Tuple[Any, int]:
         """
         Generates audio from text.
         Returns (audio_data, sample_rate).
         audio_data: numpy array or valid sounddevice input.
+        `prosody` is a deviation from the configured voice; None is no change,
+        and an engine with no knobs for it may ignore it.
         """
         pass
 
-    async def generate_stream(self, text: str) -> AsyncIterator[Tuple[Any, int]]:
+    async def generate_stream(self, text: str, prosody=None) -> AsyncIterator[Tuple[Any, int]]:
         """Yields (audio_data, sample_rate) as it becomes available.
 
         Deliberately not abstract. The default is one chunk — the whole thing,
@@ -58,7 +60,7 @@ class TTSInterface(ABC):
         working untouched, and an engine whose source is already chunked (a
         streaming HTTP response) overrides this and starts sounding sooner.
         """
-        yield await self.generate_audio(text)
+        yield await self.generate_audio(text, prosody)
 
     @abstractmethod
     def reload_config(self, config) -> None:

--- a/src/modules/tts/edge_tts_wrapper.py
+++ b/src/modules/tts/edge_tts_wrapper.py
@@ -3,7 +3,6 @@ import os
 
 import edge_tts
 import numpy as np
-import sounddevice as sd
 import soundfile as sf
 
 from src.core.expression.prosody import combine_hz, combine_percent
@@ -49,6 +48,10 @@ class EdgeTTSWrapper(TTSInterface):
 
     def _play_audio_sync(self, device_id: int, filename: str):
         """Synchronous audio playback using OutputStream for better thread safety."""
+        # imported where it is used, not at module scope: generating audio must not
+        # need PortAudio, and a headless box (CI, a server) has no such library
+        import sounddevice as sd
+
         if not os.path.exists(filename):
             logger.error(f"TTS file not found: {filename}")
             return
@@ -115,6 +118,8 @@ class EdgeTTSWrapper(TTSInterface):
 
     async def speak(self, text: str, output_device_id: int) -> None:
         """Generates and plays audio."""
+        import sounddevice as sd
+
         # deprecated: brain should use generate_audio
         data, fs = await self.generate_audio(text)
         if len(data) == 0:

--- a/src/modules/tts/edge_tts_wrapper.py
+++ b/src/modules/tts/edge_tts_wrapper.py
@@ -6,6 +6,7 @@ import numpy as np
 import sounddevice as sd
 import soundfile as sf
 
+from src.core.expression.prosody import combine_hz, combine_percent
 from src.interfaces.base_interfaces import TTSInterface
 from src.utils.logger import get_logger
 
@@ -30,9 +31,20 @@ class EdgeTTSWrapper(TTSInterface):
         if config.tts_volume != self.volume:
              self.volume = config.tts_volume
 
-    async def _generate_audio_file(self, text: str, filename: str) -> None:
+    def _voice_for(self, prosody) -> tuple[str, str, str]:
+        """The configured voice, moved by the mood. Neutral leaves it untouched."""
+        if prosody is None or prosody.neutral:
+            return self.pitch, self.rate, self.volume
+        return (
+            combine_hz(self.pitch, prosody.pitch_hz),
+            combine_percent(self.rate, prosody.rate),
+            combine_percent(self.volume, prosody.volume),
+        )
+
+    async def _generate_audio_file(self, text: str, filename: str, prosody=None) -> None:
         """Generates the audio file."""
-        communicate = edge_tts.Communicate(text, self.voice, pitch=self.pitch, rate=self.rate, volume=self.volume)
+        pitch, rate, volume = self._voice_for(prosody)
+        communicate = edge_tts.Communicate(text, self.voice, pitch=pitch, rate=rate, volume=volume)
         await communicate.save(filename)
 
     def _play_audio_sync(self, device_id: int, filename: str):
@@ -73,7 +85,7 @@ class EdgeTTSWrapper(TTSInterface):
         except Exception as e:
             logger.error(f"error playing audio: {e}")
 
-    async def generate_audio(self, text: str) -> tuple[np.ndarray, int]:
+    async def generate_audio(self, text: str, prosody=None) -> tuple[np.ndarray, int]:
         """Generates audio and returns numpy array + sample rate."""
         if not text:
              return np.zeros(0, dtype=np.float32), 24000
@@ -83,7 +95,8 @@ class EdgeTTSWrapper(TTSInterface):
 
         try:
             # generate to file
-            communicate = edge_tts.Communicate(text, self.voice, pitch=self.pitch, rate=self.rate, volume=self.volume)
+            pitch, rate, volume = self._voice_for(prosody)
+            communicate = edge_tts.Communicate(text, self.voice, pitch=pitch, rate=rate, volume=volume)
             await communicate.save(unique_filename)
 
             # read to numpy

--- a/src/modules/tts/kokoro_tts_wrapper.py
+++ b/src/modules/tts/kokoro_tts_wrapper.py
@@ -3,7 +3,6 @@ import os
 
 import numpy as np
 import requests
-import sounddevice as sd
 from kokoro_onnx import Kokoro
 
 from src.interfaces.base_interfaces import TTSInterface
@@ -94,6 +93,10 @@ class KokoroTTSWrapper(TTSInterface):
         return samples, sample_rate
 
     async def speak(self, text: str, output_device_id: int) -> None:
+        # imported where it is used, not at module scope: generating audio must not
+        # need PortAudio, and a headless box (CI, a server) has no such library
+        import sounddevice as sd
+
         # deprecated: brain should use generate_audio and handle playback
         # kept for compatibility or direct usage
         samples, sample_rate = await self.generate_audio(text)

--- a/src/modules/tts/kokoro_tts_wrapper.py
+++ b/src/modules/tts/kokoro_tts_wrapper.py
@@ -67,9 +67,12 @@ class KokoroTTSWrapper(TTSInterface):
              logger.info(f"language updated to {config.kokoro_lang}")
              self.lang = config.kokoro_lang
 
-    async def generate_audio(self, text: str) -> tuple[np.ndarray, int]:
+    async def generate_audio(self, text: str, prosody=None) -> tuple[np.ndarray, int]:
         if not text or not self.kokoro:
             return np.zeros(0, dtype=np.float32), 24000
+
+        # rate is the only knob kokoro has; pitch and volume are simply lost
+        speed = self.speed if prosody is None else self.speed * prosody.rate
 
         # run generation in thread to avoid blocking loop
         loop = asyncio.get_running_loop()
@@ -78,7 +81,7 @@ class KokoroTTSWrapper(TTSInterface):
             self.kokoro.create,
             text,
             self.voice,
-            self.speed,
+            speed,
             self.lang
         )
 

--- a/src/modules/tts/orpheus_tts_wrapper.py
+++ b/src/modules/tts/orpheus_tts_wrapper.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import numpy as np
 import requests
-import sounddevice as sd
 import soundfile as sf
 
 from src.interfaces.base_interfaces import TTSInterface
@@ -81,6 +80,10 @@ class OrpheusTTSWrapper(TTSInterface):
             raise
 
     def _play_audio_sync(self, device_id: int, filename: str):
+        # imported where it is used, not at module scope: generating audio must
+        # not need PortAudio, and a headless box (CI, a server) has no such library
+        import sounddevice as sd
+
         """plays the downloaded audio file assuming Raw PCM 24kHz."""
         if not os.path.exists(filename):
             logger.error("audio file not found.")
@@ -218,6 +221,8 @@ class OrpheusTTSWrapper(TTSInterface):
                     pass
 
     async def speak(self, text: str, output_device_id: int) -> None:
+        import sounddevice as sd
+
         # deprecated: brain should use generate_audio
         data, fs = await self.generate_audio(text)
         if len(data) == 0:

--- a/src/modules/tts/orpheus_tts_wrapper.py
+++ b/src/modules/tts/orpheus_tts_wrapper.py
@@ -13,6 +13,8 @@ from src.utils.logger import get_logger
 logger = get_logger("bea.tts.orpheus")
 
 class OrpheusTTSWrapper(TTSInterface):
+    # the endpoint takes a voice and a prompt and nothing else, so `prosody` is
+    # accepted and dropped: this engine cannot be told how to say something
     # what the endpoint returns: raw 24 kHz 16-bit mono
     SAMPLE_RATE = 24000
     # ~150ms a block: small enough to start sounding fast, big enough not to
@@ -146,7 +148,7 @@ class OrpheusTTSWrapper(TTSInterface):
         if len(pending) >= 2:
             yield pending[:len(pending) - (len(pending) % 2)]
 
-    async def generate_stream(self, text: str):
+    async def generate_stream(self, text: str, prosody=None):
         """The real thing: samples reach the caller while the rest is still coming."""
         if not text:
             return
@@ -173,7 +175,7 @@ class OrpheusTTSWrapper(TTSInterface):
         finally:
             await worker
 
-    async def generate_audio(self, text: str) -> tuple[np.ndarray, int]:
+    async def generate_audio(self, text: str, prosody=None) -> tuple[np.ndarray, int]:
         if not text:
              return np.zeros(0, dtype=np.float32), 24000
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -24,6 +24,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, field_validator
 
+from src.core.affect.rules import warmth_phrase
 from src.core.agent.registry import BACKGROUND
 from src.core.brain import AIVtuberBrain
 from src.core.config import MASK, SECRET_SKILL_FIELDS
@@ -870,6 +871,7 @@ def memory_people():
             "identities": card.identities,
             "facts": card.facts,
             "attitude": card.bea_attitude,
+            "mood": warmth_phrase(card.warmth),
             "reason": card.promoted_reason,
             "created_at": card.created_at,
             "last_updated": card.last_updated,

--- a/src/web/frontend/src/pages/MemoryPage.jsx
+++ b/src/web/frontend/src/pages/MemoryPage.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Flame, Heart, Save, Search, Sparkles, User, Users } from 'lucide-react';
+import { Flame, Heart, Save, Search, Sparkles, Thermometer, User, Users } from 'lucide-react';
 import { api } from '../api';
 import { compact, dayAndTime, relativeTime, titleCase } from '../lib/format';
 import { useToast } from '../state/ToastProvider';
@@ -138,6 +138,16 @@ function PeopleGrid({ people }) {
                             >
                                 <Heart size={12} className="mt-0.5 shrink-0" style={{ color: 'var(--vital)' }} />
                                 {person.attitude}
+                            </p>
+                        )}
+
+                        {person.mood && (
+                            <p
+                                className="mt-2 flex items-start gap-2 rounded-b2 px-2.5 py-2 text-[12px] italic leading-snug"
+                                style={{ background: 'var(--cognition-soft)', color: 'var(--text)' }}
+                            >
+                                <Thermometer size={12} className="mt-0.5 shrink-0" style={{ color: 'var(--cognition)' }} />
+                                {person.mood}
                             </p>
                         )}
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -74,6 +74,8 @@ class FakeExpression:
 
     def __init__(self):
         self.spoken: List[tuple] = []
+        # how she felt when each line was decided, for the prosody tests
+        self.felt: List[Any] = []
         self.is_speaking = False
         self.interrupts = 0
         self.mood_avatar: Optional[str] = None
@@ -86,8 +88,9 @@ class FakeExpression:
     def call_is_live(self) -> bool:
         return bool(self.call is not None and self.call.live)
 
-    async def speak(self, mood, message, *, route="local"):
+    async def speak(self, mood, message, *, route="local", feeling=None):
         self.spoken.append((mood, message, route))
+        self.felt.append(feeling)
         return None
 
     async def interrupt(self, ramp_ms: int = 200):

--- a/tests/test_affect_loop.py
+++ b/tests/test_affect_loop.py
@@ -175,3 +175,27 @@ async def test_a_mind_with_no_affect_at_all_still_speaks(store):
     await mind.hears(said())
 
     assert mind.consciousness.expression.spoken == [("normal", "ciao", "local")]
+
+
+async def test_a_line_is_never_amplified_by_its_own_mood(store):
+    """The voice is handed how she felt when she decided, not after.
+
+    Read after, the mood of the line would count twice — once as the line's own
+    colour, again as the standing mood amplifying it — and the first sharp
+    remark would sound nearly like twenty minutes of being furious.
+    """
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")])
+    await mind.hears(said())
+
+    assert [f.strength for f in mind.consciousness.expression.felt] == [0.0]
+    assert mind.consciousness.affect.current.strength > 0.0
+
+
+async def test_the_second_line_carries_what_the_first_one_did(store):
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")] * 2)
+    for _ in range(2):
+        await mind.hears(said())
+
+    first, second = mind.consciousness.expression.felt
+    assert first.strength == 0.0
+    assert second.strength > 0.0

--- a/tests/test_affect_loop.py
+++ b/tests/test_affect_loop.py
@@ -1,0 +1,177 @@
+"""Does a mood survive the loop, and does it reach the next prompt?
+
+The pieces are tested on their own. What this pins is the path between them:
+the batch that provoked a line has to still be in scope when `speak` runs, or
+the person who caused it is lost and the whole thing blames nobody.
+"""
+
+import asyncio
+import random
+
+import pytest
+
+from src.core.affect.state import AffectState
+from src.core.attention.gate import Attention
+from src.core.consciousness import Consciousness
+from src.core.memory.store import MemoryStore
+from src.core.perception.bus import PerceptionBus
+from src.core.perception.types import Author, Perception, PerceptionKind
+from src.core.skills.base import SkillRegistry
+from tests.fakes import (
+    FakeExpression,
+    FakeHistory,
+    FakeLLMClient,
+    RecordingEvents,
+    speaks,
+)
+
+
+class Config:
+    def __init__(self):
+        self.consciousness = {"enabled": True, "idle_after": 3600.0, "window": 0.0,
+                              "burst_steps": 3, "history_limit": 30,
+                              "correlation_timeout": 5.0}
+        # quiet hours off: whether this suite passes must not depend on the
+        # hour it is run at
+        self.attention = {"enabled": True, "trigger_words": ["bea"],
+                          "cooldown_seconds": 0, "quiet_hours": [0, 0]}
+        self.affect = {"enabled": True, "half_life_minutes": 25,
+                       "person_half_life_hours": 60, "memory_ttl_hours": 6}
+        self.skills = {}
+
+
+@pytest.fixture
+def store():
+    s = MemoryStore(":memory:")
+    yield s
+    s.close()
+
+
+class Mind:
+    """The real loop, with fakes at every edge."""
+
+    def __init__(self, store, script=None, affect=True):
+        config = Config()
+        rng = random.Random()
+        rng.uniform = lambda a, b: 0.0
+        self.llm = FakeLLMClient(script or [])
+        self.consciousness = Consciousness(
+            config=config, llm=self.llm, bus=PerceptionBus(window=0.0),
+            expression=FakeExpression(), surfaces=SkillRegistry(),
+            history_manager=FakeHistory(), event_manager=RecordingEvents(),
+            soul_getter=lambda: "soul", operating_getter=lambda: "rules",
+            attention=Attention(config, rng=rng),
+            affect=AffectState(config, store, events=RecordingEvents()) if affect else None,
+        )
+        self.consciousness.context = [self.consciousness._system_message([])]
+
+    async def hears(self, *perceptions, timeout: float = 1.0):
+        """Puts them on the bus and lets the loop chew through them."""
+        mind = self.consciousness
+        mind.alive = True
+        task = asyncio.create_task(mind.run())
+        for p in perceptions:
+            mind.bus.put(p)
+
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        while mind.bus._queue.qsize() and loop.time() < deadline:
+            await asyncio.sleep(0.005)
+        await asyncio.sleep(0.02)
+
+        mind.alive = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+def said(text="bea sei una noia", name="marco", native="1") -> Perception:
+    return Perception(
+        kind=PerceptionKind.CHAT, surface="discord:text", content=f"[{name}] {text}",
+        author=Author(platform="discord", native_id=native, display_name=name),
+    )
+
+
+def regular(store, identity="discord:1", name="marco"):
+    for session in ("a", "b", "c"):
+        store.roster.record(identity=identity, display_name=name,
+                            platform="discord", session_id=session)
+    entry = store.roster.get(identity)
+    card = store.people.create_from_entry(entry, reason="a regular")
+    store.roster.set_promoted(identity, card.person_id)
+    return card
+
+
+# --- through the loop -------------------------------------------------------
+
+
+async def test_a_mood_builds_up_over_a_couple_of_turns(store):
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")] * 3)
+    for _ in range(3):
+        await mind.hears(said())
+
+    assert mind.consciousness.affect.current.valence < 0
+    assert mind.consciousness.affect.render() != ""
+
+
+async def test_the_mood_is_in_the_prompt_of_the_next_turn(store):
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")] * 4)
+    for _ in range(4):
+        await mind.hears(said())
+
+    assert "[HOW YOU FEEL]" in mind.llm.last_system_prompt
+
+
+async def test_a_calm_mind_says_nothing_about_how_it_feels(store):
+    mind = Mind(store, [speaks("ciao", mood="normal")] * 3)
+    for _ in range(3):
+        await mind.hears(said())
+
+    assert "[HOW YOU FEEL]" not in mind.llm.last_system_prompt
+
+
+async def test_the_person_who_provoked_the_line_is_the_one_blamed(store):
+    card = regular(store)
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")])
+    await mind.hears(said("bea il tuo stream fa schifo"))
+
+    assert store.people.get(card.person_id).warmth < 0
+    assert "marco" in store.hot.render()
+    assert "il tuo stream fa schifo" in store.hot.render()
+
+
+async def test_a_line_nobody_provoked_blames_nobody(store):
+    card = regular(store)
+    mind = Mind(store, [speaks("che palle", mood="angry")])
+    await mind.hears(Perception(PerceptionKind.IDLE, "idle", "(nothing is happening)"))
+
+    assert mind.consciousness.affect.current.valence < 0
+    assert store.people.get(card.person_id).warmth == 0.0
+
+
+async def test_a_busy_room_is_nobody_s_fault(store):
+    card = regular(store)
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")])
+    await mind.hears(said("bea sei noiosa"), said("bea concordo", name="lucia", native="2"))
+
+    assert store.people.get(card.person_id).warmth == 0.0
+
+
+async def test_switching_it_off_leaves_the_prompt_exactly_as_it_was(store):
+    mind = Mind(store, [speaks("ma sta zitto", mood="angry")] * 4)
+    mind.consciousness.affect.config.affect["enabled"] = False
+    for _ in range(4):
+        await mind.hears(said())
+
+    assert "[HOW YOU FEEL]" not in mind.llm.last_system_prompt
+    assert store.hot.active() == []
+
+
+async def test_a_mind_with_no_affect_at_all_still_speaks(store):
+    """The whole thing is optional: nothing may depend on it being wired."""
+    mind = Mind(store, [speaks("ciao")], affect=False)
+    await mind.hears(said())
+
+    assert mind.consciousness.expression.spoken == [("normal", "ciao", "local")]

--- a/tests/test_affect_rules.py
+++ b/tests/test_affect_rules.py
@@ -1,0 +1,198 @@
+"""How she feels, as a table of cases — the point of keeping it pure.
+
+Two properties would rot quietly if nobody pinned them: the state decays in
+time rather than per utterance, and the render never tells her how to behave.
+"""
+
+import pytest
+
+from src.core.affect.rules import (
+    FELT,
+    HALF_LIFE_SECONDS,
+    Affect,
+    decay,
+    faded,
+    is_strong,
+    render,
+    stir,
+    warmth_phrase,
+)
+from src.core.mind.moods import MOODS, VECTORS, vector_for
+
+T0 = 1_000_000.0
+
+ANGRY = VECTORS["angry"]
+LOVE = VECTORS["love"]
+NORMAL = VECTORS["normal"]
+
+
+# --- the mood table ---------------------------------------------------------
+
+
+def test_every_mood_has_a_vector():
+    assert set(VECTORS) == set(MOODS)
+
+
+def test_normal_is_the_origin():
+    assert vector_for("normal") == (0.0, 0.0)
+
+
+def test_an_invented_mood_lands_on_a_real_vector():
+    assert vector_for("furious") == VECTORS["angry"]
+    assert vector_for("nonsense") == VECTORS["normal"]
+
+
+def test_angry_and_sad_are_told_apart_by_arousal():
+    # both negative; if they collapsed onto one axis prosody could not separate
+    # a shout from a sulk
+    assert VECTORS["angry"][0] < 0 and VECTORS["cry"][0] < 0
+    assert VECTORS["angry"][1] > 0 > VECTORS["cry"][1]
+
+
+# --- decay ------------------------------------------------------------------
+
+
+def test_one_half_life_halves_it():
+    assert faded(0.8, HALF_LIFE_SECONDS, HALF_LIFE_SECONDS) == pytest.approx(0.4)
+
+
+def test_decay_never_crosses_zero():
+    assert faded(-0.8, HALF_LIFE_SECONDS * 20, HALF_LIFE_SECONDS) == pytest.approx(0.0, abs=1e-5)
+    assert faded(-0.8, HALF_LIFE_SECONDS * 20, HALF_LIFE_SECONDS) <= 0.0
+
+
+def test_no_time_passing_changes_nothing():
+    before = Affect(-0.5, 0.5, T0)
+    assert decay(before, T0) == before
+
+
+def test_a_long_gap_brings_her_back_to_baseline():
+    # the restart case: she was furious, the process was down for six hours
+    after = decay(Affect(-0.9, 0.9, T0), T0 + 6 * 3600)
+    assert after.felt is False
+
+
+# --- stir -------------------------------------------------------------------
+
+
+def test_one_sharp_line_is_a_blip_not_a_mood():
+    assert stir(Affect(), ANGRY, now=T0).felt is False
+
+
+def test_two_in_a_row_are_a_mood():
+    state = stir(Affect(), ANGRY, now=T0)
+    state = stir(state, ANGRY, now=T0 + 10)
+    assert state.felt is True
+    assert state.valence < 0 and state.arousal > 0
+
+
+def test_a_neutral_line_does_not_scrub_the_mood():
+    """The additive-vs-slide property, and the reason it is additive."""
+    angry = stir(stir(Affect(), ANGRY, now=T0), ANGRY, now=T0 + 1)
+    after = stir(angry, NORMAL, now=T0 + 2)
+    assert after.valence == pytest.approx(angry.valence, abs=0.01)
+    assert after.felt is True
+
+
+def test_time_is_what_clears_a_mood_not_talking():
+    angry = stir(stir(Affect(), ANGRY, now=T0), ANGRY, now=T0 + 1)
+    assert stir(angry, NORMAL, now=T0 + HALF_LIFE_SECONDS * 4).felt is False
+
+
+def test_the_opposite_mood_pulls_her_back_faster():
+    angry = stir(stir(Affect(), ANGRY, now=T0), ANGRY, now=T0 + 1)
+    assert stir(angry, LOVE, now=T0 + 2).valence > angry.valence
+
+
+def test_it_never_leaves_the_unit_range():
+    state = Affect()
+    for i in range(20):
+        state = stir(state, ANGRY, now=T0 + i)
+    assert -1.0 <= state.valence <= 1.0
+    assert -1.0 <= state.arousal <= 1.0
+
+
+def test_stirring_ages_what_was_already_there():
+    old = Affect(-0.8, 0.0, T0)
+    fresh = stir(old, NORMAL, now=T0 + HALF_LIFE_SECONDS)
+    assert fresh.valence == pytest.approx(-0.4)
+
+
+# --- is_strong --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mood", ["angry", "love", "cry"])
+def test_the_moods_that_mean_someone_got_to_her(mood):
+    assert is_strong(VECTORS[mood]) is True
+
+
+@pytest.mark.parametrize("mood", ["normal", "shock", "ew", "bored"])
+def test_the_moods_that_are_not_about_a_person(mood):
+    # shock is loud but a surprise is not somebody doing something to her
+    assert is_strong(VECTORS[mood]) is False
+
+
+# --- render -----------------------------------------------------------------
+
+
+def test_a_calm_state_says_nothing_at_all():
+    assert render(Affect()) == ""
+
+
+def test_just_under_the_threshold_still_says_nothing():
+    assert render(Affect(-FELT + 0.01, 0.0, T0)) == ""
+
+
+def test_wound_up_and_flat_do_not_read_the_same():
+    wound_up = render(Affect(-0.7, 0.7, T0))
+    flat = render(Affect(-0.7, -0.7, T0))
+    assert wound_up and flat and wound_up != flat
+
+
+def test_good_and_bad_do_not_read_the_same():
+    assert render(Affect(0.7, 0.7, T0)) != render(Affect(-0.7, 0.7, T0))
+
+
+def test_it_is_labelled_so_she_can_tell_it_from_a_perception():
+    assert render(Affect(-0.7, 0.7, T0)).startswith("[HOW YOU FEEL]")
+
+
+# every quadrant, plus the two neutral-valence edges
+QUADRANTS = [(-0.7, 0.7), (-0.7, -0.7), (-0.7, 0.0), (0.7, 0.7), (0.7, -0.7),
+             (0.0, 0.7), (0.0, -0.7)]
+
+# a render that starts telling her how to act has stopped describing a state,
+# and has started overwriting whatever soul the owner wrote
+INSTRUCTIONS = ("be ", "act ", "keep ", "don't", "do not", "should", "make sure",
+                "try to", "remember to", "so you")
+
+
+@pytest.mark.parametrize("valence,arousal", QUADRANTS)
+def test_it_describes_a_state_and_never_gives_an_order(valence, arousal):
+    text = render(Affect(valence, arousal, T0)).lower()
+    assert text
+    assert not any(phrase in text for phrase in INSTRUCTIONS)
+
+
+@pytest.mark.parametrize("valence,arousal", QUADRANTS)
+def test_every_quadrant_has_something_to_say(valence, arousal):
+    assert render(Affect(valence, arousal, T0)) != ""
+
+
+# --- warmth -----------------------------------------------------------------
+
+
+def test_a_neutral_standing_is_not_worth_a_word():
+    assert warmth_phrase(0.0) == ""
+    assert warmth_phrase(0.2) == ""
+    assert warmth_phrase(-0.2) == ""
+
+
+def test_warmth_reads_as_words_not_as_a_number():
+    for value in (-0.9, -0.4, 0.4, 0.9):
+        phrase = warmth_phrase(value)
+        assert phrase and not any(c.isdigit() for c in phrase)
+
+
+def test_cold_and_fond_do_not_read_the_same():
+    assert warmth_phrase(-0.9) != warmth_phrase(0.9)

--- a/tests/test_affect_state.py
+++ b/tests/test_affect_state.py
@@ -272,3 +272,29 @@ def test_an_unchanged_mood_is_not_reannounced_every_turn(store):
     for _ in range(6):
         state.spoke("normal", [said("ciao")])
     assert [e for e in events.events if e[1] == "affect"] == []
+
+
+def test_the_people_page_is_given_the_words_and_never_the_number(store):
+    """A value nobody can read is a value nobody can tell is stuck."""
+    from fastapi.testclient import TestClient
+
+    from src.web import app as web
+
+    card = known(store)
+    state = affect(store)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+
+    class BrainStub:
+        memory = store
+
+    previous = web.brain_instance
+    web.brain_instance = BrainStub()
+    try:
+        person = TestClient(web.app).get("/memory/people").json()[0]
+    finally:
+        web.brain_instance = previous
+
+    assert person["person_id"] == card.person_id
+    assert "annoyed" in person["mood"]
+    assert "warmth" not in person

--- a/tests/test_affect_state.py
+++ b/tests/test_affect_state.py
@@ -1,0 +1,274 @@
+"""The standing mood, with a real store under it and a clock we control.
+
+The pure maths is in `test_affect_rules.py`. What is on trial here is what
+touches the database: that it survives a restart correctly aged, that it only
+blames somebody when there is somebody to blame, and that it never invents a
+grudge out of a busy room.
+"""
+
+import time
+
+import pytest
+
+from src.core.affect.rules import PERSON_HALF_LIFE_SECONDS, Affect
+from src.core.affect.state import AffectState
+from src.core.memory.store import MemoryStore
+from src.core.perception.types import Author, Perception, PerceptionKind
+from tests.fakes import RecordingEvents
+
+HOUR = 3600.0
+
+
+class Clock:
+    """Starts from the real clock: the store stamps its own rows with time.time()."""
+
+    def __init__(self, now: float = None):
+        self.now = time.time() if now is None else now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def tick(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class Config:
+    def __init__(self, **over):
+        self.affect = {"enabled": True, "half_life_minutes": 25,
+                       "person_half_life_hours": 60, "memory_ttl_hours": 6}
+        self.affect.update(over)
+
+
+@pytest.fixture
+def store():
+    s = MemoryStore(":memory:")
+    yield s
+    s.close()
+
+
+def affect(store, clock=None, events=None, **cfg) -> AffectState:
+    return AffectState(Config(**cfg), store, events=events, clock=clock or Clock())
+
+
+def said(text="sei una noia", name="marco", identity="discord:1", owner=False) -> Perception:
+    return Perception(
+        kind=PerceptionKind.CHAT, surface="discord:text", content=f"[{name}] {text}",
+        author=Author(platform="discord", native_id=identity.split(":")[1],
+                      display_name=name, is_owner=owner),
+    )
+
+
+def known(store, identity="discord:1", name="marco", sessions=("a", "b", "c")):
+    """Someone she has seen enough times to already have a card."""
+    for session in sessions:
+        store.roster.record(identity=identity, display_name=name,
+                            platform="discord", session_id=session)
+    entry = store.roster.get(identity)
+    card = store.people.create_from_entry(entry, reason="a regular")
+    store.roster.set_promoted(identity, card.person_id)
+    return card
+
+
+# --- the standing mood ------------------------------------------------------
+
+
+def test_she_starts_neutral(store):
+    assert affect(store).current.strength == 0.0
+    assert affect(store).render() == ""
+
+
+def test_one_line_moves_her_without_making_a_mood(store):
+    state = affect(store)
+    state.spoke("angry", [said()])
+    assert state.current.valence < 0
+    assert state.render() == ""
+
+
+def test_two_angry_lines_are_a_mood_she_can_feel(store):
+    state = affect(store)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+    assert "[HOW YOU FEEL]" in state.render()
+
+
+def test_the_mood_wears_off_on_its_own(store):
+    clock = Clock()
+    state = affect(store, clock)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+    assert state.render() != ""
+
+    clock.tick(2 * HOUR)
+    assert state.render() == ""
+
+
+def test_turning_it_off_makes_her_neutral_and_silent(store):
+    state = affect(store, enabled=False)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+    assert state.current == Affect()
+    assert state.render() == ""
+
+
+# --- surviving a restart ----------------------------------------------------
+
+
+def test_she_comes_back_still_annoyed(store):
+    clock = Clock()
+    state = affect(store, clock)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+
+    clock.tick(60)
+    restarted = affect(store, clock)
+    assert restarted.render() == state.render()
+
+
+def test_she_comes_back_calm_after_a_night(store):
+    clock = Clock()
+    state = affect(store, clock)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+
+    clock.tick(8 * HOUR)
+    assert affect(store, clock).render() == ""
+
+
+def test_a_corrupt_saved_mood_is_not_a_failure_to_start(store):
+    store.db.execute("INSERT INTO settings (key, value) VALUES ('affect.state', 'nonsense')")
+    assert affect(store).current.strength == 0.0
+
+
+# --- who caused it ----------------------------------------------------------
+
+
+def test_the_person_who_got_to_her_goes_cold(store):
+    card = known(store)
+    state = affect(store)
+    state.spoke("angry", [said()])
+    assert store.people.get(card.person_id).warmth < 0
+
+
+def test_the_person_who_made_her_day_goes_warm(store):
+    card = known(store)
+    affect(store).spoke("love", [said("sei bravissima")])
+    assert store.people.get(card.person_id).warmth > 0
+
+
+def test_a_grudge_fades_by_itself(store):
+    card = known(store)
+    a_half_life_ago = time.time() - PERSON_HALF_LIFE_SECONDS
+    store.people.nudge_warmth(card.person_id, -0.8, now=a_half_life_ago)
+    assert store.people.get(card.person_id).warmth == pytest.approx(-0.4, abs=0.01)
+
+
+def test_a_mild_mood_is_nobody_in_particular_s_fault(store):
+    card = known(store)
+    affect(store).spoke("bored", [said()])
+    assert store.people.get(card.person_id).warmth == 0.0
+
+
+def test_a_busy_room_never_gets_a_face_pinned_on_it(store):
+    card = known(store)
+    crowd = [said(name="marco"), said(name="lucia", identity="discord:2")]
+    affect(store).spoke("angry", crowd)
+    assert store.people.get(card.person_id).warmth == 0.0
+
+
+def test_her_own_bad_mood_blames_nobody(store):
+    state = affect(store)
+    state.spoke("angry", [])
+    assert state.current.valence < 0
+    assert store.hot.active() == []
+
+
+def test_the_owner_is_not_somebody_she_keeps_a_grudge_on(store):
+    affect(store).spoke("angry", [said(owner=True)])
+    assert store.hot.active() == []
+
+
+# --- remembering it happened -------------------------------------------------
+
+
+def test_she_remembers_what_it_was_about(store):
+    known(store)
+    affect(store).spoke("angry", [said("il tuo stream fa schifo")])
+
+    facts = store.hot.active()
+    assert len(facts) == 1
+    assert "marco" in facts[0].text
+    assert "il tuo stream fa schifo" in facts[0].text
+    assert facts[0].source == "live"
+
+
+def test_what_she_remembers_reaches_the_prompt(store):
+    known(store)
+    affect(store).spoke("angry", [said("il tuo stream fa schifo")])
+    assert "marco" in store.hot.render()
+
+
+def test_the_memory_is_given_a_lifetime_not_kept_forever(store):
+    known(store)
+    affect(store, memory_ttl_hours=6).spoke("angry", [said()])
+    fact = store.hot.active()[0]
+    assert fact.expires_at - fact.created_at == pytest.approx(6 * HOUR)
+
+
+# --- earning a card ---------------------------------------------------------
+
+
+def test_a_stranger_who_really_got_to_her_earns_a_card(store):
+    store.roster.record(identity="discord:9", display_name="nuovo", platform="discord")
+    affect(store).spoke("angry", [said(name="nuovo", identity="discord:9")])
+
+    card = store.people.get_by_identity("discord:9")
+    assert card is not None and card.warmth < 0
+
+
+def test_somebody_she_has_never_seen_is_not_invented(store):
+    affect(store).spoke("angry", [said(name="fantasma", identity="discord:99")])
+    assert store.people.get_by_identity("discord:99") is None
+
+
+# --- how it reads -----------------------------------------------------------
+
+
+def test_the_card_says_it_in_words_not_in_numbers(store):
+    card = known(store)
+    state = affect(store)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+
+    rendered = store.people.get(card.person_id).render()
+    assert "annoyed" in rendered
+    assert "0." not in rendered
+
+
+def test_a_settled_attitude_and_a_recent_one_both_show(store):
+    card = known(store)
+    store.people.set_attitude(card.person_id, "a friend")
+    state = affect(store)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+
+    rendered = store.people.get(card.person_id).render()
+    assert "a friend" in rendered and "annoyed" in rendered
+
+
+# --- the dashboard ----------------------------------------------------------
+
+
+def test_a_change_of_mood_is_visible_to_whoever_is_watching(store):
+    events = RecordingEvents()
+    state = affect(store, events=events)
+    state.spoke("angry", [said()])
+    state.spoke("angry", [said()])
+    assert any(source == "affect" for _, source, _, _ in events.events)
+
+
+def test_an_unchanged_mood_is_not_reannounced_every_turn(store):
+    events = RecordingEvents()
+    state = affect(store, events=events)
+    for _ in range(6):
+        state.spoke("normal", [said("ciao")])
+    assert [e for e in events.events if e[1] == "affect"] == []

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -121,7 +121,7 @@ def test_she_is_told_once_and_not_every_turn_after():
 
 
 class SilentTTS(TTSInterface):
-    async def generate_audio(self, text):
+    async def generate_audio(self, text, prosody=None):
         return np.zeros(2400, dtype=np.float32), 24000
 
     async def speak(self, text, output_device_id):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -9,6 +9,7 @@ reads the pure affect rules, and the state reads the store back through the
 social promotion rules.
 """
 
+import os
 import subprocess
 import sys
 
@@ -31,5 +32,28 @@ def test_it_imports_first(module):
     result = subprocess.run(
         [sys.executable, "-c", f"import {module}"],
         capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# importing one of these used to pull in `sounddevice`, which raises outright
+# when PortAudio is missing — so the whole suite failed to collect on a runner
+# with no sound card. Synthesising audio is not playing it.
+HEADLESS = [
+    "src.modules.tts.edge_tts_wrapper",
+    "src.modules.tts.kokoro_tts_wrapper",
+    "src.modules.tts.orpheus_tts_wrapper",
+    "src.core.expression.voice",
+    "src.web.app",
+]
+
+
+@pytest.mark.parametrize("module", HEADLESS)
+def test_it_imports_on_a_machine_with_no_sound_card(module, tmp_path):
+    (tmp_path / "sounddevice.py").write_text("raise OSError('PortAudio library not found')\n")
+    env = {**os.environ, "PYTHONPATH": str(tmp_path)}
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True, text=True, env=env,
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,35 @@
+"""Every core module has to import on its own, in any order.
+
+A cycle only shows up when something imports the two halves in the wrong order,
+which the suite does not control: pytest has already pulled half the package in
+by the time any test runs. So each one is imported first, in its own process.
+
+`memory.store` and `affect.state` are the pair that actually broke: the store
+reads the pure affect rules, and the state reads the store back through the
+social promotion rules.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+MODULES = [
+    "src.core.memory.store",
+    "src.core.affect.state",
+    "src.core.affect.rules",
+    "src.core.expression.prosody",
+    "src.core.expression.voice",
+    "src.core.skills.social.people",
+    "src.core.consciousness",
+    "src.core.brain",
+]
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_it_imports_first(module):
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_prosody.py
+++ b/tests/test_prosody.py
@@ -1,0 +1,137 @@
+"""What a mood does to her voice, and the one thing it must never do.
+
+Neutral has to stay exactly neutral: if it did not, switching the feature off
+would still change how she sounds.
+"""
+
+import pytest
+
+from src.core.affect.rules import Affect
+from src.core.expression.prosody import (
+    NEUTRAL,
+    PITCH_LIMITS,
+    RATE_LIMITS,
+    VOLUME_LIMITS,
+    Prosody,
+    as_hz,
+    as_percent,
+    combine_hz,
+    combine_percent,
+    for_mood,
+)
+
+T0 = 1_000_000.0
+FURIOUS = Affect(-0.8, 0.8, T0)
+DELIGHTED = Affect(0.8, 0.6, T0)
+CALM = Affect(0.0, 0.0, T0)
+
+
+# --- neutrality -------------------------------------------------------------
+
+
+def test_no_mood_and_no_feeling_leaves_the_voice_alone():
+    assert for_mood("normal") == NEUTRAL
+    assert for_mood("normal").neutral is True
+
+
+def test_a_calm_state_leaves_a_neutral_line_alone():
+    assert for_mood("normal", CALM) == NEUTRAL
+
+
+def test_an_unknown_mood_falls_back_to_neutral():
+    assert for_mood("gibberish") == NEUTRAL
+
+
+# --- direction --------------------------------------------------------------
+
+
+def test_angry_is_faster_higher_and_louder_than_flat():
+    angry, bored = for_mood("angry"), for_mood("bored")
+    assert angry.rate > bored.rate
+    assert angry.pitch_hz > bored.pitch_hz
+    assert angry.volume > bored.volume
+
+
+def test_angry_and_sad_do_not_sound_the_same():
+    # both are negative; only arousal separates a shout from a sulk
+    angry, cry = for_mood("angry"), for_mood("cry")
+    assert angry.rate > cry.rate
+    assert angry.pitch_hz > cry.pitch_hz
+
+
+def test_sad_is_slower_and_lower_than_neutral():
+    cry = for_mood("cry")
+    assert cry.rate < 1.0
+    assert cry.pitch_hz < 0.0
+
+
+def test_delight_lifts_the_pitch():
+    assert for_mood("love").pitch_hz > 0.0
+
+
+# --- the standing state -----------------------------------------------------
+
+
+def test_a_matching_state_makes_a_line_land_harder():
+    assert for_mood("angry", FURIOUS).pitch_hz > for_mood("angry").pitch_hz
+
+
+def test_a_contradicting_state_softens_it():
+    assert for_mood("angry", DELIGHTED).pitch_hz < for_mood("angry").pitch_hz
+
+
+def test_an_ordinary_line_said_while_furious_is_not_ordinary():
+    assert for_mood("normal", FURIOUS) != NEUTRAL
+
+
+def test_a_state_below_the_threshold_changes_nothing():
+    barely = Affect(-0.1, 0.1, T0)
+    assert for_mood("angry", barely) == for_mood("angry")
+    assert for_mood("normal", barely) == NEUTRAL
+
+
+# --- limits -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mood", ["normal", "shock", "love", "cry", "angry", "ew", "bored"])
+@pytest.mark.parametrize("affect", [None, FURIOUS, DELIGHTED, Affect(-1.0, -1.0, T0)])
+def test_no_mood_can_push_the_voice_out_of_range(mood, affect):
+    p = for_mood(mood, affect)
+    assert RATE_LIMITS[0] <= p.rate <= RATE_LIMITS[1]
+    assert PITCH_LIMITS[0] <= p.pitch_hz <= PITCH_LIMITS[1]
+    assert VOLUME_LIMITS[0] <= p.volume <= VOLUME_LIMITS[1]
+
+
+# --- translation ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value,expected", [(1.0, "+0%"), (1.12, "+12%"), (0.9, "-10%")])
+def test_a_multiplier_becomes_a_signed_percentage(value, expected):
+    assert as_percent(value) == expected
+
+
+@pytest.mark.parametrize("value,expected", [(0.0, "+0Hz"), (9.6, "+10Hz"), (-4.2, "-4Hz")])
+def test_an_offset_becomes_signed_hz(value, expected):
+    assert as_hz(value) == expected
+
+
+def test_the_configured_voice_and_the_mood_compose():
+    # +10% configured, 12% faster from the mood: she ends up 23% over nominal
+    assert combine_percent("+10%", 1.12) == "+23%"
+    assert combine_hz("+5Hz", 9.6) == "+15Hz"
+
+
+def test_neutral_prosody_leaves_the_configured_voice_untouched():
+    assert combine_percent("+10%", 1.0) == "+10%"
+    assert combine_hz("+5Hz", 0.0) == "+5Hz"
+    assert combine_percent("+33%", 1.0) == "+33%"
+
+
+@pytest.mark.parametrize("base", ["", None, "loud", "%"])
+def test_a_malformed_configured_value_is_no_change_rather_than_a_crash(base):
+    assert combine_percent(base, 1.0) == "+0%"
+    assert combine_hz(base, 0.0) == "+0Hz"
+
+
+def test_prosody_is_hashable_so_it_can_be_cached_or_compared():
+    assert Prosody(1.1, 2.0, 1.0) == Prosody(1.1, 2.0, 1.0)

--- a/tests/test_voice_prosody.py
+++ b/tests/test_voice_prosody.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from src.core.affect.rules import Affect
-from src.core.expression.prosody import Prosody
+from src.core.expression.prosody import Prosody, for_mood
 from src.core.expression.voice import Expression
 from src.interfaces.base_interfaces import TTSInterface
 from src.modules.tts.edge_tts_wrapper import EdgeTTSWrapper
@@ -136,6 +136,17 @@ async def test_the_standing_mood_colours_the_same_words():
     await e.speak("angry", "ma dai")
 
     assert furious.moods[0].pitch_hz > calm.moods[0].pitch_hz
+
+
+@pytest.mark.asyncio
+async def test_the_mind_can_say_how_she_felt_when_she_decided():
+    """Local speech is rendered in a task started after the turn moved on."""
+    tts = RecordingTTS()
+    e = expression(tts)
+    e.set_affect(Affects(Affect(-0.9, 0.9, T0)))
+    await e.speak("angry", "ma dai", feeling=Affect())
+
+    assert tts.moods[0] == for_mood("angry")
 
 
 # --- the engine translation --------------------------------------------------

--- a/tests/test_voice_prosody.py
+++ b/tests/test_voice_prosody.py
@@ -24,7 +24,9 @@ class RecordingTTS(TTSInterface):
 
     async def generate_audio(self, text, prosody=None):
         self.calls.append((text, prosody))
-        return np.zeros(2400, dtype=np.float32), 24000
+        # nothing to play: these tests are about what the engine was told, and
+        # the runner that decides it has no sound card
+        return np.zeros(0, dtype=np.float32), 24000
 
     async def speak(self, text, output_device_id):
         pass

--- a/tests/test_voice_prosody.py
+++ b/tests/test_voice_prosody.py
@@ -1,0 +1,154 @@
+"""Does the mood actually reach the engine, and does off really mean off?
+
+The maths is tested in `test_prosody.py`. What is worth pinning here is the
+wiring: a mood that never leaves `Expression` is a feature nobody can hear.
+"""
+
+import numpy as np
+import pytest
+
+from src.core.affect.rules import Affect
+from src.core.expression.prosody import Prosody
+from src.core.expression.voice import Expression
+from src.interfaces.base_interfaces import TTSInterface
+from src.modules.tts.edge_tts_wrapper import EdgeTTSWrapper
+
+T0 = 1_000_000.0
+
+
+class RecordingTTS(TTSInterface):
+    """Keeps every (text, prosody) it was handed."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def generate_audio(self, text, prosody=None):
+        self.calls.append((text, prosody))
+        return np.zeros(2400, dtype=np.float32), 24000
+
+    async def speak(self, text, output_device_id):
+        pass
+
+    def reload_config(self, config):
+        pass
+
+    @property
+    def moods(self):
+        return [p for _, p in self.calls]
+
+
+class Affects:
+    """The shape `Expression` reads a standing mood through."""
+
+    def __init__(self, current=Affect(), enabled=True):
+        self.current = current
+        self.enabled = enabled
+
+
+class Obs:
+    def set_image(self, *a, **k):
+        pass
+
+    def set_media(self, *a, **k):
+        pass
+
+    def set_text(self, *a, **k):
+        pass
+
+    async def type_text(self, **kwargs):
+        return 0
+
+
+class Events:
+    def publish(self, *a, **k):
+        pass
+
+
+class Config:
+    text_font_size = 40
+    text_line_width = 30
+    text_lines = 3
+    text_min_font_size = 20
+    text_font_step = 2
+    typing_delay = 0.0
+    text_min_duration = 0.0
+    obs_text_source = ""
+    obs_source_type = "image"
+    audio_device_id = None
+
+
+def expression(tts) -> Expression:
+    e = Expression(Config(), tts, Obs(), Events())
+    e.set_png_map({})
+    return e
+
+
+# --- the wiring -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_without_an_affect_the_engine_is_told_nothing():
+    tts = RecordingTTS()
+    await expression(tts).speak("angry", "ma dai")
+    assert tts.moods == [None]
+
+
+@pytest.mark.asyncio
+async def test_switching_it_off_is_the_same_as_not_having_it():
+    tts = RecordingTTS()
+    e = expression(tts)
+    e.set_affect(Affects(Affect(-0.9, 0.9, T0), enabled=False))
+    await e.speak("angry", "ma dai")
+    assert tts.moods == [None]
+
+
+@pytest.mark.asyncio
+async def test_an_angry_line_reaches_the_engine_as_an_angry_voice():
+    tts = RecordingTTS()
+    e = expression(tts)
+    e.set_affect(Affects())
+    await e.speak("angry", "ma dai")
+
+    spoken = tts.moods[0]
+    assert spoken is not None and not spoken.neutral
+    assert spoken.rate > 1.0 and spoken.pitch_hz > 0.0
+
+
+@pytest.mark.asyncio
+async def test_a_neutral_line_from_a_calm_mind_leaves_the_voice_alone():
+    tts = RecordingTTS()
+    e = expression(tts)
+    e.set_affect(Affects())
+    await e.speak("normal", "ok")
+    assert tts.moods[0].neutral is True
+
+
+@pytest.mark.asyncio
+async def test_the_standing_mood_colours_the_same_words():
+    calm, furious = RecordingTTS(), RecordingTTS()
+
+    e = expression(calm)
+    e.set_affect(Affects())
+    await e.speak("angry", "ma dai")
+
+    e = expression(furious)
+    e.set_affect(Affects(Affect(-0.9, 0.9, T0)))
+    await e.speak("angry", "ma dai")
+
+    assert furious.moods[0].pitch_hz > calm.moods[0].pitch_hz
+
+
+# --- the engine translation --------------------------------------------------
+
+
+def test_edge_leaves_the_configured_voice_untouched_when_nothing_is_felt():
+    edge = EdgeTTSWrapper(voice="v", pitch="+5Hz", rate="+10%", volume="+33%")
+    assert edge._voice_for(None) == ("+5Hz", "+10%", "+33%")
+    assert edge._voice_for(Prosody()) == ("+5Hz", "+10%", "+33%")
+
+
+def test_edge_moves_the_configured_voice_rather_than_replacing_it():
+    edge = EdgeTTSWrapper(voice="v", pitch="+5Hz", rate="+10%", volume="+33%")
+    pitch, rate, volume = edge._voice_for(Prosody(rate=1.12, pitch_hz=9.6, volume=1.08))
+    assert (pitch, rate) == ("+15Hz", "+23%")
+    assert volume == "+44%"

--- a/tests/test_voice_streaming.py
+++ b/tests/test_voice_streaming.py
@@ -81,7 +81,7 @@ class OneShotTTS(TTSInterface):
     def __init__(self):
         self.rendered = []
 
-    async def generate_audio(self, text):
+    async def generate_audio(self, text, prosody=None):
         self.rendered.append(text)
         return np.zeros(2400, dtype=np.float32), 24000
 
@@ -95,7 +95,7 @@ class OneShotTTS(TTSInterface):
 class ChunkedTTS(OneShotTTS):
     """An engine whose source is already chunked, the way Orpheus's really is."""
 
-    async def generate_stream(self, text):
+    async def generate_stream(self, text, prosody=None):
         self.rendered.append(text)
         for _ in range(3):
             yield np.zeros(800, dtype=np.float32), 24000
@@ -207,7 +207,7 @@ async def test_a_barge_in_stops_her_paying_for_words_nobody_will_hear():
             super().__init__()
             self.channel_getter = channel_getter
 
-        async def generate_audio(self, text):
+        async def generate_audio(self, text, prosody=None):
             self.rendered.append(text)
             channel = self.channel_getter()
             # the first piece is already playing when someone talks over her


### PR DESCRIPTION
tutto quello che le succedeva o durava meno di due minuti (un cooldown, una finestra di attività) o diventava un fatto in un prompt. mancava la scala della mezz'ora, che è quella su cui si legge l'umore di una persona: la facevi incazzare e otto secondi dopo era di nuovo allegra.

il segnale c'era già ed era buttato — il mood che sceglie a ogni `speak` finiva solo in un png. nessun tool nuovo, nessuna chiamata al modello in più, nessun task in background: il valore si porta dietro quando è stato scritto e decade quando qualcuno lo legge, come già fanno gli hot facts. quindi un crash mentre è furiosa la fa ripartire furiosa, e una notte no.

una riga forte lascia tre tracce su tre orologi: l'umore (~25 min), come sta con chi gliel'ha detta (~2 giorni, su `people.warmth`), e un hot fact per ricordarsi di cosa si trattava (6h). l'attribuzione scatta solo se in quel batch c'è una persona sola: in una chat affollata l'umore è della stanza, e prendersela con una faccia a caso sarebbe inventarsi un rancore.

si sente anche. `speak(mood)` arriva al tts come scostamento da rate/pitch/volume configurati — edge tutti e tre, kokoro solo il rate, orpheus nessuno. `Prosody()` neutro è identico a prima, quindi spegnerla le lascia la voce esattamente com'era.

due regole tenute ferme: non tocca mai `is_addressed`, perché rispondere a chi ti chiama per nome non deve dipendere da un dado; e `[HOW YOU FEEL]` dice come sta, mai come comportarsi — quello lo decide il soul, che è un file che scrivi tu.

dentro anche due cose trovate per strada: un import circolare fra `memory.store` e `affect.state` (la suite passava per ordine di import, non per costruzione) e `people.profiled_count`, nello schema ma non nelle migrazioni, che faceva crashare il profiler su ogni db più vecchio della colonna.