### PR TITLE
Choose how she appears: images, a 3D model, or VTube Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ data/memory/
 data/bea.db
 data/bea.db-wal
 data/bea.db-shm
+data/vtube_studio_token.json
 data/embeddings_cache/
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,11 @@ src/web/frontend/dist/
 .DS_Store
 Thumbs.db
 
-# Large Models
+# Large Models — fetched, never committed (see tools/fetch_model.py)
 *.onnx
 *.bin
+data/models/
+data/clips/
 
 # the author's own planning file at the root — anchored, or it also matches
 # docs/skills/plan.md, which is documentation the README links to

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install setup docker docker-up docker-down run web frontend lock clean test lint migrate
+.PHONY: help install setup docker docker-up docker-down run web frontend lock clean test lint migrate model
 
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -44,6 +44,9 @@ test: ## run the test suite
 
 lint: ## static checks
 	uv run ruff check src tests
+
+model: ## download the free sample 3d model and clip into data/
+	uv run python tools/fetch_model.py
 
 lock: ## refresh uv.lock after changing dependencies
 	uv lock

--- a/README.md
+++ b/README.md
@@ -125,35 +125,37 @@ server sees a normal player. Nothing is needed server-side.
 
 ---
 
-## Pick a body for her
+## How she looks on stream
 
-She has always been a PNG that swapped when her mood did. Now that is one choice
-of three, and the engine no longer knows which one you made.
+Three ways to put her on screen. Pick one in **Settings → Stream**, with a live
+preview of what the stream will see.
 
 | | What it is | What you need |
 |---|---|---|
-| **Images** | One picture per mood, swapped in OBS | Your PNGs. Nothing else. |
-| **3D model** | A VRM rendered in an OBS browser source | A `.vrm` — or `make model` for a free one |
-| **VTube Studio** | Your own Live2D model, over its plugin API | VTube Studio, which you already have or do not |
+| **Images** | One picture per mood, swapped in OBS | Your PNGs |
+| **3D model** | A VRM in an OBS browser source | A `.vrm` file |
+| **VTube Studio** | Your own Live2D model, driven over its API | VTube Studio running |
 
-The speech bubble is a **separate** choice: an OBS text source, the browser
-source, or nothing at all. "Images with the nicer browser caption" and "3D body
-with the bubble still in OBS" are both setups people want.
+Her speech bubble is a separate choice — an OBS text source, the same browser
+source, or nothing — so you can mix them however you like.
 
-**No model ships with projectBEA.** A model is 11 MB of binary most people
-replace with their own, and its licence is not ours to hand you — the same call
-the repo already makes for the speech models. `make model` fetches pixiv's free
-VRM 1.0 sample, and `tools/inspect_vrm.py` reads any model's licence out of the
-file itself and tells you in words what it allows.
+For the 3D route, `make model` downloads a free model to start from. If you go
+looking for your own, run it through the inspector first:
 
-The mood she picks for a line already decides how she sounds. Now it decides how
-she looks, out of the same two numbers: `src/core/expression/face.py` turns a
-mood into VRM expression weights, and the test suite checks them against the
-valence/arousal vectors so a face can never contradict a feeling. Her mouth is
-driven by the loudness of the audio she is about to say — 180 frames for six
-seconds, computed in a fifth of a millisecond, sent once.
+```bash
+uv run python tools/inspect_vrm.py your-model.vrm
+```
 
-**[How the avatar port works →](docs/modules/avatar.md)**
+It tells you whether the model can do what she needs — a mouth that moves, a face
+per mood — and reads out the licence the file carries, so you know what you are
+allowed to stream with it. Her gestures are `.vrma` clips: drop them in
+`data/clips` and assign one per mood.
+
+Whichever you pick, the mood she chooses for a line drives all of it — her
+expression, her gesture, and her mouth, which follows the audio she is about to
+say.
+
+**[How it works, and how to add a backend →](docs/modules/avatar.md)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,38 @@ server sees a normal player. Nothing is needed server-side.
 
 ---
 
+## Pick a body for her
+
+She has always been a PNG that swapped when her mood did. Now that is one choice
+of three, and the engine no longer knows which one you made.
+
+| | What it is | What you need |
+|---|---|---|
+| **Images** | One picture per mood, swapped in OBS | Your PNGs. Nothing else. |
+| **3D model** | A VRM rendered in an OBS browser source | A `.vrm` — or `make model` for a free one |
+| **VTube Studio** | Your own Live2D model, over its plugin API | VTube Studio, which you already have or do not |
+
+The speech bubble is a **separate** choice: an OBS text source, the browser
+source, or nothing at all. "Images with the nicer browser caption" and "3D body
+with the bubble still in OBS" are both setups people want.
+
+**No model ships with projectBEA.** A model is 11 MB of binary most people
+replace with their own, and its licence is not ours to hand you — the same call
+the repo already makes for the speech models. `make model` fetches pixiv's free
+VRM 1.0 sample, and `tools/inspect_vrm.py` reads any model's licence out of the
+file itself and tells you in words what it allows.
+
+The mood she picks for a line already decides how she sounds. Now it decides how
+she looks, out of the same two numbers: `src/core/expression/face.py` turns a
+mood into VRM expression weights, and the test suite checks them against the
+valence/arousal vectors so a face can never contradict a feeling. Her mouth is
+driven by the loudness of the audio she is about to say — 180 frames for six
+seconds, computed in a fifth of a millisecond, sent once.
+
+**[How the avatar port works →](docs/modules/avatar.md)**
+
+---
+
 ## A busy chat costs almost nothing
 
 Answering every message is what makes an always-on persona expensive to run and
@@ -272,6 +304,8 @@ touching the core.
 | **LLM** | `LLMClient` (tool-aware) | OpenRouter, OpenAI, Groq |
 | **TTS** | `TTSInterface` | EdgeTTS (free), Kokoro (local ONNX), Orpheus (API) |
 | **STT** | `STTInterface` | Groq, OpenRouter (Whisper) |
+| **Avatar** | `AvatarInterface` | Images (OBS), 3D model (VRM), VTube Studio |
+| **Caption** | `CaptionInterface` | OBS text source, browser source, off |
 | **OBS** | `OBSInterface` | OBS WebSocket |
 
 Models are configured per **role**, not one at a time: `mind` for the
@@ -280,7 +314,7 @@ role is a pool that round-robins to spread rate limits and falls back when a
 provider is down. Hot reload is built in: change models, voices or settings at
 runtime, without a restart.
 
-**[LLM →](docs/modules/llm.md)** · **[TTS →](docs/modules/tts.md)** · **[STT →](docs/modules/stt.md)** · **[OBS →](docs/modules/obs.md)**
+**[LLM →](docs/modules/llm.md)** · **[TTS →](docs/modules/tts.md)** · **[STT →](docs/modules/stt.md)** · **[Avatar →](docs/modules/avatar.md)** · **[OBS →](docs/modules/obs.md)**
 
 ---
 
@@ -387,7 +421,7 @@ same source.
 | [Setup & Install](docs/setup.md) | Installation, OBS setup, audio routing |
 | [Configuration](docs/configuration.md) | Every config field, CLI arg and `.env` var |
 | [Skills Overview](docs/skills/overview.md) | The `Skill` API, the registry, every tool |
-| [Modules](docs/modules/llm.md) | [LLM](docs/modules/llm.md) · [TTS](docs/modules/tts.md) · [STT](docs/modules/stt.md) · [OBS](docs/modules/obs.md) |
+| [Modules](docs/modules/llm.md) | [LLM](docs/modules/llm.md) · [TTS](docs/modules/tts.md) · [STT](docs/modules/stt.md) · [Avatar](docs/modules/avatar.md) · [OBS](docs/modules/obs.md) |
 | [Skills](docs/skills/overview.md) | [Memory](docs/skills/memory.md) · [Social](docs/skills/social.md) · [Dream](docs/skills/dream.md) · [Plan](docs/skills/plan.md) · [Discord](docs/skills/discord.md) · [Telegram](docs/skills/telegram.md) · [Twitch](docs/skills/twitch.md) · [Minecraft](docs/skills/minecraft.md) · [Donations](docs/skills/donations.md) · [Monologue](docs/skills/monologue.md) |
 | [Web](docs/web/api.md) | [API reference](docs/web/api.md) · [Frontend](docs/web/frontend.md) |
 | [Contributing](docs/contributing.md) | Where to start, the invariants, tests, pull requests |

--- a/config.example.json
+++ b/config.example.json
@@ -57,6 +57,21 @@
         }
     },
     "png_dir": "data/pngs",
+    "stage": {
+        "avatar_backend": "png",
+        "caption_backend": "obs",
+        "lipsync_fps": 30,
+        "model_path": "",
+        "clips_dir": "data/clips",
+        "shot": "bust",
+        "mood_clips": {},
+        "background": "",
+        "vts_host": "127.0.0.1",
+        "vts_port": 8001,
+        "vts_expressions": {},
+        "vts_clips": {},
+        "vts_mouth_param": "MouthOpen"
+    },
     "text_line_width": 40,
     "text_lines": 4,
     "text_font_size": 75,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,8 @@ ProjectBEA/
 │   ├── bea.db              # everything she remembers (gitignored)
 │   ├── conversations/      # session transcripts, one JSON per session
 │   ├── embeddings_cache/   # the local embedding model's cache
+│   ├── models/             # the .vrm you bring (gitignored, `make model`)
+│   ├── clips/              # .vrma behaviours (gitignored, `make model`)
 │   ├── pngs/               # avatars per mood (idle/talking)
 │   └── prompts/            # soul · operating · monologue · minecraft · chat
 ├── docs/                   # this documentation, rendered by the docs site
@@ -80,16 +82,20 @@ ProjectBEA/
     │   ├── mind/           # routing, scheduler, conversations, correlation
     │   ├── memory/         # sqlite, rag, embedder, profiler, plan
     │   ├── social/         # the roster, reach and agenda
-    │   ├── expression/     # the single output sink + humanizer
+    │   ├── expression/     # the single output sink + humanizer + the face
+    │   ├── stage.py        # fan-out to the OBS browser source
     │   ├── agent/          # LLMClient, role pools, tools, runner
     │   └── skills/         # one package per capability
-    ├── interfaces/         # TTS · STT · OBS contracts
-    ├── modules/            # llm · tts · stt · obs implementations
+    ├── interfaces/         # TTS · STT · OBS · Avatar · Caption contracts
+    ├── modules/            # llm · tts · stt · obs · avatar · caption implementations
     ├── setup/              # the wizard behind `bea --setup`
     ├── utils/
     └── web/
         ├── app.py          # FastAPI
         └── frontend/       # React + Vite + Tailwind
+            ├── index.html  # the dashboard
+            ├── stage.html  # the OBS browser source (separate bundle)
+            └── src/stage/  # caption + the VRM renderer
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -355,6 +355,44 @@ continues. [OBS module →](modules/obs.md)
 
 ---
 
+## stage — how she appears
+
+Two independent choices, plus the settings each one needs.
+
+| Key | Default | What it does |
+|---|---|---|
+| `avatar_backend` | `"png"` | `png`, `model` or `vtube_studio`. An unknown name falls back to `png` with a warning. |
+| `caption_backend` | `"obs"` | `obs`, `stage` (the browser source) or `off`. |
+| `lipsync_fps` | `30` | How many times a second her mouth is told what to do. |
+
+**The `model` backend**
+
+| Key | Default | What it does |
+|---|---|---|
+| `model_path` | `""` | The `.vrm` on this machine. Nothing ships with the repo; `make model` fetches a free one. |
+| `clips_dir` | `"data/clips"` | Where `.vrma` behaviours live. They appear by name in the dashboard. |
+| `shot` | `"bust"` | `bust`, `half` or `full`. Framed off the head bone, so any model is framed alike. |
+| `mood_clips` | `{}` | mood → clip name. Optional; a mood without one just changes expression. |
+| `background` | `""` | A colour behind her, or empty for transparent. |
+
+**The `vtube_studio` backend** — nothing is bundled; it drives the VTube Studio you already run.
+
+| Key | Default | What it does |
+|---|---|---|
+| `vts_host` | `"127.0.0.1"` | Where VTube Studio is. |
+| `vts_port` | `8001` | Its plugin API port. |
+| `vts_expressions` | `{}` | mood → expression file in **your** model. The dashboard reads the list from the connected model. |
+| `vts_clips` | `{}` | clip name → hotkey id or name. |
+| `vts_mouth_param` | `"MouthOpen"` | The parameter the lip sync writes to. |
+
+The token VTube Studio issues is **not** kept here. It lives in
+`data/vtube_studio_token.json`, gitignored, because `GET /config` is
+unauthenticated.
+
+Full reference: **[Avatar module →](modules/avatar.md)**
+
+---
+
 ## Avatar and the text bubble
 
 `avatar_map` holds one `{idle, talking}` pair per mood: `normal`, `angry`,

--- a/docs/modules/avatar.md
+++ b/docs/modules/avatar.md
@@ -1,0 +1,301 @@
+# Avatar Module
+
+← [Back to README](../../README.md) | [Architecture](../architecture.md) | [OBS →](obs.md)
+
+---
+
+## Overview
+
+How Bea appears on screen is a **port**, not a setting buried in the speech path.
+`Expression` hands down what she *is* — a mood and a state — and a backend
+decides what that means.
+
+```
+src/modules/avatar/
+├── factory.py       build_avatar(config, obs, publisher)
+├── png.py           PngAvatar          one image per mood, swapped in OBS
+├── model3d.py       Model3DAvatar      a VRM drawn in a browser source
+└── vtube_studio.py  VTubeStudioAvatar  your Live2D model, over the VTS API
+
+src/modules/caption/
+├── factory.py       build_caption(config, obs, publisher)
+├── obs_text.py      ObsTextCaption     typed into an OBS text source
+├── stage.py         StageCaption       typed in the browser source
+└── silent.py        SilentCaption      no words at all
+```
+
+The two choices are independent. "PNG avatar with the nicer browser caption" and
+"3D body with the bubble still in OBS" are both setups people want, so neither
+is allowed to imply the other.
+
+---
+
+## The contract
+
+`src/interfaces/base_interfaces.py`:
+
+```python
+class AvatarInterface(ABC):
+    def show(self, mood: str, state: str) -> None: ...   # idle|talking|listening|sleeping
+    def perform(self, clip: str) -> None: ...            # a named behaviour
+    def mouth(self, envelope, fps: int) -> None: ...     # loudness per frame, in [0,1]
+    def reload_config(self, config) -> None: ...
+    def close(self) -> None: ...
+```
+
+Three things are deliberate:
+
+**Every method is synchronous.** A backend that needs the network queues the
+work. Nothing the engine does while she is speaking waits on a socket.
+
+**`mouth` takes the whole utterance, not one value per frame.** A page can
+replay it against its own clock; a backend that needs a stream paces it itself.
+
+**A backend may ignore what it cannot do.** `PngAvatar.perform` and
+`PngAvatar.mouth` are no-ops, and say so. That is why nothing above the port
+has to ask which backend is running.
+
+`CaptionInterface` is `say(text)` (awaitable, because the OBS backend animates
+over time and barge-in cancels it mid-sentence) and `clear()`.
+
+---
+
+## Choosing a backend
+
+Dashboard → **Settings → Stream**, or `config.json`:
+
+```json
+"stage": {
+  "avatar_backend": "png",      // png | model | vtube_studio
+  "caption_backend": "obs"      // obs | stage | off
+}
+```
+
+Both are hot-reloadable: the engine rebuilds only the port that changed, so
+switching the caption does not drop a loaded 3D model. An unknown name falls
+back to the default with a warning rather than leaving her invisible.
+
+---
+
+## `png` — one image per mood
+
+What projectBEA has always done. `avatar_map` holds an `idle` and a `talking`
+path per mood, and the backend swaps the file in an OBS image or media source.
+
+States get their own slot when you give them one:
+
+```json
+"avatar_map": {
+  "angry":    { "idle": "data/pngs/angry/idle.png", "talking": "data/pngs/angry/talking.png" },
+  "sleeping": { "idle": "data/pngs/sleeping.png",   "talking": "data/pngs/sleeping.png" }
+}
+```
+
+`sleeping` and `listening` are **states, not moods**. Without a slot the backend
+falls back to the mood's image and warns once — it used to fall back silently,
+which is why the sleeping avatar was never once seen.
+
+---
+
+## `model` — a 3D VRM
+
+The model is rendered by a page you point an OBS **Browser Source** at:
+`http://127.0.0.1:8000/stage`. The engine publishes expression weights, a
+behaviour name and a loudness envelope; the page owns three.js.
+
+```json
+"stage": {
+  "avatar_backend": "model",
+  "model_path": "data/models/VRM1_Constraint_Twist_Sample.vrm",
+  "clips_dir": "data/clips",
+  "shot": "bust",
+  "mood_clips": { "angry": "lean_in" },
+  "lipsync_fps": 30,
+  "background": ""
+}
+```
+
+### Why VRM and not glTF
+
+A plain `.glb` names its bones however the artist felt like: `Bip01_L_UpperArm`,
+`mixamorig:LeftArm`, `braccio_sx`. **VRM standardises the names** — 54 humanoid
+bones and 18 expressions (five emotions, five visemes, blinks, look direction).
+That is the whole reason a mapping written today works on a model you download
+next year, and the reason behaviours are portable at all.
+
+### Getting a model
+
+**No model ships with projectBEA.** It is 11 MB of binary that most people
+replace with their own, and the repository is a bad place for either — the same
+call `.gitignore` already makes for the speech models.
+
+```bash
+make model      # fetches pixiv's free VRM 1.0 sample and one .vrma clip
+```
+
+Then read what it allows, which is a thing only VRM lets you do:
+
+```bash
+uv run python tools/inspect_vrm.py data/models/*.vrm
+```
+
+```
+  Licence, as the file itself declares it
+    authors:  pixiv Inc.
+    avatarPermission: everyone — anyone may use this avatar
+    commercialUsage: corporation — companies may use it commercially
+    creditNotation: unnecessary — no credit required
+    allowRedistribution: yes
+
+  Rig: 54 humanoid bones
+  Expressions: 18 presets
+    emotions: happy, angry, sad, relaxed, surprised, neutral
+    visemes:  aa, ih, ou, ee, oh
+```
+
+Run the same tool on your own model before you go live. It tells you what is
+missing — no `aa` viseme means her mouth cannot move; no emotions means one face
+for every mood.
+
+To make your own: **VRoid Studio** is free, runs on macOS and Windows, and
+exports VRM with all 18 expressions already wired.
+
+### Behaviours
+
+A `.vrma` clip drives humanoid bones **by standard name**, so it carries no mesh,
+no material and no texture — 11 KB for three seconds. That is why a clip library
+can ship with the repo while a model cannot. Drop clips in `clips_dir`; they
+appear by name in the dashboard, and `mood_clips` picks one per mood.
+
+### Two traps worth knowing
+
+Both were found by looking at the thing on screen, and both are handled in
+`src/web/frontend/src/stage/avatar.js`:
+
+- **The 180° turn belongs to VRM 0.x only.** `VRMUtils.rotateVRM0` applies it
+  where it is due. An unconditional `rotation.y = Math.PI` shows you the back of
+  the head of every VRM 1.0 model.
+- **The camera is framed off the `head` bone**, never off hardcoded numbers.
+  That is what makes one `shot` setting frame a 1.4 m model and a 1.8 m one the
+  same way.
+
+---
+
+## `vtube_studio` — your own Live2D model
+
+Nothing is bundled and nothing is required. VTube Studio is what most VTubers
+already run; if you have it, projectBEA drives it over its plugin API.
+
+```json
+"stage": {
+  "avatar_backend": "vtube_studio",
+  "vts_host": "127.0.0.1",
+  "vts_port": 8001,
+  "vts_expressions": { "angry": "furious.exp3.json" },
+  "vts_clips": { "lean_in": "hotkey-id-or-name" },
+  "vts_mouth_param": "MouthOpen"
+}
+```
+
+| Port call | VTube Studio request |
+|---|---|
+| `show(mood, state)` | `ExpressionActivationRequest` with `vts_expressions[mood]` |
+| `perform(clip)` | `HotkeyTriggerRequest` with `vts_clips[clip]` |
+| `mouth(envelope, fps)` | `InjectParameterDataRequest` on `vts_mouth_param`, one per frame |
+
+Turn the API on in VTube Studio (**Settings → Start API**). The first time she
+connects it asks you to allow the plugin; say yes, and the token is stored in
+`data/vtube_studio_token.json` — gitignored, and never in `config.json`, which is
+served by an unauthenticated endpoint.
+
+Expressions and hotkeys are named by **whoever rigged your model**, so the
+dashboard reads them from the connected model and offers them as a list rather
+than a text box. Press **Test the connection** to fill it.
+
+Two differences from the other backends, both handled inside the adapter:
+
+- VTube Studio has no clock of ours, so this is the one backend that **paces the
+  mouth itself**, one message per frame.
+- VTS leaves an expression on until told otherwise, so the adapter **turns the
+  previous one off** before activating the next.
+
+---
+
+## Lip sync
+
+`envelope()` in `src/core/expression/pcm.py` is the per-frame RMS of the audio
+she is about to say, normalised to `[0, 1]`. Not a phoneme model and not a
+viseme classifier: the shape of the line, which is all a mouth needs.
+
+It is computed on this machine because the audio is played on this machine and
+the page never hears it. Six seconds of speech is **180 frames, about 0.2 ms and
+1.2 KB of JSON** — small enough to send whole, ahead of playback, so the page can
+run it off its own clock instead of waiting for 30 messages a second.
+
+A lip sync failure is logged and swallowed: a mouth that breaks must never stop
+her from speaking.
+
+---
+
+## The mood → face table
+
+`src/core/expression/face.py` turns a mood into VRM expression weights, the same
+way `prosody.py` turns it into a way of speaking.
+
+| mood | (valence, arousal) | weights |
+|---|---|---|
+| `normal` | (0.00, 0.00) | `neutral 1.0` |
+| `shock` | (-0.15, 0.85) | `surprised 0.9` |
+| `love` | (0.90, 0.50) | `happy 1.0` |
+| `cry` | (-0.70, -0.25) | `sad 1.0` |
+| `angry` | (-0.80, 0.85) | `angry 1.0` |
+| `ew` | (-0.50, 0.15) | `angry 0.45` + `sad 0.35` |
+| `bored` | (-0.30, -0.70) | `relaxed 0.25` + `sad 0.35` |
+
+Bea has seven moods; VRM standardises five emotions. `ew` and `bored` have no
+preset of their own and are blends — the only judgement calls in the file.
+
+`tests/test_face.py` checks every row against the valence/arousal vectors in
+`moods.py`, and it earns its keep: the first draft of `bored` was
+`relaxed 0.7`, and the test rejected it with *"bored feels bad but looks good"*.
+`relaxed` in VRM means *at ease*, so she came out looking pleased to be ignoring
+you. It is the kind of mistake you do not catch by eye and everybody catches on
+stream.
+
+---
+
+## The stage channel
+
+`src/core/stage.py` is the fan-out to the browser source. Deliberately **not**
+`EventManager`: that one replays a backlog to every new subscriber, which is
+right for a dashboard reading a log and wrong here — OBS reloads a browser
+source whenever you toggle it, and a replay would have her act out the last
+minute of the stream again.
+
+A page that connects gets **one snapshot** of how she looks now, and patches
+after that. Keys like `envelope` and `perform` describe a moment rather than a
+state and are never stored, so a page that reconnects does not mouth a sentence
+nobody is saying.
+
+| Endpoint | What it is |
+|---|---|
+| `GET /stage` | the page to point a Browser Source at |
+| `GET /stage/stream` | SSE: one snapshot, then patches |
+| `GET /stage/config` | what the page needs to draw her — never a secret |
+| `GET /stage/model` | the configured `.vrm` |
+| `GET /stage/clips` | the behaviours installed, by name |
+| `GET /stage/clips/{name}` | one `.vrma` |
+| `GET /stage/preview` | one avatar image, for the dashboard preview |
+
+---
+
+## Adding a backend
+
+1. Implement `AvatarInterface` in `src/modules/avatar/`.
+2. Add a builder to `BUILDERS` in `factory.py`. Put the import **inside** the
+   builder, so choosing another backend never pays for yours.
+3. If it needs somewhere to publish, add its name to `NEEDS_PUBLISHER`.
+4. Add it to `AVATARS` in `src/setup/wizard.py`.
+
+`tests/test_avatar_backends.py` walks `BUILDERS` and checks every registered
+backend honours the port, so step 1 cannot be half-done.

--- a/docs/modules/avatar.md
+++ b/docs/modules/avatar.md
@@ -6,83 +6,87 @@
 
 ## Overview
 
-How Bea appears on screen is a **port**, not a setting buried in the speech path.
-`Expression` hands down what she *is* — a mood and a state — and a backend
-decides what that means.
+Two ports decide how Bea reaches the screen. `Expression` calls them with a mood
+and a state and never learns which backend is behind either.
 
 ```
-src/modules/avatar/
-├── factory.py       build_avatar(config, obs, publisher)
-├── png.py           PngAvatar          one image per mood, swapped in OBS
-├── model3d.py       Model3DAvatar      a VRM drawn in a browser source
-└── vtube_studio.py  VTubeStudioAvatar  your Live2D model, over the VTS API
-
-src/modules/caption/
-├── factory.py       build_caption(config, obs, publisher)
-├── obs_text.py      ObsTextCaption     typed into an OBS text source
-├── stage.py         StageCaption       typed in the browser source
-└── silent.py        SilentCaption      no words at all
+src/modules/avatar/                          src/modules/caption/
+├── factory.py   build_avatar()              ├── factory.py   build_caption()
+├── png.py       PngAvatar                   ├── obs_text.py  ObsTextCaption
+├── model3d.py   Model3DAvatar               ├── stage.py     StageCaption
+└── vtube_studio.py  VTubeStudioAvatar       └── silent.py    SilentCaption
 ```
 
-The two choices are independent. "PNG avatar with the nicer browser caption" and
-"3D body with the bubble still in OBS" are both setups people want, so neither
-is allowed to imply the other.
+They are chosen independently: any avatar backend works with any caption
+backend.
+
+| | Avatar backends | Caption backends |
+|---|---|---|
+| key | `png` · `model` · `vtube_studio` | `obs` · `stage` · `off` |
+| needs OBS WebSocket | `png` only | `obs` only |
+| needs a browser source | `model` | `stage` |
 
 ---
 
-## The contract
-
-`src/interfaces/base_interfaces.py`:
+## `AvatarInterface`
 
 ```python
 class AvatarInterface(ABC):
-    def show(self, mood: str, state: str) -> None: ...   # idle|talking|listening|sleeping
-    def perform(self, clip: str) -> None: ...            # a named behaviour
-    def mouth(self, envelope, fps: int) -> None: ...     # loudness per frame, in [0,1]
+    def show(self, mood: str, state: str) -> None: ...
+    def perform(self, clip: str) -> None: ...
+    def mouth(self, envelope: Sequence[float], fps: int) -> None: ...
     def reload_config(self, config) -> None: ...
     def close(self) -> None: ...
 ```
 
-Three things are deliberate:
+| Method | Called | Argument |
+|---|---|---|
+| `show` | before and after every spoken line, and on a state change | `mood` is one of `MOODS`; `state` is `idle`, `talking`, `listening` or `sleeping` |
+| `perform` | when a mood maps to a behaviour | a clip name, resolved by the backend |
+| `mouth` | once per line, **before playback starts** | the whole envelope, so the backend can pace it against its own clock |
+| `close` | on shutdown | — |
 
-**Every method is synchronous.** A backend that needs the network queues the
-work. Nothing the engine does while she is speaking waits on a socket.
+Three rules a backend has to hold to:
 
-**`mouth` takes the whole utterance, not one value per frame.** A page can
-replay it against its own clock; a backend that needs a stream paces it itself.
+- **Every method is synchronous.** A backend that needs the network queues the
+  work. Blocking here blocks the turn she is speaking in.
+- **`mouth` receives the whole utterance.** Do not expect a call per frame.
+- **Ignore what you cannot do.** `perform` and `mouth` are no-ops on `PngAvatar`.
+  Callers never branch on the backend.
 
-**A backend may ignore what it cannot do.** `PngAvatar.perform` and
-`PngAvatar.mouth` are no-ops, and say so. That is why nothing above the port
-has to ask which backend is running.
-
-`CaptionInterface` is `say(text)` (awaitable, because the OBS backend animates
-over time and barge-in cancels it mid-sentence) and `clear()`.
+`CaptionInterface` is `say(text)` and `clear()`. `say` is awaitable because the
+OBS backend animates over time and barge-in cancels it mid-sentence.
 
 ---
 
-## Choosing a backend
+## Configuration
 
-Dashboard → **Settings → Stream**, or `config.json`:
+Everything lives in the `stage` block. Dashboard → **Settings → Stream** writes
+the same keys.
 
 ```json
 "stage": {
-  "avatar_backend": "png",      // png | model | vtube_studio
-  "caption_backend": "obs"      // obs | stage | off
+  "avatar_backend": "png",
+  "caption_backend": "obs",
+  "lipsync_fps": 30
 }
 ```
 
-Both are hot-reloadable: the engine rebuilds only the port that changed, so
-switching the caption does not drop a loaded 3D model. An unknown name falls
-back to the default with a warning rather than leaving her invisible.
+| Key | Default | Notes |
+|---|---|---|
+| `avatar_backend` | `"png"` | Unknown value → `png`, with a warning. |
+| `caption_backend` | `"obs"` | Unknown value → `obs`, with a warning. |
+| `lipsync_fps` | `30` | Frames per second of mouth data. |
+
+Both are hot-reloadable. `AIVtuberBrain._reload_stage` rebuilds only the port
+whose backend changed, so switching the caption does not drop a loaded model or
+an authenticated socket.
 
 ---
 
-## `png` — one image per mood
+## `png`
 
-What projectBEA has always done. `avatar_map` holds an `idle` and a `talking`
-path per mood, and the backend swaps the file in an OBS image or media source.
-
-States get their own slot when you give them one:
+Swaps a file in an OBS image or media source. `obs_source_type` decides which.
 
 ```json
 "avatar_map": {
@@ -91,17 +95,22 @@ States get their own slot when you give them one:
 }
 ```
 
-`sleeping` and `listening` are **states, not moods**. Without a slot the backend
-falls back to the mood's image and warns once — it used to fall back silently,
-which is why the sleeping avatar was never once seen.
+Keys are moods, plus optionally the two non-speech **states**, `sleeping` and
+`listening`. Resolution order for `show(mood, state)`:
+
+1. `avatar_map[state]` if `state` is `sleeping` or `listening` and has an entry
+2. `avatar_map[mood]`, taking `talking` or `idle`
+3. `avatar_map["normal"]`
+4. any entry at all
+
+A missing state entry logs one warning per state, not per frame.
 
 ---
 
-## `model` — a 3D VRM
+## `model`
 
-The model is rendered by a page you point an OBS **Browser Source** at:
-`http://127.0.0.1:8000/stage`. The engine publishes expression weights, a
-behaviour name and a loudness envelope; the page owns three.js.
+Renders a VRM in a page served at `/stage`, which you add to OBS as a **Browser
+Source**. The backend publishes to the stage channel; the page owns three.js.
 
 ```json
 "stage": {
@@ -110,81 +119,64 @@ behaviour name and a loudness envelope; the page owns three.js.
   "clips_dir": "data/clips",
   "shot": "bust",
   "mood_clips": { "angry": "lean_in" },
-  "lipsync_fps": 30,
   "background": ""
 }
 ```
 
-### Why VRM and not glTF
+| Key | Notes |
+|---|---|
+| `model_path` | Any path on this machine. Served by `GET /stage/model`; the page never touches the filesystem. |
+| `clips_dir` | `.vrma` files, listed by `GET /stage/clips` and offered in the dashboard. |
+| `shot` | `bust`, `half` or `full`. Computed from the `head` and `hips` bones, so it frames any model the same way regardless of its height. |
+| `mood_clips` | mood → clip name. A mood without one changes expression only. |
+| `background` | A CSS colour behind her. Empty means transparent. |
 
-A plain `.glb` names its bones however the artist felt like: `Bip01_L_UpperArm`,
-`mixamorig:LeftArm`, `braccio_sx`. **VRM standardises the names** — 54 humanoid
-bones and 18 expressions (five emotions, five visemes, blinks, look direction).
-That is the whole reason a mapping written today works on a model you download
-next year, and the reason behaviours are portable at all.
+### Why the format matters
 
-### Getting a model
+A plain `.glb` names bones however the artist chose — `Bip01_L_UpperArm`,
+`mixamorig:LeftArm`. VRM fixes the names: 54 humanoid bones and 18 expressions
+(`happy angry sad relaxed surprised`, the visemes `aa ih ou ee oh`, blinks, look
+direction). Every mapping in this module is written against those names, which
+is what makes it work on a model the code has never seen.
 
-**No model ships with projectBEA.** It is 11 MB of binary that most people
-replace with their own, and the repository is a bad place for either — the same
-call `.gitignore` already makes for the speech models.
+The same applies to behaviours. A `.vrma` drives bones by standard name and
+carries no mesh, material or texture — a three-second clip is about 11 KB, and
+it plays on any VRM.
+
+### Checking a model
 
 ```bash
-make model      # fetches pixiv's free VRM 1.0 sample and one .vrma clip
+uv run python tools/inspect_vrm.py data/models/bea.vrm
 ```
 
-Then read what it allows, which is a thing only VRM lets you do:
+Prints the rig, the expressions and the licence fields VRM stores inside the
+file. Use it to find out before going live whether a model is missing the `aa`
+viseme (her mouth cannot move) or the emotion presets (one face for every mood).
+It exits non-zero when something required is absent.
 
-```bash
-uv run python tools/inspect_vrm.py data/models/*.vrm
-```
+`make model` downloads pixiv's VRM 1.0 sample and one clip into `data/models`
+and `data/clips`, both gitignored.
 
-```
-  Licence, as the file itself declares it
-    authors:  pixiv Inc.
-    avatarPermission: everyone — anyone may use this avatar
-    commercialUsage: corporation — companies may use it commercially
-    creditNotation: unnecessary — no credit required
-    allowRedistribution: yes
+### Notes for the renderer
 
-  Rig: 54 humanoid bones
-  Expressions: 18 presets
-    emotions: happy, angry, sad, relaxed, surprised, neutral
-    visemes:  aa, ih, ou, ee, oh
-```
-
-Run the same tool on your own model before you go live. It tells you what is
-missing — no `aa` viseme means her mouth cannot move; no emotions means one face
-for every mood.
-
-To make your own: **VRoid Studio** is free, runs on macOS and Windows, and
-exports VRM with all 18 expressions already wired.
-
-### Behaviours
-
-A `.vrma` clip drives humanoid bones **by standard name**, so it carries no mesh,
-no material and no texture — 11 KB for three seconds. That is why a clip library
-can ship with the repo while a model cannot. Drop clips in `clips_dir`; they
-appear by name in the dashboard, and `mood_clips` picks one per mood.
-
-### Two traps worth knowing
-
-Both were found by looking at the thing on screen, and both are handled in
 `src/web/frontend/src/stage/avatar.js`:
 
-- **The 180° turn belongs to VRM 0.x only.** `VRMUtils.rotateVRM0` applies it
-  where it is due. An unconditional `rotation.y = Math.PI` shows you the back of
-  the head of every VRM 1.0 model.
-- **The camera is framed off the `head` bone**, never off hardcoded numbers.
-  That is what makes one `shot` setting frame a 1.4 m model and a 1.8 m one the
-  same way.
+- Turning the model 180° is correct for **VRM 0.x only**. `VRMUtils.rotateVRM0`
+  applies it conditionally; an unconditional `rotation.y = Math.PI` faces every
+  VRM 1.0 model away from the camera.
+- Camera framing reads the `head` and `hips` world positions and solves the
+  distance from the FOV. Hardcoding a position ties the shot to one model's
+  height.
+- The page is a separate Vite entry (`stage.html`). three.js is behind a dynamic
+  import, so it is fetched only when `avatar_backend` is `model`. Importing from
+  `src/stage/` anywhere in the dashboard would pull it into the main bundle.
 
 ---
 
-## `vtube_studio` — your own Live2D model
+## `vtube_studio`
 
-Nothing is bundled and nothing is required. VTube Studio is what most VTubers
-already run; if you have it, projectBEA drives it over its plugin API.
+Drives a VTube Studio instance over its plugin API. Nothing is bundled; the
+model and the software are the user's.
 
 ```json
 "stage": {
@@ -197,50 +189,38 @@ already run; if you have it, projectBEA drives it over its plugin API.
 }
 ```
 
-| Port call | VTube Studio request |
+| Port call | Request |
 |---|---|
-| `show(mood, state)` | `ExpressionActivationRequest` with `vts_expressions[mood]` |
-| `perform(clip)` | `HotkeyTriggerRequest` with `vts_clips[clip]` |
-| `mouth(envelope, fps)` | `InjectParameterDataRequest` on `vts_mouth_param`, one per frame |
+| `show(mood, state)` | `ExpressionActivationRequest`, file from `vts_expressions[mood]` |
+| `perform(clip)` | `HotkeyTriggerRequest`, id from `vts_clips[clip]`, falling back to the name itself |
+| `mouth(envelope, fps)` | `InjectParameterDataRequest` on `vts_mouth_param`, one per frame, `mode: "set"` |
 
-Turn the API on in VTube Studio (**Settings → Start API**). The first time she
-connects it asks you to allow the plugin; say yes, and the token is stored in
-`data/vtube_studio_token.json` — gitignored, and never in `config.json`, which is
-served by an unauthenticated endpoint.
+**Authentication.** `AuthenticationTokenRequest` prompts the user inside VTube
+Studio; the token is written to `data/vtube_studio_token.json` and reused with
+`AuthenticationRequest` on later sessions. A token that stops authenticating is
+deleted so the next attempt asks again instead of failing forever. It is kept
+out of `config.json` because `GET /config` is unauthenticated.
 
-Expressions and hotkeys are named by **whoever rigged your model**, so the
-dashboard reads them from the connected model and offers them as a list rather
-than a text box. Press **Test the connection** to fill it.
+**Threading.** `_run` owns one connection and drains a bounded queue over it,
+reconnecting with backoff from 3s to 30s. When the queue fills, the oldest
+command is dropped — the newest face is the correct one. The mouth runs in its
+own task so a new line cancels the previous one.
 
-Two differences from the other backends, both handled inside the adapter:
+**Two behaviours specific to this backend.** VTube Studio holds an expression
+until told otherwise, so the adapter deactivates the previous one before
+activating the next. And it has no clock shared with the engine, so this is the
+only backend that paces the envelope itself.
 
-- VTube Studio has no clock of ours, so this is the one backend that **paces the
-  mouth itself**, one message per frame.
-- VTS leaves an expression on until told otherwise, so the adapter **turns the
-  previous one off** before activating the next.
-
----
-
-## Lip sync
-
-`envelope()` in `src/core/expression/pcm.py` is the per-frame RMS of the audio
-she is about to say, normalised to `[0, 1]`. Not a phoneme model and not a
-viseme classifier: the shape of the line, which is all a mouth needs.
-
-It is computed on this machine because the audio is played on this machine and
-the page never hears it. Six seconds of speech is **180 frames, about 0.2 ms and
-1.2 KB of JSON** — small enough to send whole, ahead of playback, so the page can
-run it off its own clock instead of waiting for 30 messages a second.
-
-A lip sync failure is logged and swallowed: a mouth that breaks must never stop
-her from speaking.
+**Discovery.** Expression files and hotkey ids are defined by whoever rigged the
+model. `GET /vts/model` returns both from the connected instance so the dashboard
+can offer a list.
 
 ---
 
-## The mood → face table
+## Mood → expression
 
-`src/core/expression/face.py` turns a mood into VRM expression weights, the same
-way `prosody.py` turns it into a way of speaking.
+`src/core/expression/face.py`. `weights_for(mood)` returns a weight for every VRM
+emotion, zeros included, so a face is never left wearing part of the last mood.
 
 | mood | (valence, arousal) | weights |
 |---|---|---|
@@ -252,50 +232,79 @@ way `prosody.py` turns it into a way of speaking.
 | `ew` | (-0.50, 0.15) | `angry 0.45` + `sad 0.35` |
 | `bored` | (-0.30, -0.70) | `relaxed 0.25` + `sad 0.35` |
 
-Bea has seven moods; VRM standardises five emotions. `ew` and `bored` have no
-preset of their own and are blends — the only judgement calls in the file.
+VRM standardises five emotions; `MOODS` has seven. `ew` and `bored` are blends.
 
-`tests/test_face.py` checks every row against the valence/arousal vectors in
-`moods.py`, and it earns its keep: the first draft of `bored` was
-`relaxed 0.7`, and the test rejected it with *"bored feels bad but looks good"*.
-`relaxed` in VRM means *at ease*, so she came out looking pleased to be ignoring
-you. It is the kind of mistake you do not catch by eye and everybody catches on
-stream.
+`tests/test_face.py` asserts that the weights agree with the valence/arousal
+vectors in `moods.py`: a mood below -0.2 valence must weigh `sad`/`angry` above
+`happy`/`relaxed`, and the reverse above +0.2. This catches the easy mistake with
+`relaxed`, which means *at ease* and reads as contentment — weighting `bored`
+toward it produces a face that looks pleased rather than unbothered.
+
+The table is also checked against the sample model, when it is present, so a
+weight cannot name an expression no real VRM has.
+
+---
+
+## Lip sync
+
+`envelope(audio, sample_rate, fps)` in `src/core/expression/pcm.py` returns the
+per-frame RMS of the audio, normalised to `[0, 1]` and rounded to three decimals.
+
+It is computed in `Expression._speak_local` between synthesis and playback, and
+on the call route it is accumulated per sentence as each one is synthesised. It
+runs on this machine because the audio is played here; the page never hears it.
+
+Cost for six seconds at 30 fps: 180 frames, ~0.2 ms, ~1.2 KB of JSON. Small
+enough to send in one message ahead of playback rather than streaming it.
+
+`Expression._move_mouth` catches and logs any failure. A broken mouth must not
+stop her from speaking.
 
 ---
 
 ## The stage channel
 
-`src/core/stage.py` is the fan-out to the browser source. Deliberately **not**
-`EventManager`: that one replays a backlog to every new subscriber, which is
-right for a dashboard reading a log and wrong here — OBS reloads a browser
-source whenever you toggle it, and a replay would have her act out the last
-minute of the stream again.
+`src/core/stage.py`. A fan-out to however many browser sources are open, plus
+the current state.
 
-A page that connects gets **one snapshot** of how she looks now, and patches
-after that. Keys like `envelope` and `perform` describe a moment rather than a
-state and are never stored, so a page that reconnects does not mouth a sentence
-nobody is saying.
+```python
+channel.publish({"mood": "angry", "state": "talking"})   # merged into the state
+channel.publish({"envelope": [...], "envelope_fps": 30}) # sent, not stored
+channel.snapshot()                                       # what a new page receives
+```
 
-| Endpoint | What it is |
+Keys in `TRANSIENT` (`envelope`, `perform`) describe a moment and are fanned out
+without being stored. A page connecting mid-utterance is not made to mouth a
+sentence that has already ended.
+
+There is no backlog. OBS reloads a browser source whenever it is toggled, and a
+subscriber that received a replay would act the last minute out again. A queue
+that fills is dropped rather than awaited.
+
+| Endpoint | Returns |
 |---|---|
-| `GET /stage` | the page to point a Browser Source at |
-| `GET /stage/stream` | SSE: one snapshot, then patches |
-| `GET /stage/config` | what the page needs to draw her — never a secret |
+| `GET /stage` | the page for the Browser Source |
+| `GET /stage/stream` | SSE: one `snapshot`, then `patch` messages |
+| `GET /stage/config` | backends, shot, lip sync rate, caption typography |
 | `GET /stage/model` | the configured `.vrm` |
-| `GET /stage/clips` | the behaviours installed, by name |
-| `GET /stage/clips/{name}` | one `.vrma` |
-| `GET /stage/preview` | one avatar image, for the dashboard preview |
+| `GET /stage/clips` | clip names in `clips_dir` |
+| `GET /stage/clips/{name}` | one `.vrma`; a name that escapes the folder is a 404 |
+| `GET /stage/preview` | one avatar image, restricted to paths in `avatar_map` |
+| `POST /test/vts` · `GET /vts/model` | VTube Studio reachability and model contents |
+
+None of these are authenticated, so none of them return a secret.
 
 ---
 
 ## Adding a backend
 
 1. Implement `AvatarInterface` in `src/modules/avatar/`.
-2. Add a builder to `BUILDERS` in `factory.py`. Put the import **inside** the
-   builder, so choosing another backend never pays for yours.
-3. If it needs somewhere to publish, add its name to `NEEDS_PUBLISHER`.
+2. Add a builder to `BUILDERS` in `factory.py`. Keep the import inside the
+   builder so other backends do not pay for its dependencies.
+3. If it needs a `publisher`, add its name to `NEEDS_PUBLISHER`. Without one the
+   factory falls back to `png` rather than publishing into nothing.
 4. Add it to `AVATARS` in `src/setup/wizard.py`.
 
-`tests/test_avatar_backends.py` walks `BUILDERS` and checks every registered
-backend honours the port, so step 1 cannot be half-done.
+`tests/test_avatar_backends.py` iterates `BUILDERS` and asserts each one builds
+an `AvatarInterface`; `tests/test_setup.py` asserts the wizard never offers a
+name the factory does not have.

--- a/docs/modules/avatar.md
+++ b/docs/modules/avatar.md
@@ -129,7 +129,7 @@ Source**. The backend publishes to the stage channel; the page owns three.js.
 | `clips_dir` | `.vrma` files, listed by `GET /stage/clips` and offered in the dashboard. |
 | `shot` | `bust`, `half` or `full`. Computed from the `head` and `hips` bones, so it frames any model the same way regardless of its height. |
 | `mood_clips` | mood → clip name. A mood without one changes expression only. |
-| `background` | A CSS colour behind her. Empty means transparent. |
+| `background` | A CSS colour behind her. Empty is transparent, which is what OBS composites over your scene. |
 
 ### Why the format matters
 
@@ -281,11 +281,17 @@ There is no backlog. OBS reloads a browser source whenever it is toggled, and a
 subscriber that received a replay would act the last minute out again. A queue
 that fills is dropped rather than awaited.
 
+Saving settings publishes `{"config": public_config(...)}`, so a running page
+picks up a new shot or background without being reloaded by hand. The page
+reloads itself only when the change is structural — a different backend, or a
+different model, which `model_id` (the file name and its mtime) detects. That
+same push is what keeps the preview in the dashboard current.
+
 | Endpoint | Returns |
 |---|---|
 | `GET /stage` | the page for the Browser Source |
 | `GET /stage/stream` | SSE: one `snapshot`, then `patch` messages |
-| `GET /stage/config` | backends, shot, lip sync rate, caption typography |
+| `GET /stage/config` | backends, shot, lip sync rate, caption typography, `model_id` |
 | `GET /stage/model` | the configured `.vrm` |
 | `GET /stage/clips` | clip names in `clips_dir` |
 | `GET /stage/clips/{name}` | one `.vrma`; a name that escapes the folder is a 404 |

--- a/docs/modules/obs.md
+++ b/docs/modules/obs.md
@@ -1,20 +1,26 @@
 # OBS Module
 
-← [Back to README](../../README.md) | [Architecture](../architecture.md)
+← [Back to README](../../README.md) | [Architecture](../architecture.md) | [Avatar →](avatar.md)
 
 ---
 
 ## Overview
 
-The OBS module connects to OBS Studio via WebSocket and controls two types of sources in real time:
+`OBSController` is the WebSocket transport to OBS Studio. It is **not** how Bea
+appears — that is the [avatar port](avatar.md), and OBS is one of the places it
+can draw to. This module owns the connection and the two kinds of source it can
+drive:
 
-1. **Avatar source** — swaps the image/video file to reflect Bea's current mood and speaking state.
-2. **Text source** — animates text with a typewriter effect for the speech bubble overlay.
+1. **Avatar source** — the file swapped by the `png` avatar backend.
+2. **Text source** — the typewriter driven by the `obs` caption backend.
 
 ```
 src/modules/obs/
 └── obs_websocket.py    OBSController implementing OBSInterface
 ```
+
+Choose `stage` for the caption, or `model` / `vtube_studio` for the avatar, and
+nothing here is used at all.
 
 ---
 
@@ -54,6 +60,11 @@ obs.set_media("data/pngs/angry/talking.mp4")
 
 `type_text()` writes a message character-by-character into the OBS text source, paginating if the message exceeds the visible area.
 
+> **One request per character.** A 158-character line costs 159 WebSocket
+> requests and 29.7 KB of JSON, because every one of them re-sends the font
+> block. The `stage` caption backend sends the line **once** and animates it in
+> the browser instead. `tests/test_stage.py` measures both.
+
 **Parameters:**
 
 | Parameter | Description |
@@ -69,7 +80,9 @@ obs.set_media("data/pngs/angry/talking.mp4")
 | `min_page_duration` | Minimum seconds a page stays visible |
 | `speaking_rate` | Characters per second used to estimate reading time per page (default: `12.0`). Controls the post-typing wait so that longer pages stay visible longer. |
 
-Returns the final font size used (stored by the brain to correctly clear the source afterward).
+Returns the final font size used. `ObsTextCaption` keeps it so it can clear the
+source at the size the text was actually typed at — a long line shrinks to fit,
+and clearing at the configured size resizes the box on screen.
 
 The typing task and the playback task run in parallel — both are asyncio tasks,
 and `Expression.interrupt()` cancels them together on barge-in, keeping what was
@@ -83,18 +96,18 @@ OBS text sources have their font settings stored in OBS. The controller reads th
 
 ---
 
-## Avatar Swap Logic
+## Avatar swap logic
 
-`Expression` (`src/core/expression/voice.py`) owns this — it is the single
-output sink, so nothing else touches OBS:
+This lives in `PngAvatar` (`src/modules/avatar/png.py`), behind the avatar port.
+`Expression` asks for a mood and a state and never learns there is a file:
 
-1. `_resolve_paths(mood)` looks up `(idle_path, talking_path)` in `png_map`.
-2. Before speaking: `set_media(talking_path)` (or `set_image`).
-3. After speaking: `set_media(idle_path)`.
+1. `show(mood, "talking")` before speaking.
+2. `show(mood, "idle")` after.
 
-If the mood is unknown it falls back to `"normal"`. `set_mood_avatar()` is also
-used directly for states rather than speech — `sleeping` when she goes to
-sleep, `normal` when she wakes.
+An unknown mood falls back to `"normal"`. A **state** — `sleeping`, `listening` —
+uses its own slot in `avatar_map` when there is one, and otherwise falls back to
+the mood's image with a warning. It used to fall back silently, which is why the
+sleeping avatar was never once seen.
 
 ---
 

--- a/docs/modules/obs.md
+++ b/docs/modules/obs.md
@@ -6,10 +6,8 @@
 
 ## Overview
 
-`OBSController` is the WebSocket transport to OBS Studio. It is **not** how Bea
-appears — that is the [avatar port](avatar.md), and OBS is one of the places it
-can draw to. This module owns the connection and the two kinds of source it can
-drive:
+`OBSController` is the WebSocket transport to OBS Studio: the connection and the
+two kinds of source it can drive.
 
 1. **Avatar source** — the file swapped by the `png` avatar backend.
 2. **Text source** — the typewriter driven by the `obs` caption backend.
@@ -19,8 +17,9 @@ src/modules/obs/
 └── obs_websocket.py    OBSController implementing OBSInterface
 ```
 
-Choose `stage` for the caption, or `model` / `vtube_studio` for the avatar, and
-nothing here is used at all.
+Which of the two are in use depends on the backends in `stage` — see the
+[avatar module](avatar.md). With `model` or `vtube_studio` for the avatar and
+`stage` or `off` for the caption, this module is never called.
 
 ---
 
@@ -60,10 +59,10 @@ obs.set_media("data/pngs/angry/talking.mp4")
 
 `type_text()` writes a message character-by-character into the OBS text source, paginating if the message exceeds the visible area.
 
-> **One request per character.** A 158-character line costs 159 WebSocket
-> requests and 29.7 KB of JSON, because every one of them re-sends the font
-> block. The `stage` caption backend sends the line **once** and animates it in
-> the browser instead. `tests/test_stage.py` measures both.
+Cost: one `SetInputSettings` request per character, each carrying the font block.
+A 158-character line is 159 requests and ~30 KB of JSON. The `stage` caption
+backend sends the line in one message and animates it in the page;
+`tests/test_stage.py` asserts the difference.
 
 **Parameters:**
 
@@ -104,10 +103,10 @@ This lives in `PngAvatar` (`src/modules/avatar/png.py`), behind the avatar port.
 1. `show(mood, "talking")` before speaking.
 2. `show(mood, "idle")` after.
 
-An unknown mood falls back to `"normal"`. A **state** — `sleeping`, `listening` —
-uses its own slot in `avatar_map` when there is one, and otherwise falls back to
-the mood's image with a warning. It used to fall back silently, which is why the
-sleeping avatar was never once seen.
+An unknown mood falls back to `"normal"`. The states `sleeping` and `listening`
+use their own entry in `avatar_map` when there is one, and otherwise fall back to
+the mood's image and log a warning. Full resolution order is in the
+[avatar module](avatar.md).
 
 ---
 

--- a/docs/web/api.md
+++ b/docs/web/api.md
@@ -521,10 +521,64 @@ Filters the event buffer and returns only events in the `skill`, `thought`, and 
 
 ---
 
+### The stage
+
+What the OBS browser source reads, and what the dashboard asks about the avatar.
+None of it is authenticated, so none of it ever carries a secret.
+
+#### `GET /stage`
+The page to point an OBS **Browser Source** at. `404` with "run `make frontend`"
+when the frontend has not been built.
+
+#### `GET /stage/stream`
+Server-sent events for the browser source. **One snapshot first**, then patches:
+
+```
+data: {"type": "snapshot", "mood": "angry", "state": "talking", "caption": "..."}
+data: {"type": "patch", "envelope": [0.02, 0.31, ...], "envelope_fps": 30}
+```
+
+Deliberately no backlog. OBS reloads a browser source whenever it is toggled,
+and replaying what already happened would have her act out the last minute of
+the stream again.
+
+#### `GET /stage/config`
+What the page needs to draw her: the two backends, the shot, the lip sync rate
+and the caption's typography. Never a key, a token or a password.
+
+#### `GET /stage/model`
+The configured `.vrm`. `404` when none is set, or when it is set and missing —
+the message names the path.
+
+#### `GET /stage/clips` · `GET /stage/clips/{name}`
+The behaviours installed, by name, and one `.vrma` each. A name that would walk
+out of the clips folder is a `404`.
+
+#### `GET /stage/preview`
+**Query:** `mood`, `state` (`idle` by default). One avatar image, for the
+preview in the dashboard. Only paths that appear in `avatar_map` are served —
+anything else is a `404`, so the endpoint cannot be used to read the disk.
+
+#### `POST /test/vts`
+Whether she can reach VTube Studio. Returns the standard
+`{ ok, message, detail }`, and reports a refused connection rather than raising.
+
+#### `GET /vts/model`
+The expressions and hotkeys of the model VTube Studio currently has loaded, so
+the dashboard can offer them as a list instead of a text box.
+
+---
+
 ## Frontend Static Serving
 
-When the React frontend is built (`npm run build`), only the `dist/assets/` sub-folder is mounted as a `StaticFiles` route at `/assets`. All other requests — including navigation routes like `/dashboard` and the root `/` — are handled by a catch-all `GET /{full_path}` route that returns `dist/index.html` directly.
+Two entry points are built from `src/web/frontend`: `index.html` (the dashboard)
+and `stage.html` (the OBS browser source). They are separate bundles — the stage
+does not carry React, the router or the dashboard, and three.js is loaded only
+when the 3D backend is chosen.
 
-> **Note:** Files placed in `dist/` outside of `assets/` (e.g. `favicon.ico`, `robots.txt`) are **not** served as static files. Any request for such a file will receive `index.html` instead.
+`dist/assets/` is mounted as a `StaticFiles` route at `/assets`. Everything else
+falls through to a catch-all `GET /{full_path}`, which serves a **real file** if
+one exists under `dist/` (the favicon, `stage.html`) and otherwise returns
+`dist/index.html` so the SPA can route it.
 
 [Frontend Documentation →](frontend.md)

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -15,7 +15,6 @@ from src.core.mind.operating import BUILTIN_OPERATING, missing_tools
 from src.core.mind.spontaneous import SpontaneousPresence
 from src.core.perception.bus import PerceptionBus
 from src.core.persona import Persona, persona_of
-from src.core.resources import load_avatar_resources
 from src.core.skills.base import SkillRegistry
 from src.core.skills.chat import ChatSurface
 from src.core.skills.clock import ClockSkill
@@ -35,6 +34,8 @@ from src.core.social.agenda import AgendaRunner
 from src.core.social.reach import Reach
 from src.core.social.rhythm import RhythmTick
 from src.interfaces.base_interfaces import OBSInterface, STTInterface, TTSInterface
+from src.modules.avatar import build_avatar
+from src.modules.caption import build_caption
 from src.utils.history_manager import HistoryManager
 from src.utils.logger import get_logger
 from src.utils.prompts import compose, load_text
@@ -75,7 +76,11 @@ class AIVtuberBrain:
         self.tts = tts
         self.stt = stt
         self.obs = obs
-        self.png_map = {}
+
+        # how she appears and how her words are shown: two ports, so the engine
+        # never learns whether that is a PNG, a 3D model or VTube Studio
+        self.avatar = build_avatar(config, obs)
+        self.caption = build_caption(config, obs)
         self.soul = ""           # shared persona, prepended to the operating manual
         self.system_prompt = ""  # composed: soul + operating manual
         self.history_manager = HistoryManager()
@@ -83,7 +88,7 @@ class AIVtuberBrain:
         self.event_manager = EventManager()
 
         # single output sink (VOICE actuator + barge-in)
-        self.expression = Expression(config, tts, obs, self.event_manager)
+        self.expression = Expression(config, tts, self.avatar, self.caption, self.event_manager)
 
         # everything Bea remembers, in one transactional file
         self.memory = self._build_memory()
@@ -216,11 +221,6 @@ class AIVtuberBrain:
     def initialize(self):
         """Loads resources and connects to services."""
         logger.info("Initializing Brain...")
-
-        self.png_map = load_avatar_resources(self.config.avatar_map)
-        if not self.png_map:
-            logger.warning("No avatar resources loaded from avatar_map.")
-        self.expression.set_png_map(self.png_map)
 
         self.soul = self.persona.fill(load_text(self.config.soul_path))
         self.system_prompt = compose(self.soul, self._load_operating_rules())
@@ -373,6 +373,7 @@ class AIVtuberBrain:
             self.consciousness.llm = self.llm
         self.tts.reload_config(self.config)
         self.obs.reload_config(self.config)
+        # the ports are reloaded through Expression, which owns them
         self.expression.reload_config(self.config)
         if self.stt:
             self.stt.reload_config(self.config)
@@ -601,5 +602,6 @@ class AIVtuberBrain:
             await self.consciousness.stop()
 
     def shutdown(self):
+        self.avatar.close()
         self.obs.disconnect()
         self.memory.close()

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -35,7 +35,9 @@ from src.core.social.reach import Reach
 from src.core.social.rhythm import RhythmTick
 from src.interfaces.base_interfaces import OBSInterface, STTInterface, TTSInterface
 from src.modules.avatar import build_avatar
+from src.modules.avatar.factory import backend_name as avatar_backend
 from src.modules.caption import build_caption
+from src.modules.caption.factory import backend_name as caption_backend
 from src.utils.history_manager import HistoryManager
 from src.utils.logger import get_logger
 from src.utils.prompts import compose, load_text
@@ -81,6 +83,7 @@ class AIVtuberBrain:
         # never learns whether that is a PNG, a 3D model or VTube Studio
         self.avatar = build_avatar(config, obs)
         self.caption = build_caption(config, obs)
+        self._backends = (avatar_backend(config), caption_backend(config))
         self.soul = ""           # shared persona, prepended to the operating manual
         self.system_prompt = ""  # composed: soul + operating manual
         self.history_manager = HistoryManager()
@@ -373,12 +376,29 @@ class AIVtuberBrain:
             self.consciousness.llm = self.llm
         self.tts.reload_config(self.config)
         self.obs.reload_config(self.config)
-        # the ports are reloaded through Expression, which owns them
-        self.expression.reload_config(self.config)
+        self._reload_stage()
         if self.stt:
             self.stt.reload_config(self.config)
 
         logger.info("Hot Reload Complete")
+
+    def _reload_stage(self) -> None:
+        """Re-points the avatar and caption, rebuilding only what changed.
+
+        Picking a different backend in the dashboard has to take effect without
+        a restart, and rebuilding a port that did not change would drop the
+        state it holds — a loaded model, an authenticated socket.
+        """
+        wanted = (avatar_backend(self.config), caption_backend(self.config))
+        if wanted[0] != self._backends[0]:
+            self.avatar.close()
+            self.avatar = build_avatar(self.config, self.obs)
+        if wanted[1] != self._backends[1]:
+            self.caption = build_caption(self.config, self.obs)
+        if wanted != self._backends:
+            self.expression.set_ports(self.avatar, self.caption)
+            self._backends = wanted
+        self.expression.reload_config(self.config)
 
     def _obs_connect(self):
         if hasattr(self.obs, "source_name"):

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -33,6 +33,7 @@ from src.core.skills.voice.surface import VoiceSurface
 from src.core.social.agenda import AgendaRunner
 from src.core.social.reach import Reach
 from src.core.social.rhythm import RhythmTick
+from src.core.stage import StageChannel
 from src.interfaces.base_interfaces import OBSInterface, STTInterface, TTSInterface
 from src.modules.avatar import build_avatar
 from src.modules.avatar.factory import backend_name as avatar_backend
@@ -79,10 +80,13 @@ class AIVtuberBrain:
         self.stt = stt
         self.obs = obs
 
+        # what the browser source is told, when there is one
+        self.stage = StageChannel()
+
         # how she appears and how her words are shown: two ports, so the engine
         # never learns whether that is a PNG, a 3D model or VTube Studio
-        self.avatar = build_avatar(config, obs)
-        self.caption = build_caption(config, obs)
+        self.avatar = build_avatar(config, obs, self.stage)
+        self.caption = build_caption(config, obs, self.stage)
         self._backends = (avatar_backend(config), caption_backend(config))
         self.soul = ""           # shared persona, prepended to the operating manual
         self.system_prompt = ""  # composed: soul + operating manual
@@ -392,9 +396,9 @@ class AIVtuberBrain:
         wanted = (avatar_backend(self.config), caption_backend(self.config))
         if wanted[0] != self._backends[0]:
             self.avatar.close()
-            self.avatar = build_avatar(self.config, self.obs)
+            self.avatar = build_avatar(self.config, self.obs, self.stage)
         if wanted[1] != self._backends[1]:
-            self.caption = build_caption(self.config, self.obs)
+            self.caption = build_caption(self.config, self.obs, self.stage)
         if wanted != self._backends:
             self.expression.set_ports(self.avatar, self.caption)
             self._backends = wanted
@@ -622,6 +626,7 @@ class AIVtuberBrain:
             await self.consciousness.stop()
 
     def shutdown(self):
+        self.stage.close()
         self.avatar.close()
         self.obs.disconnect()
         self.memory.close()

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -33,7 +33,7 @@ from src.core.skills.voice.surface import VoiceSurface
 from src.core.social.agenda import AgendaRunner
 from src.core.social.reach import Reach
 from src.core.social.rhythm import RhythmTick
-from src.core.stage import StageChannel
+from src.core.stage import StageChannel, public_config
 from src.interfaces.base_interfaces import OBSInterface, STTInterface, TTSInterface
 from src.modules.avatar import build_avatar
 from src.modules.avatar.factory import backend_name as avatar_backend
@@ -403,6 +403,9 @@ class AIVtuberBrain:
             self.expression.set_ports(self.avatar, self.caption)
             self._backends = wanted
         self.expression.reload_config(self.config)
+        # the browser source is told rather than left to be reloaded by hand,
+        # so a shot or a model changed mid-stream takes effect where it shows
+        self.stage.publish({"config": public_config(self.config)})
 
     def _obs_connect(self):
         if hasattr(self.obs, "source_name"):

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -90,10 +90,34 @@ class BrainConfig:
 
 
 
-    # avatar: one slot per mood, derived so a new mood is never avatar-less
+    # avatar: one slot per mood, derived so a new mood is never avatar-less.
+    # Used by the `png` backend; the others have their own maps under `stage`.
     avatar_map: Dict[str, Dict[str, str]] = field(default_factory=default_avatar_map)
 
     png_dir: str = "data/pngs"
+
+    # how she is put on screen. Two independent choices, because "PNG avatar with
+    # the nicer browser caption" and "3D body with the bubble still in OBS" are
+    # both setups people actually want.
+    stage: Dict[str, Any] = field(default_factory=lambda: {
+        "avatar_backend": "png",       # png | model | vtube_studio
+        "caption_backend": "obs",      # obs | stage | off
+        "lipsync_fps": 30,             # how often the mouth is told what to do
+
+        # the `model` backend
+        "model_path": "",              # the .vrm you bring; never shipped with the repo
+        "clips_dir": "data/clips",     # .vrma behaviours, which are portable and are
+        "shot": "bust",                # bust | half | full, framed off the head bone
+        "mood_clips": {},              # mood -> clip name, all optional
+        "background": "",              # a colour behind her, or empty for transparent
+
+        # the `vtube_studio` backend: nothing is bundled, it talks to yours
+        "vts_host": "127.0.0.1",
+        "vts_port": 8001,
+        "vts_expressions": {},         # mood -> expression file in the user's model
+        "vts_clips": {},               # clip name -> hotkey id in the user's model
+        "vts_mouth_param": "MouthOpen",
+    })
 
     # typing animation
     text_line_width: int = 40

--- a/src/core/consciousness.py
+++ b/src/core/consciousness.py
@@ -97,7 +97,7 @@ class Consciousness:
             return
         self.sleeping = True
         try:
-            self.expression.set_mood_avatar("sleeping")
+            self.expression.set_state("sleeping")
         except Exception as e:
             logger.error(f"Failed to set sleeping avatar: {e}")
         self.events.publish(EventCategory.SYSTEM, "consciousness", f"Bea fell asleep ({reason}).")
@@ -109,7 +109,7 @@ class Consciousness:
             return
         self.sleeping = False
         try:
-            self.expression.set_mood_avatar("normal")
+            self.expression.set_state("idle", mood="normal")
         except Exception as e:
             logger.error(f"Failed to restore avatar on wake: {e}")
         self.events.publish(EventCategory.SYSTEM, "consciousness", "Bea woke up.")

--- a/src/core/expression/face.py
+++ b/src/core/expression/face.py
@@ -1,0 +1,49 @@
+"""What a mood looks like on a face that has one.
+
+`prosody.py` turned a mood into a way of speaking. This turns the same mood into
+a set of expression weights, and it exists for the same reason: the mood was
+already chosen, and until now it only ever reached a file name.
+
+VRM 1.0 standardises five emotions — happy, angry, sad, relaxed, surprised —
+plus five visemes and the blinks. Bea has seven moods. Two of them, `ew` and
+`bored`, have no preset of their own and are blends. Those blends are the only
+judgement call in this file, and `tests/test_face.py` checks them against the
+valence/arousal vectors in `moods.py` so they cannot drift apart from how she
+actually feels.
+"""
+
+from typing import Dict
+
+from src.core.mind.moods import MOODS, normalize_mood
+
+# the emotion presets VRM 1.0 declares, and nothing invented on top
+VRM_EMOTIONS = ("happy", "angry", "sad", "relaxed", "surprised", "neutral")
+
+# the mouth shapes; `aa` is the one the lip sync drives
+VRM_VISEMES = ("aa", "ih", "ou", "ee", "oh")
+
+WEIGHTS: Dict[str, Dict[str, float]] = {
+    "normal": {"neutral": 1.0},
+    "shock": {"surprised": 0.9},
+    "love": {"happy": 1.0},
+    "cry": {"sad": 1.0},
+    "angry": {"angry": 1.0},
+    # disgust has no preset: contempt reads as a little anger over unhappiness
+    "ew": {"angry": 0.45, "sad": 0.35},
+    # `relaxed` alone reads as serene, which is the opposite of bored. It needs
+    # the unhappiness under it or she looks pleased to be ignoring you.
+    "bored": {"relaxed": 0.25, "sad": 0.35},
+}
+
+# a mood with no face would silently do nothing on screen
+assert set(WEIGHTS) == set(MOODS), "every mood needs expression weights"
+
+
+def weights_for(mood: str) -> Dict[str, float]:
+    """The expression weights for a mood, normalising whatever the model said.
+
+    Always returns every emotion, zeros included: a face that is handed only the
+    weights that changed keeps whatever it was wearing before.
+    """
+    wanted = WEIGHTS[normalize_mood(mood)]
+    return {name: float(wanted.get(name, 0.0)) for name in VRM_EMOTIONS}

--- a/src/core/expression/face.py
+++ b/src/core/expression/face.py
@@ -1,8 +1,8 @@
 """What a mood looks like on a face that has one.
 
-`prosody.py` turned a mood into a way of speaking. This turns the same mood into
-a set of expression weights, and it exists for the same reason: the mood was
-already chosen, and until now it only ever reached a file name.
+The mood she picks for a line reaches her voice through `prosody.py` and her
+face through here, both reading the same two numbers in `moods.py`. One choice,
+two readers, so how she sounds and how she looks cannot disagree.
 
 VRM 1.0 standardises five emotions — happy, angry, sad, relaxed, surprised —
 plus five visemes and the blinks. Bea has seven moods. Two of them, `ew` and

--- a/src/core/expression/pcm.py
+++ b/src/core/expression/pcm.py
@@ -83,3 +83,37 @@ def split_at_ms(pcm: bytes, played_ms: int) -> Tuple[bytes, bytes]:
     # never split mid-frame: half a sample is a click
     cut -= cut % (CALL_CHANNELS * BYTES_PER_SAMPLE)
     return pcm[:cut], pcm[cut:]
+
+
+# how often the mouth is told what to do. 30 is well under a stream's frame rate
+# and already smoother than a mouth can move.
+ENVELOPE_FPS = 30
+
+
+def envelope(audio: np.ndarray, sample_rate: int, fps: int = ENVELOPE_FPS) -> list:
+    """Per-frame loudness in [0, 1] — the only thing a mouth actually needs.
+
+    Not a phoneme model and not a viseme classifier: the RMS of the audio she is
+    about to say, normalised. It costs a fraction of a millisecond for a whole
+    utterance, and it is computed here rather than in the browser because the
+    audio is played on this machine and the page never hears it.
+    """
+    if audio is None or getattr(audio, "size", 0) == 0:
+        return []
+    mono = to_mono(np.asarray(audio))
+    if mono.dtype == np.int16:
+        mono = mono.astype(np.float32) / 32768.0
+
+    hop = max(1, int(sample_rate) // max(1, int(fps)))
+    frames = mono.size // hop
+    if frames == 0:
+        return []
+
+    blocks = mono[: frames * hop].reshape(frames, hop)
+    rms = np.sqrt(np.mean(np.square(blocks, dtype=np.float64), axis=1))
+    peak = rms.max()
+    if peak <= 0:
+        return [0.0] * frames
+    # rounded because this crosses the wire: three decimals is finer than a
+    # mouth can be seen to move, and halves the payload
+    return [round(float(value), 3) for value in (rms / peak)]

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -70,9 +70,8 @@ class Expression:
     def set_state(self, state: str, mood: Optional[str] = None) -> None:
         """A visible state that is not speech: sleeping, listening, idle.
 
-        A state is not a mood. Passing `"sleeping"` where a mood belonged is
-        exactly why the sleeping avatar was never once seen: it resolved to
-        `normal` without a word of complaint.
+        The state travels beside the mood rather than in place of it, so falling
+        asleep does not also decide what her face is doing.
         """
         if mood is not None:
             self._mood = mood

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -6,7 +6,7 @@ from typing import Optional
 from src.core.config import BrainConfig
 from src.core.events import EventCategory, EventManager
 from src.core.expression.chunking import split_for_speech
-from src.core.expression.pcm import duration_ms, to_call_pcm
+from src.core.expression.pcm import ENVELOPE_FPS, duration_ms, envelope, to_call_pcm
 from src.core.expression.prosody import for_mood
 from src.core.mind.moods import DEFAULT_MOOD
 from src.interfaces.base_interfaces import AvatarInterface, CaptionInterface, TTSInterface
@@ -278,6 +278,9 @@ class Expression:
                 if message:
                     audio_data, fs = await self.tts.generate_audio(
                         message, self._prosody(mood, feeling))
+                    # the mouth is told before playback starts, so the page has
+                    # the whole shape of the line and can run it off its own clock
+                    self._move_mouth(audio_data, fs)
                     self.current_speech_task = asyncio.create_task(
                         self._play_audio(audio_data, fs, self.config.audio_device_id)
                     )
@@ -311,6 +314,9 @@ class Expression:
 
         seq = 0
         spoken_ms = 0
+        # the shape of the whole line, gathered sentence by sentence as it is
+        # synthesised, so the mouth can run once the room starts hearing her
+        frames: list = []
         # read once per turn: the second half of a sentence must not drift into
         # a different mood from the first
         prosody = self._prosody(mood, feeling)
@@ -323,11 +329,12 @@ class Expression:
                     continue
                 await self.call.play(pcm, utterance_id=utterance_id, text=message,
                                      seq=seq, last=False)
+                frames.extend(envelope(audio_data, sample_rate, self._lipsync_fps))
                 spoken_ms += duration_ms(pcm)
                 seq += 1
 
         await self.call.end(utterance_id)
-        asyncio.create_task(self._visual_only(mood, message, spoken_ms / 1000.0))
+        asyncio.create_task(self._visual_only(mood, message, spoken_ms / 1000.0, frames))
         return self.call.utterances.get(utterance_id)
 
     def _call_moved_on(self, utterance_id: str, seq: int) -> bool:
@@ -341,12 +348,28 @@ class Expression:
         current = self.call.current
         return not self.call_is_live or current is None or current.id != utterance_id
 
-    async def _visual_only(self, mood: str, message: str, duration: float):
+    @property
+    def _lipsync_fps(self) -> int:
+        return int((getattr(self.config, "stage", None) or {}).get("lipsync_fps", ENVELOPE_FPS))
+
+    def _move_mouth(self, audio_data, sample_rate: int) -> None:
+        """Hands the avatar the loudness of the line she is about to say."""
+        fps = self._lipsync_fps
+        try:
+            self.avatar.mouth(envelope(audio_data, sample_rate, fps), fps)
+        except Exception as e:
+            # a mouth that fails must never stop her from speaking
+            logger.error(f"Lip sync failed: {e}")
+
+    async def _visual_only(self, mood: str, message: str, duration: float,
+                           frames=None):
         """Drives the visuals for a line the room hears, without playing it here."""
         self.is_speaking = True
         self._mood = mood
         try:
             self.avatar.show(mood, "talking")
+            if frames:
+                self.avatar.mouth(frames, self._lipsync_fps)
 
             typed = asyncio.create_task(self.caption.say(message))
             # a caption backend that shows nothing returns at once, and the

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -1,16 +1,15 @@
 import asyncio
 import time
 import uuid
-from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 from src.core.config import BrainConfig
 from src.core.events import EventCategory, EventManager
 from src.core.expression.chunking import split_for_speech
 from src.core.expression.pcm import duration_ms, to_call_pcm
 from src.core.expression.prosody import for_mood
-from src.core.resources import resolve_mood_paths
-from src.interfaces.base_interfaces import OBSInterface, TTSInterface
+from src.core.mind.moods import DEFAULT_MOOD
+from src.interfaces.base_interfaces import AvatarInterface, CaptionInterface, TTSInterface
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.expression")
@@ -19,14 +18,18 @@ logger = get_logger("bea.expression")
 class Expression:
     """The single output sink for everything Bea expresses.
 
-    Owns the VOICE actuator: TTS generation, local audio playback, OBS avatar/text
-    animation, barge-in/interruption and the resume buffer. Every surface that used
-    to roll its own speech path (chat, discord voice, minecraft thoughts, monologue)
-    routes through here so the rendering logic lives in exactly one place.
+    Owns the VOICE actuator: TTS generation, local audio playback, the avatar and
+    the caption, barge-in/interruption and the resume buffer. Every surface that
+    used to roll its own speech path (chat, discord voice, minecraft thoughts,
+    monologue) routes through here so the rendering logic lives in one place.
+
+    It drives two ports and knows neither of their backends: whether the avatar
+    is a PNG in OBS, a VRM in a browser source or a Live2D model in VTube Studio
+    is a line of config, not a branch in here.
 
     Routes:
     - "local"  -> generate audio and play it on the configured device (stream/OBS).
-    - "call"   -> generate audio, drive only the OBS visuals, and push the samples
+    - "call"   -> generate audio, drive only the visuals, and push the samples
                   into the live voice call through the push channel.
 
     The call is a sink she *owns*, not a reply she hands back: nothing outside
@@ -34,13 +37,17 @@ class Expression:
     and knowing how far a sentence got can live in one place.
     """
 
-    def __init__(self, config: BrainConfig, tts: TTSInterface, obs: OBSInterface, event_manager: EventManager):
+    def __init__(self, config: BrainConfig, tts: TTSInterface, avatar: AvatarInterface,
+                 caption: CaptionInterface, event_manager: EventManager):
         self.config = config
         self.tts = tts
-        self.obs = obs
+        self.avatar = avatar
+        self.caption = caption
         self.event_manager = event_manager
 
-        self.png_map = {}
+        # the last mood she was seen in, so a state change (falling asleep, a
+        # resumed sentence) does not silently reset her face to neutral
+        self._mood = DEFAULT_MOOD
 
         self._is_speaking = False
         self.current_typing_task: Optional[asyncio.Task] = None
@@ -60,15 +67,21 @@ class Expression:
         # the last utterance a barge-in cut short, for the mind to be told about
         self.interrupted = None
 
-    def set_png_map(self, png_map) -> None:
-        self.png_map = png_map
+    def set_state(self, state: str, mood: Optional[str] = None) -> None:
+        """A visible state that is not speech: sleeping, listening, idle.
 
-    def set_mood_avatar(self, mood: str) -> None:
-        """Set a static (idle) avatar for a mood without speaking — e.g. sleeping."""
-        self._set_idle(mood)
+        A state is not a mood. Passing `"sleeping"` where a mood belonged is
+        exactly why the sleeping avatar was never once seen: it resolved to
+        `normal` without a word of complaint.
+        """
+        if mood is not None:
+            self._mood = mood
+        self.avatar.show(self._mood, state)
 
     def reload_config(self, config: BrainConfig) -> None:
         self.config = config
+        self.avatar.reload_config(config)
+        self.caption.reload_config(config)
 
     # --- VOICE actuator -----------------------------------------------------
 
@@ -232,7 +245,7 @@ class Expression:
     async def _speak_local(self, mood: str, message: str, feeling=None):
         """Audio + visual output on the local device (stream/OBS)."""
         self.is_speaking = True
-        font_used = self.config.text_font_size
+        self._mood = mood
         try:
             logger.info(f"Mood: {mood}")
             logger.info(f"Message: {message}")
@@ -245,20 +258,11 @@ class Expression:
                 logger.info("Interrupting previous speech task...")
                 self.current_speech_task.cancel()
 
-            if self.config.obs_text_source:
-                self.obs.set_text("", self.config.obs_text_source)
-
-            idle_path, talking_path = self._resolve_paths(mood)
-
-            if self.config.obs_source_type == "media":
-                self.obs.set_media(talking_path)
-            else:
-                self.obs.set_image(talking_path)
+            self.caption.clear()
+            self.avatar.show(mood, "talking")
 
             async with self.audio_lock:
-                self.current_typing_task = None
-                if self.config.obs_text_source:
-                    self.current_typing_task = asyncio.create_task(self._type(message))
+                self.current_typing_task = asyncio.create_task(self.caption.say(message))
 
                 self.event_manager.publish(
                     EventCategory.OUTPUT, "tts", f"Speaking: {message[:50]}...",
@@ -272,20 +276,13 @@ class Expression:
                         self._play_audio(audio_data, fs, self.config.audio_device_id)
                     )
 
-                    font_used = self.config.text_font_size
                     try:
-                        if self.current_typing_task:
-                            results = await asyncio.gather(self.current_typing_task, self.current_speech_task)
-                            font_used = results[0]
-                        else:
-                            await self.current_speech_task
+                        await asyncio.gather(self.current_typing_task, self.current_speech_task)
                     except asyncio.CancelledError:
                         logger.info("Output tasks cancelled (Interruption).")
 
-            if self.config.obs_text_source:
-                self.obs.set_text("", self.config.obs_text_source, font_size=font_used)
-
-            self._set_idle(mood)
+            self.caption.clear()
+            self.avatar.show(mood, "idle")
         finally:
             self.is_speaking = False
 
@@ -339,57 +336,21 @@ class Expression:
         return not self.call_is_live or current is None or current.id != utterance_id
 
     async def _visual_only(self, mood: str, message: str, duration: float):
-        """Updates OBS visuals/text without playing local audio."""
+        """Drives the visuals for a line the room hears, without playing it here."""
         self.is_speaking = True
+        self._mood = mood
         try:
-            _, talking_path = self._resolve_paths(mood)
-            if self.config.obs_source_type == "media":
-                self.obs.set_media(talking_path)
-            else:
-                self.obs.set_image(talking_path)
+            self.avatar.show(mood, "talking")
 
-            if self.config.obs_text_source:
-                await self._type(message)
-            else:
-                await asyncio.sleep(duration)
+            typed = asyncio.create_task(self.caption.say(message))
+            # a caption backend that shows nothing returns at once, and the
+            # visuals would snap back before the room finished hearing her
+            await asyncio.gather(typed, asyncio.sleep(duration))
 
-            self._set_idle(mood)
-            if self.config.obs_text_source:
-                self.obs.set_text("", self.config.obs_text_source)
+            self.avatar.show(mood, "idle")
+            self.caption.clear()
         finally:
             self.is_speaking = False
-
-    async def _type(self, message: str) -> int:
-        return await self.obs.type_text(
-            text=message,
-            source_name=self.config.obs_text_source,
-            line_width=self.config.text_line_width,
-            max_lines=self.config.text_lines,
-            base_font_size=self.config.text_font_size,
-            min_font_size=self.config.text_min_font_size,
-            font_step=self.config.text_font_step,
-            typing_delay=self.config.typing_delay,
-            min_page_duration=self.config.text_min_duration,
-        )
-
-    def _resolve_paths(self, mood: str) -> Tuple[Path, Path]:
-        try:
-            return resolve_mood_paths(self.png_map, mood)
-        except KeyError:
-            logger.warning(f"Could not resolve mood {mood}, falling back to 'normal'.")
-            if "normal" in self.png_map:
-                return self.png_map["normal"]
-            return Path("placeholder.png"), Path("placeholder.png")
-
-    def _set_idle(self, mood: str):
-        try:
-            idle_path, _ = self._resolve_paths(mood)
-        except Exception:
-            idle_path = self.png_map.get("normal", (Path("placeholder.png"),))[0]
-        if self.config.obs_source_type == "media":
-            self.obs.set_media(idle_path)
-        else:
-            self.obs.set_image(idle_path)
 
     # --- barge-in / resume --------------------------------------------------
 
@@ -434,8 +395,8 @@ class Expression:
         if self.current_typing_task and not self.current_typing_task.done():
             self.current_typing_task.cancel()
 
-        if self.config.obs_text_source:
-            self.obs.set_text("", self.config.obs_text_source)
+        self.caption.clear()
+        self.avatar.show(self._mood, "idle")
 
         self.is_speaking = False
         return "Interrupted"
@@ -450,12 +411,9 @@ class Expression:
         self.is_speaking = True
         try:
             async with self.audio_lock:
-                if "normal" in self.png_map:
-                    _, talking_path = self.png_map["normal"]
-                    if self.config.obs_source_type == "media":
-                        self.obs.set_media(talking_path)
-                    else:
-                        self.obs.set_image(talking_path)
+                # the mood she was cut off in, not `normal`: finishing an angry
+                # sentence with a neutral face is worse than not finishing it
+                self.avatar.show(self._mood, "talking")
 
                 self.current_speech_task = asyncio.create_task(
                     self._play_audio(self.resume_buffer, self.playback_sample_rate, self.config.audio_device_id)
@@ -468,9 +426,4 @@ class Expression:
                 self.resume_buffer = None
         finally:
             self.is_speaking = False
-            if "normal" in self.png_map:
-                idle_path, _ = self.png_map["normal"]
-                if self.config.obs_source_type == "media":
-                    self.obs.set_media(idle_path)
-                else:
-                    self.obs.set_image(idle_path)
+            self.avatar.show(self._mood, "idle")

--- a/src/core/expression/voice.py
+++ b/src/core/expression/voice.py
@@ -78,6 +78,12 @@ class Expression:
             self._mood = mood
         self.avatar.show(self._mood, state)
 
+    def set_ports(self, avatar: AvatarInterface, caption: CaptionInterface) -> None:
+        """Swaps the backends under her, mid-run, without dropping the mood."""
+        self.avatar = avatar
+        self.caption = caption
+        self.avatar.show(self._mood, "idle")
+
     def reload_config(self, config: BrainConfig) -> None:
         self.config = config
         self.avatar.reload_config(config)

--- a/src/core/resources.py
+++ b/src/core/resources.py
@@ -5,8 +5,6 @@ from src.utils.logger import get_logger
 
 logger = get_logger("bea.resources")
 
-ALIASES = {"thankingA1": "thanking—"}
-
 def load_avatar_resources(avatar_map: Dict[str, Dict[str, str]]) -> Dict[str, Tuple[Path, Path]]:
     """
     Carica e valida le risorse avatar dalla mappa di configurazione.
@@ -36,23 +34,18 @@ def load_avatar_resources(avatar_map: Dict[str, Dict[str, str]]) -> Dict[str, Tu
     return processed_map
 
 def resolve_mood_paths(png_map: Dict[str, Tuple[Path, Path]], mood: str) -> Tuple[Path, Path]:
-    """Trova i PNG per il mood, applicando alias e fallback a normal."""
+    """Trova i PNG per il mood, con fallback a normal."""
     # 1. exact match
     if mood in png_map:
         return png_map[mood]
 
-    # 2. aliases
-    alias = ALIASES.get(mood)
-    if alias and alias in png_map:
-        return png_map[alias]
-
-    # 3. fallback normal
+    # 2. fallback normal
     if "normal" in png_map:
         return png_map["normal"]
 
-    # 4. fallback any
+    # 3. fallback any
     if png_map:
         return next(iter(png_map.values()))
 
-    # 5. last resort
+    # 4. last resort
     return (Path("placeholder_idle.png"), Path("placeholder_talking.png"))

--- a/src/core/stage.py
+++ b/src/core/stage.py
@@ -1,0 +1,74 @@
+"""What the browser source is told, and the last thing it was told.
+
+Deliberately not `EventManager`. That one replays a backlog to every new
+subscriber, which is right for a dashboard reading a log and wrong for a stage:
+OBS reloads a browser source whenever you toggle it, and replaying fifty events
+would make her act out the last minute of the stream again. Here a fresh
+connection gets one snapshot of how she looks *now*, and patches after that.
+"""
+
+import asyncio
+import contextlib
+from typing import Any, Dict, List
+
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.stage")
+
+# how many patches a stalled page may buffer before it is dropped
+QUEUE_LIMIT = 200
+
+# things that describe a moment rather than a state. Storing the envelope would
+# make a page that reconnects mouth a sentence nobody is saying any more.
+TRANSIENT = frozenset({"envelope", "perform"})
+
+
+class StageChannel:
+    """One-way fan-out from the engine to however many browser sources exist."""
+
+    def __init__(self) -> None:
+        self._subscribers: List["asyncio.Queue[Dict[str, Any]]"] = []
+        self._state: Dict[str, Any] = {"mood": "normal", "state": "idle", "caption": ""}
+
+    # --- writing ------------------------------------------------------------
+
+    def publish(self, patch: Dict[str, Any]) -> None:
+        """Merges the durable keys into the state and fans the patch out."""
+        for key, value in patch.items():
+            if key not in TRANSIENT:
+                self._state[key] = value
+        self._fanout(patch)
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Everything a page needs to draw her correctly the instant it loads."""
+        return dict(self._state)
+
+    # --- reading ------------------------------------------------------------
+
+    def subscribe(self) -> "asyncio.Queue[Dict[str, Any]]":
+        queue: "asyncio.Queue[Dict[str, Any]]" = asyncio.Queue(maxsize=QUEUE_LIMIT)
+        self._subscribers.append(queue)
+        return queue
+
+    def unsubscribe(self, queue) -> None:
+        if queue in self._subscribers:
+            self._subscribers.remove(queue)
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    def _fanout(self, payload: Dict[str, Any]) -> None:
+        for queue in list(self._subscribers):
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                # a page that stopped reading must not slow down the engine
+                logger.debug("Dropping a stalled stage subscriber.")
+                self.unsubscribe(queue)
+
+    def close(self) -> None:
+        for queue in list(self._subscribers):
+            self.unsubscribe(queue)
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait({"closed": True})

--- a/src/core/stage.py
+++ b/src/core/stage.py
@@ -9,6 +9,7 @@ connection gets one snapshot of how she looks *now*, and patches after that.
 
 import asyncio
 import contextlib
+from pathlib import Path
 from typing import Any, Dict, List
 
 from src.utils.logger import get_logger
@@ -21,6 +22,38 @@ QUEUE_LIMIT = 200
 # things that describe a moment rather than a state. Storing the envelope would
 # make a page that reconnects mouth a sentence nobody is saying any more.
 TRANSIENT = frozenset({"envelope", "perform"})
+
+
+def _model_id(raw: str) -> str:
+    """Changes whenever the model does, without telling the page a path."""
+    if not raw:
+        return ""
+    path = Path(raw)
+    try:
+        return f"{path.name}:{int(path.stat().st_mtime)}"
+    except OSError:
+        return path.name
+
+
+def public_config(config) -> Dict[str, Any]:
+    """What the browser source needs to draw her, and nothing else.
+
+    Read by a page running inside OBS, so it carries no key, token or password.
+    """
+    stage = dict(getattr(config, "stage", None) or {})
+    return {
+        "avatar_backend": stage.get("avatar_backend", "png"),
+        "caption_backend": stage.get("caption_backend", "obs"),
+        "shot": stage.get("shot", "bust"),
+        "background": stage.get("background", ""),
+        "lipsync_fps": stage.get("lipsync_fps", 30),
+        "has_model": bool(stage.get("model_path")),
+        "model_id": _model_id(stage.get("model_path") or ""),
+        "typing_delay": config.typing_delay,
+        "text_line_width": config.text_line_width,
+        "text_lines": config.text_lines,
+        "text_font_size": config.text_font_size,
+    }
 
 
 class StageChannel:

--- a/src/interfaces/base_interfaces.py
+++ b/src/interfaces/base_interfaces.py
@@ -117,12 +117,10 @@ class OBSInterface(ABC):
 class AvatarInterface(ABC):
     """How Bea looks. Knows nothing about files, OBS or three.js.
 
-    `OBSInterface` above conflated two jobs — the avatar and the speech bubble —
-    and both of them spoke in file paths. A body has no file per mood, so the
-    engine hands down what she *is* (a mood, a state) and each backend decides
-    what that means: a PNG swap, a blend of VRM expressions, a VTube Studio
-    hotkey. Every method is synchronous; a backend that needs the network
-    queues the work rather than making the whole engine wait on it.
+    The engine hands down what she *is* — a mood and a state — and each backend
+    decides what that means: a PNG swap, a blend of VRM expressions, a VTube
+    Studio hotkey. Every method is synchronous, so a backend that needs the
+    network queues the work instead of holding up the turn she is speaking in.
     """
 
     @abstractmethod

--- a/src/interfaces/base_interfaces.py
+++ b/src/interfaces/base_interfaces.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, AsyncIterator, Dict, Optional, Tuple, Union
+from typing import Any, AsyncIterator, Dict, Optional, Sequence, Tuple, Union
 
 
 class LLMInterface(ABC):
@@ -113,6 +113,76 @@ class OBSInterface(ABC):
         Sets text immediately without animation.
         """
         pass
+
+class AvatarInterface(ABC):
+    """How Bea looks. Knows nothing about files, OBS or three.js.
+
+    `OBSInterface` above conflated two jobs — the avatar and the speech bubble —
+    and both of them spoke in file paths. A body has no file per mood, so the
+    engine hands down what she *is* (a mood, a state) and each backend decides
+    what that means: a PNG swap, a blend of VRM expressions, a VTube Studio
+    hotkey. Every method is synchronous; a backend that needs the network
+    queues the work rather than making the whole engine wait on it.
+    """
+
+    @abstractmethod
+    def show(self, mood: str, state: str) -> None:
+        """Her mood, and what she is doing: idle, talking, listening, sleeping."""
+        pass
+
+    @abstractmethod
+    def perform(self, clip: str) -> None:
+        """Play a named behaviour. A backend without behaviours ignores it."""
+        pass
+
+    @abstractmethod
+    def mouth(self, envelope: Sequence[float], fps: int) -> None:
+        """Per-frame loudness of the line about to be heard, in [0, 1].
+
+        Deliberately the whole utterance at once rather than a value per frame:
+        a page can replay it against its own clock, and a backend that needs a
+        stream (VTube Studio wants one message per frame) can pace it itself.
+        A backend with no mouth ignores it.
+        """
+        pass
+
+    @abstractmethod
+    def reload_config(self, config) -> None:
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release whatever the backend holds.
+
+        Abstract rather than a no-op default: a backend that opens a socket and
+        forgets to close it leaks a task for the life of the process, and every
+        backend saying out loud whether it holds anything is cheaper than
+        finding that out on a stream.
+        """
+        pass
+
+
+class CaptionInterface(ABC):
+    """The words on screen while she talks, if the setup shows them at all."""
+
+    @abstractmethod
+    async def say(self, text: str) -> None:
+        """Put a line on screen, with whatever animation the backend has.
+
+        Awaitable because the OBS backend animates over time and barge-in
+        cancels the task mid-sentence.
+        """
+        pass
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Take the words away. Safe to call when there are none."""
+        pass
+
+    @abstractmethod
+    def reload_config(self, config) -> None:
+        pass
+
 
 class STTInterface(ABC):
     @abstractmethod

--- a/src/modules/avatar/__init__.py
+++ b/src/modules/avatar/__init__.py
@@ -1,0 +1,3 @@
+from src.modules.avatar.factory import build_avatar
+
+__all__ = ["build_avatar"]

--- a/src/modules/avatar/factory.py
+++ b/src/modules/avatar/factory.py
@@ -1,0 +1,20 @@
+"""The one place that knows how to build an avatar backend.
+
+Same shape as `llm/factory.py`: the engine asks for a backend by name and never
+imports a concrete one, so adding a way for Bea to have a body is a branch here
+and nothing else.
+"""
+
+from src.interfaces.base_interfaces import AvatarInterface, OBSInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.avatar.factory")
+
+DEFAULT_BACKEND = "png"
+
+
+def build_avatar(config, obs: OBSInterface) -> AvatarInterface:
+    """The avatar described by `stage.avatar_backend`."""
+    from src.modules.avatar.png import PngAvatar
+
+    return PngAvatar(config, obs)

--- a/src/modules/avatar/factory.py
+++ b/src/modules/avatar/factory.py
@@ -20,11 +20,20 @@ def _png(config, obs, publisher):
     return PngAvatar(config, obs)
 
 
+def _model(config, obs, publisher):
+    from src.modules.avatar.model3d import Model3DAvatar
+    return Model3DAvatar(config, publisher)
+
+
 # name -> builder. Imports live inside the builders so that choosing the PNG
 # backend never pays for the ones it is not using.
 BUILDERS: Dict[str, Callable[..., AvatarInterface]] = {
     "png": _png,
+    "model": _model,
 }
+
+# backends that cannot work without somewhere to publish to
+NEEDS_PUBLISHER = frozenset({"model"})
 
 
 def backend_name(config) -> str:
@@ -47,6 +56,9 @@ def build_avatar(config, obs: OBSInterface, publisher=None) -> AvatarInterface:
     do not need one ignore it.
     """
     name = backend_name(config)
+    if name in NEEDS_PUBLISHER and publisher is None:
+        logger.warning(f"The {name!r} avatar needs a stage channel; using {DEFAULT_BACKEND!r}.")
+        name = DEFAULT_BACKEND
     avatar = BUILDERS[name](config, obs, publisher)
     logger.info(f"Avatar backend: {name}")
     return avatar

--- a/src/modules/avatar/factory.py
+++ b/src/modules/avatar/factory.py
@@ -25,11 +25,17 @@ def _model(config, obs, publisher):
     return Model3DAvatar(config, publisher)
 
 
+def _vtube_studio(config, obs, publisher):
+    from src.modules.avatar.vtube_studio import VTubeStudioAvatar
+    return VTubeStudioAvatar(config)
+
+
 # name -> builder. Imports live inside the builders so that choosing the PNG
 # backend never pays for the ones it is not using.
 BUILDERS: Dict[str, Callable[..., AvatarInterface]] = {
     "png": _png,
     "model": _model,
+    "vtube_studio": _vtube_studio,
 }
 
 # backends that cannot work without somewhere to publish to

--- a/src/modules/avatar/factory.py
+++ b/src/modules/avatar/factory.py
@@ -1,9 +1,11 @@
 """The one place that knows how to build an avatar backend.
 
 Same shape as `llm/factory.py`: the engine asks for a backend by name and never
-imports a concrete one, so adding a way for Bea to have a body is a branch here
-and nothing else.
+imports a concrete one, so giving Bea a new kind of body is a branch here and
+nothing else.
 """
+
+from typing import Callable, Dict
 
 from src.interfaces.base_interfaces import AvatarInterface, OBSInterface
 from src.utils.logger import get_logger
@@ -13,8 +15,38 @@ logger = get_logger("bea.avatar.factory")
 DEFAULT_BACKEND = "png"
 
 
-def build_avatar(config, obs: OBSInterface) -> AvatarInterface:
-    """The avatar described by `stage.avatar_backend`."""
+def _png(config, obs, publisher):
     from src.modules.avatar.png import PngAvatar
-
     return PngAvatar(config, obs)
+
+
+# name -> builder. Imports live inside the builders so that choosing the PNG
+# backend never pays for the ones it is not using.
+BUILDERS: Dict[str, Callable[..., AvatarInterface]] = {
+    "png": _png,
+}
+
+
+def backend_name(config) -> str:
+    """The configured backend, or the default when it is not one we have."""
+    name = (getattr(config, "stage", None) or {}).get("avatar_backend", DEFAULT_BACKEND)
+    if name in BUILDERS:
+        return name
+    # a typo in config.json must not leave her invisible for a whole stream
+    logger.warning(
+        f"Unknown avatar backend {name!r}; falling back to {DEFAULT_BACKEND!r}. "
+        f"Valid: {', '.join(sorted(BUILDERS))}."
+    )
+    return DEFAULT_BACKEND
+
+
+def build_avatar(config, obs: OBSInterface, publisher=None) -> AvatarInterface:
+    """The avatar described by `stage.avatar_backend`.
+
+    `publisher` is how a backend reaches the browser source; the backends that
+    do not need one ignore it.
+    """
+    name = backend_name(config)
+    avatar = BUILDERS[name](config, obs, publisher)
+    logger.info(f"Avatar backend: {name}")
+    return avatar

--- a/src/modules/avatar/model3d.py
+++ b/src/modules/avatar/model3d.py
@@ -1,0 +1,72 @@
+"""A 3D body, drawn by the browser source and driven from here.
+
+Nothing in this file knows about three.js. It turns a mood into expression
+weights and a behaviour name, and publishes them; the page owns the rendering.
+That split is deliberate — it is what lets the renderer be replaced without the
+engine noticing, and what keeps this testable without a browser.
+"""
+
+from typing import Sequence
+
+from src.core.expression.face import weights_for
+from src.core.expression.pcm import ENVELOPE_FPS
+from src.core.stage import StageChannel
+from src.interfaces.base_interfaces import AvatarInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.avatar.model")
+
+
+class Model3DAvatar(AvatarInterface):
+    """Publishes what she is; the browser source turns it into pixels."""
+
+    def __init__(self, config, channel: StageChannel):
+        self.config = config
+        self.channel = channel
+        self._warned_missing = False
+        self._check_model()
+
+    @property
+    def _stage(self) -> dict:
+        return getattr(self.config, "stage", None) or {}
+
+    def _check_model(self) -> None:
+        if not self._stage.get("model_path") and not self._warned_missing:
+            self._warned_missing = True
+            logger.warning(
+                "The 3D avatar has no model_path. No model ships with projectBEA: "
+                "run `make model` for the free sample, or point it at your own .vrm."
+            )
+
+    def reload_config(self, config) -> None:
+        self.config = config
+        self._warned_missing = False
+        self._check_model()
+
+    # --- the port -----------------------------------------------------------
+
+    def show(self, mood: str, state: str) -> None:
+        patch = {
+            "mood": mood,
+            "state": state,
+            # the weights, not the mood name: the vocabulary of moods stays in
+            # Python where it is tested, and the page only lerps toward numbers
+            "expressions": weights_for(mood),
+        }
+        clip = (self._stage.get("mood_clips") or {}).get(mood)
+        if clip and state == "talking":
+            patch["perform"] = clip
+        self.channel.publish(patch)
+
+    def perform(self, clip: str) -> None:
+        if not clip:
+            return
+        self.channel.publish({"perform": clip})
+
+    def mouth(self, envelope: Sequence[float], fps: int = ENVELOPE_FPS) -> None:
+        if not len(envelope):
+            return
+        self.channel.publish({"envelope": list(envelope), "envelope_fps": int(fps)})
+
+    def close(self) -> None:
+        """The channel outlives the backend; the brain closes it."""

--- a/src/modules/avatar/png.py
+++ b/src/modules/avatar/png.py
@@ -1,0 +1,88 @@
+"""The avatar she has always had: one image per mood, swapped over OBS.
+
+This is not new code. It is `Expression._resolve_paths` and `_set_idle` moved
+behind `AvatarInterface`, so that the six copies of
+`if obs_source_type == "media"` that were scattered through the speech path can
+live in one method.
+"""
+
+from pathlib import Path
+from typing import Dict, Sequence, Tuple
+
+from src.core.resources import load_avatar_resources, resolve_mood_paths
+from src.interfaces.base_interfaces import AvatarInterface, OBSInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.avatar.png")
+
+# states that are not speech and deserve a picture of their own if one exists
+_STATE_SLOTS = ("sleeping", "listening")
+
+
+class PngAvatar(AvatarInterface):
+    """One idle image and one talking image per mood, swapped in an OBS source."""
+
+    def __init__(self, config, obs: OBSInterface):
+        self.obs = obs
+        self.config = config
+        self.png_map: Dict[str, Tuple[Path, Path]] = {}
+        self._warned: set = set()
+        self._load()
+
+    def _load(self) -> None:
+        self.png_map = load_avatar_resources(self.config.avatar_map)
+        if not self.png_map:
+            logger.warning("No avatar resources loaded from avatar_map.")
+
+    def reload_config(self, config) -> None:
+        self.config = config
+        self._load()
+
+    # --- the port -----------------------------------------------------------
+
+    def show(self, mood: str, state: str) -> None:
+        # a state is not a mood: `sleeping` used to be passed where a mood was
+        # expected and resolved silently to `normal`, so the sleeping avatar was
+        # never once seen. It gets its own slot, and says so when it has none.
+        if state in _STATE_SLOTS:
+            slot = self.png_map.get(state)
+            if slot:
+                self._swap(slot[0])
+                return
+            self._warn_once(state)
+
+        idle, talking = self._paths(mood)
+        self._swap(talking if state == "talking" else idle)
+
+    def perform(self, clip: str) -> None:
+        """A still image has no behaviours."""
+
+    def mouth(self, envelope: Sequence[float], fps: int) -> None:
+        """A still image has no mouth: the talking frame already stands in for it."""
+
+    def close(self) -> None:
+        """Holds nothing of its own; the OBS client belongs to the brain."""
+
+    # --- internals ----------------------------------------------------------
+
+    def _paths(self, mood: str) -> Tuple[Path, Path]:
+        try:
+            return resolve_mood_paths(self.png_map, mood)
+        except KeyError:
+            logger.warning(f"Could not resolve mood {mood}, falling back to 'normal'.")
+            return self.png_map.get("normal", (Path("placeholder.png"), Path("placeholder.png")))
+
+    def _swap(self, path: Path) -> None:
+        if self.config.obs_source_type == "media":
+            self.obs.set_media(path)
+        else:
+            self.obs.set_image(path)
+
+    def _warn_once(self, state: str) -> None:
+        if state in self._warned:
+            return
+        self._warned.add(state)
+        logger.warning(
+            f"No avatar image for the '{state}' state; showing the mood image instead. "
+            f"Add a '{state}' entry to avatar_map to give it its own picture."
+        )

--- a/src/modules/avatar/png.py
+++ b/src/modules/avatar/png.py
@@ -1,9 +1,7 @@
-"""The avatar she has always had: one image per mood, swapped over OBS.
+"""One image per mood, swapped in an OBS source.
 
-This is not new code. It is `Expression._resolve_paths` and `_set_idle` moved
-behind `AvatarInterface`, so that the six copies of
-`if obs_source_type == "media"` that were scattered through the speech path can
-live in one method.
+The only place that knows whether the scene holds an image source or a media
+source, so nothing above the port has to ask.
 """
 
 from pathlib import Path
@@ -41,9 +39,7 @@ class PngAvatar(AvatarInterface):
     # --- the port -----------------------------------------------------------
 
     def show(self, mood: str, state: str) -> None:
-        # a state is not a mood: `sleeping` used to be passed where a mood was
-        # expected and resolved silently to `normal`, so the sleeping avatar was
-        # never once seen. It gets its own slot, and says so when it has none.
+        # a state gets a slot of its own rather than resolving to a mood's image
         if state in _STATE_SLOTS:
             slot = self.png_map.get(state)
             if slot:

--- a/src/modules/avatar/vtube_studio.py
+++ b/src/modules/avatar/vtube_studio.py
@@ -1,0 +1,356 @@
+"""Her body in VTube Studio: a Live2D model that is yours, not ours.
+
+Nothing is bundled and nothing is required. VTube Studio is the software most
+VTubers already run — Neuro-sama included — and its plugin API is a WebSocket,
+so projectBEA can drive a model it never has to ship, licence or render.
+
+The whole port is synchronous, and this backend talks over a socket, so every
+call drops a message on a queue that one background task drains. Nothing the
+engine does while she is speaking can be made to wait on VTube Studio.
+
+Protocol: https://github.com/DenchiSoft/VTubeStudio
+"""
+
+import asyncio
+import contextlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from src.core.expression.pcm import ENVELOPE_FPS
+from src.interfaces.base_interfaces import AvatarInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.avatar.vts")
+
+API_NAME = "VTubeStudioPublicAPI"
+API_VERSION = "1.0"
+
+PLUGIN_NAME = "projectBEA"
+PLUGIN_DEVELOPER = "projectBEA"
+
+# where the token VTube Studio issues is kept. Not in config.json: it is a
+# credential, and config.json is read by an unauthenticated endpoint.
+TOKEN_FILE = Path("data/vtube_studio_token.json")
+
+# how long to wait before trying the socket again, and the ceiling on that wait
+RETRY_SECONDS = 3.0
+RETRY_CEILING = 30.0
+
+
+class VTubeStudioError(Exception):
+    pass
+
+
+def _envelope_message(param: str, value: float) -> Dict[str, Any]:
+    return {
+        "faceFound": False,
+        # "set" rather than "add": the mouth is hers alone while she talks
+        "mode": "set",
+        "parameterValues": [{"id": param, "value": round(float(value), 3)}],
+    }
+
+
+class VTubeStudioClient:
+    """One authenticated connection, and the requests projectBEA makes on it."""
+
+    def __init__(self, host: str, port: int, token_file: Path = TOKEN_FILE):
+        self.host = host
+        self.port = port
+        self.token_file = token_file
+        self._socket = None
+
+    @property
+    def url(self) -> str:
+        return f"ws://{self.host}:{self.port}"
+
+    @property
+    def connected(self) -> bool:
+        return self._socket is not None
+
+    # --- the wire -----------------------------------------------------------
+
+    async def _send(self, message_type: str, data: Optional[Dict] = None) -> Dict[str, Any]:
+        if self._socket is None:
+            raise VTubeStudioError("not connected")
+        payload = {
+            "apiName": API_NAME,
+            "apiVersion": API_VERSION,
+            "requestID": uuid.uuid4().hex,
+            "messageType": message_type,
+        }
+        if data is not None:
+            payload["data"] = data
+
+        await self._socket.send(json.dumps(payload))
+        answer = json.loads(await self._socket.recv())
+        if answer.get("messageType") == "APIError":
+            detail = answer.get("data", {})
+            raise VTubeStudioError(f"{detail.get('errorID')}: {detail.get('message')}")
+        return answer.get("data", {})
+
+    def _stored_token(self) -> Optional[str]:
+        try:
+            return json.loads(self.token_file.read_text()).get("token")
+        except (OSError, ValueError):
+            return None
+
+    def _store_token(self, token: str) -> None:
+        try:
+            self.token_file.parent.mkdir(parents=True, exist_ok=True)
+            self.token_file.write_text(json.dumps({"token": token}, indent=2))
+        except OSError as e:
+            # not fatal: she will just have to be allowed again next time
+            logger.warning(f"Could not save the VTube Studio token: {e}")
+
+    async def connect(self) -> None:
+        """Opens the socket and authenticates, asking to be allowed if needed."""
+        import websockets
+
+        self._socket = await websockets.connect(self.url, open_timeout=5, ping_interval=20)
+
+        token = self._stored_token()
+        if not token:
+            logger.info("Asking VTube Studio for permission — say yes in its window.")
+            data = await self._send("AuthenticationTokenRequest", {
+                "pluginName": PLUGIN_NAME,
+                "pluginDeveloper": PLUGIN_DEVELOPER,
+            })
+            token = data.get("authenticationToken")
+            if not token:
+                raise VTubeStudioError("VTube Studio refused the plugin")
+            self._store_token(token)
+
+        data = await self._send("AuthenticationRequest", {
+            "pluginName": PLUGIN_NAME,
+            "pluginDeveloper": PLUGIN_DEVELOPER,
+            "authenticationToken": token,
+        })
+        if not data.get("authenticated"):
+            # a token that no longer works is worse than none: drop it and the
+            # next attempt asks for permission again instead of failing forever
+            with contextlib.suppress(OSError):
+                self.token_file.unlink(missing_ok=True)
+            raise VTubeStudioError(data.get("reason") or "authentication refused")
+
+        logger.info(f"Connected to VTube Studio at {self.url}")
+
+    async def close(self) -> None:
+        if self._socket is not None:
+            with contextlib.suppress(Exception):
+                await self._socket.close()
+            self._socket = None
+
+    # --- what projectBEA asks of it -----------------------------------------
+
+    async def current_model(self) -> Dict[str, Any]:
+        return await self._send("CurrentModelRequest")
+
+    async def expressions(self) -> List[Dict[str, Any]]:
+        data = await self._send("ExpressionStateRequest", {"details": False})
+        return data.get("expressions", [])
+
+    async def hotkeys(self) -> List[Dict[str, Any]]:
+        data = await self._send("HotkeysInCurrentModelRequest", {"modelID": ""})
+        return data.get("availableHotkeys", [])
+
+    async def set_expression(self, expression_file: str, active: bool,
+                             fade: float = 0.25) -> None:
+        await self._send("ExpressionActivationRequest", {
+            "expressionFile": expression_file,
+            "fadeTime": fade,
+            "active": active,
+        })
+
+    async def trigger(self, hotkey_id: str) -> None:
+        await self._send("HotkeyTriggerRequest", {"hotkeyID": hotkey_id})
+
+    async def set_parameter(self, param: str, value: float) -> None:
+        await self._send("InjectParameterDataRequest", _envelope_message(param, value))
+
+
+class VTubeStudioAvatar(AvatarInterface):
+    """The port, backed by a queue and one background task."""
+
+    def __init__(self, config, token_file: Path = TOKEN_FILE):
+        self.config = config
+        self.token_file = token_file
+        self._commands: asyncio.Queue = asyncio.Queue(maxsize=64)
+        self._worker: Optional[asyncio.Task] = None
+        self._mouth: Optional[asyncio.Task] = None
+        self._active_expression: Optional[str] = None
+        # the live connection, owned by the worker task and read by the mouth
+        self._connected: Optional[VTubeStudioClient] = None
+        self.model: Dict[str, Any] = {}
+
+    @property
+    def _stage(self) -> dict:
+        return getattr(self.config, "stage", None) or {}
+
+    def reload_config(self, config) -> None:
+        self.config = config
+
+    # --- the port -----------------------------------------------------------
+
+    def show(self, mood: str, state: str) -> None:
+        expression = (self._stage.get("vts_expressions") or {}).get(mood)
+        self._enqueue(("expression", expression))
+        if state != "talking":
+            self._stop_mouth()
+
+    def perform(self, clip: str) -> None:
+        hotkey = (self._stage.get("vts_clips") or {}).get(clip, clip)
+        if hotkey:
+            self._enqueue(("hotkey", hotkey))
+
+    def mouth(self, envelope: Sequence[float], fps: int = ENVELOPE_FPS) -> None:
+        """Replays the envelope frame by frame.
+
+        The browser source is handed the whole line and runs it off its own
+        clock; VTube Studio has no clock of ours, so this is the one backend
+        that has to pace the mouth itself.
+        """
+        if not len(envelope):
+            return
+        self._stop_mouth()
+        loop = self._loop()
+        if loop is None:
+            return
+        self._mouth = loop.create_task(self._run_mouth(list(envelope), max(1, int(fps))))
+
+    def close(self) -> None:
+        self._stop_mouth()
+        if self._worker is not None:
+            self._worker.cancel()
+            self._worker = None
+
+    # --- internals ----------------------------------------------------------
+
+    @staticmethod
+    def _loop() -> Optional[asyncio.AbstractEventLoop]:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            # built before the engine started; the first call from inside the
+            # loop arms the worker
+            return None
+
+    def _enqueue(self, command) -> None:
+        loop = self._loop()
+        if loop is None:
+            return
+        if self._worker is None or self._worker.done():
+            self._worker = loop.create_task(self._run())
+        try:
+            self._commands.put_nowait(command)
+        except asyncio.QueueFull:
+            # she is talking faster than VTube Studio can answer; the newest
+            # face is the right one to keep
+            with contextlib.suppress(asyncio.QueueEmpty):
+                self._commands.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                self._commands.put_nowait(command)
+
+    def _stop_mouth(self) -> None:
+        if self._mouth is not None and not self._mouth.done():
+            self._mouth.cancel()
+        self._mouth = None
+
+    async def _run_mouth(self, frames: List[float], fps: int) -> None:
+        client = self._connected
+        if client is None or not client.connected:
+            return
+        param = self._stage.get("vts_mouth_param") or "MouthOpen"
+        step = 1.0 / fps
+        try:
+            for value in frames:
+                await client.set_parameter(param, value)
+                await asyncio.sleep(step)
+            await client.set_parameter(param, 0.0)
+        except asyncio.CancelledError:
+            with contextlib.suppress(Exception):
+                await client.set_parameter(param, 0.0)
+            raise
+        except Exception as e:
+            logger.debug(f"Lip sync to VTube Studio stopped: {e}")
+
+    async def _run(self) -> None:
+        """Keeps one connection alive and drains the queue over it."""
+        delay = RETRY_SECONDS
+        while True:
+            client = VTubeStudioClient(
+                self._stage.get("vts_host") or "127.0.0.1",
+                int(self._stage.get("vts_port") or 8001),
+                self.token_file,
+            )
+            try:
+                await client.connect()
+                self._connected = client
+                self.model = await client.current_model()
+                delay = RETRY_SECONDS
+                await self._drain(client)
+            except asyncio.CancelledError:
+                await client.close()
+                raise
+            except Exception as e:
+                logger.warning(f"VTube Studio unreachable ({e}); retrying in {delay:.0f}s.")
+            finally:
+                self._connected = None
+                await client.close()
+
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, RETRY_CEILING)
+
+    async def _drain(self, client: VTubeStudioClient) -> None:
+        while True:
+            kind, value = await self._commands.get()
+            if kind == "expression":
+                await self._apply_expression(client, value)
+            elif kind == "hotkey":
+                await client.trigger(value)
+
+    async def _apply_expression(self, client: VTubeStudioClient, expression) -> None:
+        """One expression at a time: VTS keeps them on until told otherwise."""
+        if expression == self._active_expression:
+            return
+        if self._active_expression:
+            with contextlib.suppress(VTubeStudioError):
+                await client.set_expression(self._active_expression, active=False)
+        if expression:
+            await client.set_expression(expression, active=True)
+        self._active_expression = expression
+
+
+async def probe(config, token_file: Path = TOKEN_FILE) -> Dict[str, Any]:
+    """One-off: what model is loaded and what it can do. For the dashboard.
+
+    A separate connection from the avatar's, so asking does not disturb a live
+    stream, and so it still answers before the backend has ever been switched on.
+    """
+    stage = getattr(config, "stage", None) or {}
+    client = VTubeStudioClient(
+        stage.get("vts_host") or "127.0.0.1",
+        int(stage.get("vts_port") or 8001),
+        token_file,
+    )
+    try:
+        await client.connect()
+        model = await client.current_model()
+        if not model.get("modelLoaded"):
+            return {"ok": True, "model": None,
+                    "message": "Connected, but no model is loaded in VTube Studio",
+                    "expressions": [], "hotkeys": []}
+        return {
+            "ok": True,
+            "model": model.get("modelName"),
+            "message": f"Connected to {model.get('modelName')}",
+            "expressions": [e.get("file") for e in await client.expressions() if e.get("file")],
+            "hotkeys": [{"id": h.get("hotkeyID"), "name": h.get("name")}
+                        for h in await client.hotkeys()],
+        }
+    except Exception as e:
+        return {"ok": False, "model": None, "message": str(e)[:300],
+                "expressions": [], "hotkeys": []}
+    finally:
+        await client.close()

--- a/src/modules/avatar/vtube_studio.py
+++ b/src/modules/avatar/vtube_studio.py
@@ -74,7 +74,7 @@ class VTubeStudioClient:
     async def _send(self, message_type: str, data: Optional[Dict] = None) -> Dict[str, Any]:
         if self._socket is None:
             raise VTubeStudioError("not connected")
-        payload = {
+        payload: Dict[str, Any] = {
             "apiName": API_NAME,
             "apiVersion": API_VERSION,
             "requestID": uuid.uuid4().hex,

--- a/src/modules/caption/__init__.py
+++ b/src/modules/caption/__init__.py
@@ -1,0 +1,3 @@
+from src.modules.caption.factory import build_caption
+
+__all__ = ["build_caption"]

--- a/src/modules/caption/factory.py
+++ b/src/modules/caption/factory.py
@@ -15,6 +15,11 @@ def _obs(config, obs, publisher):
     return ObsTextCaption(config, obs)
 
 
+def _stage(config, obs, publisher):
+    from src.modules.caption.stage import StageCaption
+    return StageCaption(config, publisher)
+
+
 def _off(config, obs, publisher):
     from src.modules.caption.silent import SilentCaption
     return SilentCaption()
@@ -22,8 +27,12 @@ def _off(config, obs, publisher):
 
 BUILDERS: Dict[str, Callable[..., CaptionInterface]] = {
     "obs": _obs,
+    "stage": _stage,
     "off": _off,
 }
+
+# backends that cannot work without somewhere to publish to
+NEEDS_PUBLISHER = frozenset({"stage"})
 
 
 def backend_name(config) -> str:
@@ -41,6 +50,9 @@ def backend_name(config) -> str:
 def build_caption(config, obs: OBSInterface, publisher=None) -> CaptionInterface:
     """The caption described by `stage.caption_backend`."""
     name = backend_name(config)
+    if name in NEEDS_PUBLISHER and publisher is None:
+        logger.warning(f"The {name!r} caption needs a stage channel; using {DEFAULT_BACKEND!r}.")
+        name = DEFAULT_BACKEND
     caption = BUILDERS[name](config, obs, publisher)
     logger.info(f"Caption backend: {name}")
     return caption

--- a/src/modules/caption/factory.py
+++ b/src/modules/caption/factory.py
@@ -1,5 +1,7 @@
 """The one place that knows how to build a caption backend."""
 
+from typing import Callable, Dict
+
 from src.interfaces.base_interfaces import CaptionInterface, OBSInterface
 from src.utils.logger import get_logger
 
@@ -8,8 +10,37 @@ logger = get_logger("bea.caption.factory")
 DEFAULT_BACKEND = "obs"
 
 
-def build_caption(config, obs: OBSInterface) -> CaptionInterface:
-    """The caption described by `stage.caption_backend`."""
+def _obs(config, obs, publisher):
     from src.modules.caption.obs_text import ObsTextCaption
-
     return ObsTextCaption(config, obs)
+
+
+def _off(config, obs, publisher):
+    from src.modules.caption.silent import SilentCaption
+    return SilentCaption()
+
+
+BUILDERS: Dict[str, Callable[..., CaptionInterface]] = {
+    "obs": _obs,
+    "off": _off,
+}
+
+
+def backend_name(config) -> str:
+    """The configured backend, or the default when it is not one we have."""
+    name = (getattr(config, "stage", None) or {}).get("caption_backend", DEFAULT_BACKEND)
+    if name in BUILDERS:
+        return name
+    logger.warning(
+        f"Unknown caption backend {name!r}; falling back to {DEFAULT_BACKEND!r}. "
+        f"Valid: {', '.join(sorted(BUILDERS))}."
+    )
+    return DEFAULT_BACKEND
+
+
+def build_caption(config, obs: OBSInterface, publisher=None) -> CaptionInterface:
+    """The caption described by `stage.caption_backend`."""
+    name = backend_name(config)
+    caption = BUILDERS[name](config, obs, publisher)
+    logger.info(f"Caption backend: {name}")
+    return caption

--- a/src/modules/caption/factory.py
+++ b/src/modules/caption/factory.py
@@ -1,0 +1,15 @@
+"""The one place that knows how to build a caption backend."""
+
+from src.interfaces.base_interfaces import CaptionInterface, OBSInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.caption.factory")
+
+DEFAULT_BACKEND = "obs"
+
+
+def build_caption(config, obs: OBSInterface) -> CaptionInterface:
+    """The caption described by `stage.caption_backend`."""
+    from src.modules.caption.obs_text import ObsTextCaption
+
+    return ObsTextCaption(config, obs)

--- a/src/modules/caption/obs_text.py
+++ b/src/modules/caption/obs_text.py
@@ -1,9 +1,8 @@
 """The speech bubble, typed character by character into an OBS text source.
 
-Moved out of `Expression` unchanged, with one thing put right: `type_text`
-handed the font size it had settled on back to the caller, and `Expression` kept
-it around only so it could clear the source with the same font later. That is an
-OBS detail, and it now stays here.
+The size a line settles at is kept here: a long line shrinks to fit, and
+clearing the source at the configured size instead would resize the box on
+screen between one line and the next.
 """
 
 from typing import Optional

--- a/src/modules/caption/obs_text.py
+++ b/src/modules/caption/obs_text.py
@@ -1,0 +1,52 @@
+"""The speech bubble, typed character by character into an OBS text source.
+
+Moved out of `Expression` unchanged, with one thing put right: `type_text`
+handed the font size it had settled on back to the caller, and `Expression` kept
+it around only so it could clear the source with the same font later. That is an
+OBS detail, and it now stays here.
+"""
+
+from typing import Optional
+
+from src.interfaces.base_interfaces import CaptionInterface, OBSInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.caption.obs")
+
+
+class ObsTextCaption(CaptionInterface):
+    """Writes into the OBS text source named by `obs_text_source`."""
+
+    def __init__(self, config, obs: OBSInterface):
+        self.config = config
+        self.obs = obs
+        self._font_size: Optional[int] = None
+
+    def reload_config(self, config) -> None:
+        self.config = config
+
+    @property
+    def source(self) -> str:
+        return self.config.obs_text_source or ""
+
+    async def say(self, text: str) -> None:
+        if not self.source:
+            return
+        self._font_size = await self.obs.type_text(
+            text=text,
+            source_name=self.source,
+            line_width=self.config.text_line_width,
+            max_lines=self.config.text_lines,
+            base_font_size=self.config.text_font_size,
+            min_font_size=self.config.text_min_font_size,
+            font_step=self.config.text_font_step,
+            typing_delay=self.config.typing_delay,
+            min_page_duration=self.config.text_min_duration,
+        )
+
+    def clear(self) -> None:
+        if not self.source:
+            return
+        # the size it was actually typed at, not the configured one: a long line
+        # shrinks to fit, and clearing at the base size resizes the box on screen
+        self.obs.set_text("", self.source, font_size=self._font_size)

--- a/src/modules/caption/silent.py
+++ b/src/modules/caption/silent.py
@@ -1,0 +1,19 @@
+"""No words on screen at all.
+
+An explicit backend rather than an empty `obs_text_source`: "off" is a choice
+someone makes on purpose, and it should read that way in the dashboard instead
+of being expressed by blanking a source name.
+"""
+
+from src.interfaces.base_interfaces import CaptionInterface
+
+
+class SilentCaption(CaptionInterface):
+    async def say(self, text: str) -> None:
+        """She speaks; nothing is written."""
+
+    def clear(self) -> None:
+        """Nothing to take away."""
+
+    def reload_config(self, config) -> None:
+        """Nothing to reload."""

--- a/src/modules/caption/stage.py
+++ b/src/modules/caption/stage.py
@@ -1,0 +1,31 @@
+"""Her words, typed in the browser source instead of in OBS.
+
+The OBS backend sends one WebSocket request per character — 159 of them, and
+29.7 KB of JSON, for a 158-character line, because each one re-sends the whole
+font block. Here the line crosses the wire once and the page animates it.
+"""
+
+import uuid
+
+from src.core.stage import StageChannel
+from src.interfaces.base_interfaces import CaptionInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.caption.stage")
+
+
+class StageCaption(CaptionInterface):
+    def __init__(self, config, channel: StageChannel):
+        self.config = config
+        self.channel = channel
+
+    def reload_config(self, config) -> None:
+        self.config = config
+
+    async def say(self, text: str) -> None:
+        # an id per line so a page that reconnects mid-sentence can tell a line
+        # it has already typed from a new one it has not
+        self.channel.publish({"caption": text, "caption_id": uuid.uuid4().hex})
+
+    def clear(self) -> None:
+        self.channel.publish({"caption": "", "caption_id": ""})

--- a/src/setup/config_plan.py
+++ b/src/setup/config_plan.py
@@ -67,6 +67,12 @@ def apply_answers(config, answers: Dict[str, Any]):
     if answers.get("audio_device_id") is not None:
         config.audio_device_id = answers["audio_device_id"]
 
+    stage = answers.get("stage")
+    if stage:
+        # merged, not replaced: the wizard asks about the two choices and the one
+        # or two knobs they imply, never about every key in the block
+        config.stage = {**config.stage, **stage}
+
     obs = answers.get("obs")
     if obs:
         config.obs_host = obs.get("host", config.obs_host)

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -43,6 +43,18 @@ PROVIDERS: List[Tuple[str, str, str]] = [
     ("groq", "Groq", "Fastest, smallest catalogue. https://console.groq.com/keys"),
 ]
 
+AVATARS: List[Tuple[str, str, str]] = [
+    ("png", "Images", "One picture per mood, swapped in OBS. Nothing else to install."),
+    ("model", "A 3D model", "A .vrm you bring, rendered in an OBS browser source."),
+    ("vtube_studio", "VTube Studio", "Your own Live2D model, driven over its API."),
+]
+
+CAPTIONS: List[Tuple[str, str, str]] = [
+    ("stage", "Browser source", "Typed in the page. One message per line instead of one per letter."),
+    ("obs", "OBS text source", "Typed into a text source over WebSocket."),
+    ("off", "Nothing", "She speaks; nothing is written on screen."),
+]
+
 TTS_ENGINES: List[Tuple[str, str, str]] = [
     ("edge", "EdgeTTS", "Free, no key, good quality. Needs internet."),
     ("kokoro", "Kokoro", "Runs locally from an ONNX file you download yourself."),
@@ -255,21 +267,50 @@ def _ask_ears(console: Console, answers: Dict[str, Any]) -> None:
     answers["stt_key"] = _ask_key(console, "API key", PROVIDER_KEYS[stt_provider][1])
 
 
-def _ask_obs(console: Console, answers: Dict[str, Any]) -> None:
-    _rule(console, "4/5", "OBS")
-    console.print("  Enable the WebSocket server first: OBS → Tools → WebSocket Server Settings.\n")
+def _ask_stage(console: Console, answers: Dict[str, Any]) -> None:
+    _rule(console, "4/5", "How she appears")
+    console.print("  Two separate choices: what the audience sees of her, and how her "
+                  "words are shown.\n")
 
-    if not Confirm.ask("  Connect to OBS?", default=True):
-        return
-
+    avatar = _choose(console, "Avatar", AVATARS, "png")
     console.print()
-    answers["obs"] = {
-        "host": Prompt.ask("  Host", default="localhost"),
-        "port": IntPrompt.ask("  Port", default=4455),
-        "password": Prompt.ask("  Password", password=True, default="", show_default=False),
-        "avatar_source": Prompt.ask("  Avatar source name", default="BeaPNG"),
-        "text_source": Prompt.ask("  Text bubble source name", default="AIText"),
-    }
+    caption = _choose(console, "Speech bubble", CAPTIONS, "stage")
+    console.print()
+
+    stage: Dict[str, Any] = {"avatar_backend": avatar, "caption_backend": caption}
+
+    if avatar == "model":
+        console.print("  No model ships with projectBEA. Run `make model` afterwards for the "
+                      "free sample, or point this at your own .vrm.\n")
+        stage["model_path"] = Prompt.ask("  Model file", default="data/models/VRM1_Constraint_Twist_Sample.vrm")
+        console.print()
+    elif avatar == "vtube_studio":
+        console.print("  Turn the plugin API on first: VTube Studio → Settings → "
+                      "Start API. She will ask to be allowed the first time.\n")
+        stage["vts_port"] = IntPrompt.ask("  API port", default=8001)
+        console.print()
+
+    answers["stage"] = stage
+
+    if avatar == "png" or caption == "obs":
+        console.print("  That needs OBS. Enable the WebSocket server first: "
+                      "OBS → Tools → WebSocket Server Settings.\n")
+        if not Confirm.ask("  Connect to OBS?", default=True):
+            return
+        console.print()
+        obs: Dict[str, Any] = {
+            "host": Prompt.ask("  Host", default="localhost"),
+            "port": IntPrompt.ask("  Port", default=4455),
+            "password": Prompt.ask("  Password", password=True, default="", show_default=False),
+        }
+        if avatar == "png":
+            obs["avatar_source"] = Prompt.ask("  Avatar source name", default="BeaPNG")
+        if caption == "obs":
+            obs["text_source"] = Prompt.ask("  Text bubble source name", default="AIText")
+        answers["obs"] = obs
+    elif avatar == "model" or caption == "stage":
+        console.print("  Add a Browser Source in OBS pointing at http://127.0.0.1:8000/stage,")
+        console.print("  and untick 'Shutdown source when not visible' so she keeps her pose.\n")
 
 
 def _ask_skills(console: Console, answers: Dict[str, Any]) -> None:
@@ -345,6 +386,9 @@ def _summary(console: Console, answers: Dict[str, Any]) -> None:
     table.add_row("Mind", f"{answers['llm_provider']} · {answers['llm_model']}")
     table.add_row("Voice", answers.get("tts_voice") or answers.get("tts_provider", "edge"))
     table.add_row("Ears", answers.get("stt_provider") or "off")
+    stage = answers.get("stage", {})
+    table.add_row("Avatar", dict((a[0], a[1]) for a in AVATARS).get(stage.get("avatar_backend", "png"), "Images"))
+    table.add_row("Speech bubble", dict((c[0], c[1]) for c in CAPTIONS).get(stage.get("caption_backend", "obs"), "OBS text source"))
     table.add_row("OBS", "connected" if answers.get("obs") else "off")
 
     armed = [name for name in PLATFORM_SKILLS if name in answers.get("skills", {})]
@@ -390,7 +434,7 @@ def run_setup(console: Optional[Console] = None) -> int:
         _ask_voice(console, answers)
         _ask_ears(console, answers)
         if profile in ("stream", "full"):
-            _ask_obs(console, answers)
+            _ask_stage(console, answers)
         if profile == "full":
             _ask_skills(console, answers)
     except (KeyboardInterrupt, EOFError):

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1068,6 +1068,50 @@ def _avatar_files(config) -> Dict[str, Path]:
     return out
 
 
+@app.get("/stage/stream")
+async def stage_stream(request: Request):
+    """Server-sent events for the browser source.
+
+    A snapshot first, then patches. No backlog on purpose: OBS reloads a browser
+    source whenever it is toggled, and replaying what already happened would
+    have her act out the last minute of the stream a second time.
+    """
+    brain = get_brain()
+    queue = brain.stage.subscribe()
+
+    async def pump():
+        yield f"data: {json.dumps({'type': 'snapshot', **brain.stage.snapshot()})}\n\n"
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    patch = await asyncio.wait_for(queue.get(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    yield ": keep-alive\n\n"
+                    continue
+                yield f"data: {json.dumps({'type': 'patch', **patch})}\n\n"
+        finally:
+            brain.stage.unsubscribe(queue)
+
+    return StreamingResponse(pump(), media_type="text/event-stream", headers={
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+    })
+
+
+@app.get("/stage")
+def stage_page():
+    """The page you point an OBS Browser Source at."""
+    page = frontend_path / "stage.html"
+    if not page.is_file():
+        raise HTTPException(
+            status_code=404,
+            detail="The stage page is not built. Run `make frontend`.",
+        )
+    return FileResponse(page)
+
+
 @app.get("/stage/preview")
 def stage_preview(mood: str, state: str = "idle"):
     """One avatar image, for the preview in the dashboard."""

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1003,12 +1003,12 @@ async def test_vts():
     from src.modules.avatar.vtube_studio import probe
 
     found = await probe(get_brain().config)
-    return TestResult(
-        ok=found["ok"],
-        message=found["message"],
-        detail=(f"{len(found['expressions'])} expressions, {len(found['hotkeys'])} hotkeys"
-                if found["ok"] else None),
-    )
+    # "" and not None: `detail` is a str, and the failure path is exactly the
+    # one that would have hit a validation error instead of reporting the failure
+    detail = ""
+    if found["ok"]:
+        detail = f"{len(found['expressions'])} expressions, {len(found['hotkeys'])} hotkeys"
+    return TestResult(ok=found["ok"], message=found["message"], detail=detail)
 
 
 @app.get("/vts/model")

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -37,6 +37,7 @@ from src.core.persona_store import describe as persona_describe
 from src.core.settings_schema import ValidationError, apply_section, describe
 from src.core.settings_schema import restart_needed as _restart_needed
 from src.core.settings_schema import section as _section
+from src.core.stage import public_config
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.web")
@@ -1059,25 +1060,8 @@ def audio_devices():
 
 @app.get("/stage/config")
 def stage_config():
-    """What the browser source needs to draw her, and nothing else.
-
-    Deliberately not the whole config: this endpoint is read by a page that
-    lives in OBS, and OBS is not a place to hand out API keys.
-    """
-    config = get_brain().config
-    stage = dict(getattr(config, "stage", {}) or {})
-    return {
-        "avatar_backend": stage.get("avatar_backend", "png"),
-        "caption_backend": stage.get("caption_backend", "obs"),
-        "shot": stage.get("shot", "bust"),
-        "background": stage.get("background", ""),
-        "lipsync_fps": stage.get("lipsync_fps", 30),
-        "has_model": bool(stage.get("model_path")),
-        "typing_delay": config.typing_delay,
-        "text_line_width": config.text_line_width,
-        "text_lines": config.text_lines,
-        "text_font_size": config.text_font_size,
-    }
+    """What the browser source needs to draw her. Never a secret."""
+    return public_config(get_brain().config)
 
 
 def _clips_dir(config) -> Path:

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1054,6 +1054,48 @@ def stage_config():
     }
 
 
+def _clips_dir(config) -> Path:
+    stage = getattr(config, "stage", {}) or {}
+    return Path(stage.get("clips_dir") or "data/clips")
+
+
+@app.get("/stage/model")
+def stage_model():
+    """The .vrm the browser source draws.
+
+    Served by the engine rather than by a path in the page, so the model can
+    live anywhere on the machine without the browser needing file access.
+    """
+    config = get_brain().config
+    raw = (getattr(config, "stage", {}) or {}).get("model_path")
+    if not raw:
+        raise HTTPException(status_code=404, detail="No model is configured")
+    path = Path(raw).resolve()
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail=f"Configured, but not on disk: {path}")
+    return FileResponse(path, media_type="model/gltf-binary")
+
+
+@app.get("/stage/clips")
+def stage_clips():
+    """The behaviours installed, by name — what the dashboard offers you."""
+    folder = _clips_dir(get_brain().config)
+    if not folder.is_dir():
+        return []
+    return sorted(p.stem for p in folder.glob("*.vrma"))
+
+
+@app.get("/stage/clips/{name}")
+def stage_clip(name: str):
+    """One .vrma behaviour, by the name `/stage/clips` listed."""
+    folder = _clips_dir(get_brain().config).resolve()
+    path = (folder / f"{name}.vrma").resolve()
+    # the name comes from a page: it must not be able to walk out of the folder
+    if not path.is_relative_to(folder) or not path.is_file():
+        raise HTTPException(status_code=404, detail=f"No behaviour called {name!r}")
+    return FileResponse(path, media_type="model/gltf-binary")
+
+
 def _avatar_files(config) -> Dict[str, Path]:
     """Every image the avatar map names, keyed `mood/state`.
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -997,6 +997,32 @@ def test_obs():
         return TestResult(ok=False, message="Could not reach OBS", detail=str(e)[:300])
 
 
+@app.post("/test/vts", response_model=TestResult)
+async def test_vts():
+    """Whether she can reach VTube Studio, and what your model can do."""
+    from src.modules.avatar.vtube_studio import probe
+
+    found = await probe(get_brain().config)
+    return TestResult(
+        ok=found["ok"],
+        message=found["message"],
+        detail=(f"{len(found['expressions'])} expressions, {len(found['hotkeys'])} hotkeys"
+                if found["ok"] else None),
+    )
+
+
+@app.get("/vts/model")
+async def vts_model():
+    """The expressions and hotkeys of the model VTube Studio has loaded.
+
+    So the dashboard offers what your own model actually has, instead of a text
+    box where a typo is silent until you are live.
+    """
+    from src.modules.avatar.vtube_studio import probe
+
+    return await probe(get_brain().config)
+
+
 @app.get("/secrets")
 def secrets_state():
     """Which secrets are set — never their values.

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1028,6 +1028,58 @@ def audio_devices():
         return []
 
 
+# --- the stage -------------------------------------------------------------
+
+
+@app.get("/stage/config")
+def stage_config():
+    """What the browser source needs to draw her, and nothing else.
+
+    Deliberately not the whole config: this endpoint is read by a page that
+    lives in OBS, and OBS is not a place to hand out API keys.
+    """
+    config = get_brain().config
+    stage = dict(getattr(config, "stage", {}) or {})
+    return {
+        "avatar_backend": stage.get("avatar_backend", "png"),
+        "caption_backend": stage.get("caption_backend", "obs"),
+        "shot": stage.get("shot", "bust"),
+        "background": stage.get("background", ""),
+        "lipsync_fps": stage.get("lipsync_fps", 30),
+        "has_model": bool(stage.get("model_path")),
+        "typing_delay": config.typing_delay,
+        "text_line_width": config.text_line_width,
+        "text_lines": config.text_lines,
+        "text_font_size": config.text_font_size,
+    }
+
+
+def _avatar_files(config) -> Dict[str, Path]:
+    """Every image the avatar map names, keyed `mood/state`.
+
+    The allow-list for the preview: an endpoint that served any path the query
+    string asked for would read any file on the machine.
+    """
+    out: Dict[str, Path] = {}
+    for mood, slots in (config.avatar_map or {}).items():
+        for state, raw in (slots or {}).items():
+            if raw:
+                out[f"{mood}/{state}"] = Path(raw).resolve()
+    return out
+
+
+@app.get("/stage/preview")
+def stage_preview(mood: str, state: str = "idle"):
+    """One avatar image, for the preview in the dashboard."""
+    config = get_brain().config
+    path = _avatar_files(config).get(f"{mood}/{state}")
+    if path is None:
+        raise HTTPException(status_code=404, detail="No image is mapped for that mood and state")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail=f"Mapped, but not on disk: {path}")
+    return FileResponse(path)
+
+
 @app.get("/health")
 def health():
     return {"status": "ok", "brain": brain_instance is not None}

--- a/src/web/frontend/package-lock.json
+++ b/src/web/frontend/package-lock.json
@@ -8,12 +8,15 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@pixiv/three-vrm": "^3.5.5",
+        "@pixiv/three-vrm-animation": "^3.5.5",
         "@tailwindcss/postcss": "^4.1.18",
         "framer-motion": "^12.34.1",
         "lucide-react": "^0.562.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.0"
+        "react-router-dom": "^7.13.0",
+        "three": "^0.186.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1053,6 +1056,165 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@pixiv/three-vrm": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm/-/three-vrm-3.5.5.tgz",
+      "integrity": "sha512-RPXy7jYAXs704NIpZlosB0U2ENu21G9DrqGWdQgRe8dShaCo1ugpj+6BVPRCy91nt+MPMA96j5rbsSzEl0HlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/three-vrm-core": "3.5.5",
+        "@pixiv/three-vrm-materials-hdr-emissive-multiplier": "3.5.5",
+        "@pixiv/three-vrm-materials-mtoon": "3.5.5",
+        "@pixiv/three-vrm-materials-v0compat": "3.5.5",
+        "@pixiv/three-vrm-node-constraint": "3.5.5",
+        "@pixiv/three-vrm-springbone": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-animation": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-animation/-/three-vrm-animation-3.5.5.tgz",
+      "integrity": "sha512-Q0kEtmftxfv0iCUHQkJH2jAr1zmT9ywYXnAzhxnLPMYCsx0Kken3J3U2GJF9PdGZmLlKpoK0LFEXVdD/L7ZA4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/three-vrm-core": "3.5.5",
+        "@pixiv/types-vrmc-vrm-1.0": "3.5.5",
+        "@pixiv/types-vrmc-vrm-animation-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-core": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-core/-/three-vrm-core-3.5.5.tgz",
+      "integrity": "sha512-jjaXZbMVRsk2HAGVxqDLmSJyGOJqbMcJpuTHR1TY/TN1FxiKdAzSqdr/ZUcczYipNf8IL9vDT9NX2XmWj+ybRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrm-0.0": "3.5.5",
+        "@pixiv/types-vrmc-vrm-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-materials-hdr-emissive-multiplier": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-hdr-emissive-multiplier/-/three-vrm-materials-hdr-emissive-multiplier-3.5.5.tgz",
+      "integrity": "sha512-XnHEqpY4ctYMucpeRcptdphOe0RrW7V5fUvojasD8Ja4MTjjrjCNFxsAvp3+HBkPZbkTM2sDCjJBJNzxN1scrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-materials-mtoon": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-mtoon/-/three-vrm-materials-mtoon-3.5.5.tgz",
+      "integrity": "sha512-7lThHf4OKBOsVenD+R6L6HffNUlKO3Twnhr3+z77MnUsSzsOanjVKJtjSIly9QJ6hgl8YJmI6RnxCKqXcpplog==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrm-0.0": "3.5.5",
+        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-materials-v0compat": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-v0compat/-/three-vrm-materials-v0compat-3.5.5.tgz",
+      "integrity": "sha512-NjsTK4P4qdcr+RoL2gEUNgF2CY/aplNvyHHxI99N7D6CxDZ2H93FQ9aIuLCABj5b+4CIvldWMCcnS7YuLIr3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrm-0.0": "3.5.5",
+        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-node-constraint": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-node-constraint/-/three-vrm-node-constraint-3.5.5.tgz",
+      "integrity": "sha512-+ShEXioZ5Ctf0EZ5ZViZ4n0jhV/qtJRH0Juw8nRnMNODZXDSr+B3An2lrfRoMhowCzG63GiUG4lXWV9noMXosA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrmc-node-constraint-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/three-vrm-springbone": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-springbone/-/three-vrm-springbone-3.5.5.tgz",
+      "integrity": "sha512-GWAWrIegGH/u1ZA+Es03Qzc2yafrQOrhtal9jzUIAgU8Wm2DYuqAABOY+du/9RpBRK8D4T8DBPvRGQqvfrQ/uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrm-0.0": "3.5.5",
+        "@pixiv/types-vrmc-springbone-1.0": "3.5.5",
+        "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.5.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/@pixiv/types-vrm-0.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrm-0.0/-/types-vrm-0.0-3.5.5.tgz",
+      "integrity": "sha512-2S/0jswMjJTwL9ky8YzDR0CIaP6ZmE+HFuyW/0h+SA+awELf+J7WGgC8lTLM1MXzokO7Z2YVljU2F0fEhlKDIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0/-/types-vrmc-materials-hdr-emissive-multiplier-1.0-3.5.5.tgz",
+      "integrity": "sha512-IuHw9ehXt2bymqfdFV+f2cCXo8kvJUfh0Zuut8qmKXoEb7HVyLGIQyS4TcQHG5yY22UTWHI1Axo5tQv35lPTgQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-materials-mtoon-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-mtoon-1.0/-/types-vrmc-materials-mtoon-1.0-3.5.5.tgz",
+      "integrity": "sha512-GFVuksAJVhrWTXYmI/ucNsE611/d8N6BoZrzhUAAINndt98loyzapW2+DJu+GsUBO5yxd+vLsL0FB16XD9+TGg==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-node-constraint-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-node-constraint-1.0/-/types-vrmc-node-constraint-1.0-3.5.5.tgz",
+      "integrity": "sha512-8EbJ1uzkn9yJQarCChmpG12+mc2c7PimHvQ8H6/tMh/hqp5NtJND0z2lR2KeVxw9A3M+TpF+xgImhLBxGjqwzQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-springbone-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-1.0/-/types-vrmc-springbone-1.0-3.5.5.tgz",
+      "integrity": "sha512-gRQ5Y7PaGiMefvOrJ3hvoSPqpA67jiwyhwh8ItjsPi3yri/Hn3CeXplW3Cbx3ZPbfu+C3Q2MCRa2TqAUOjeMRA==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-springbone-extended-collider-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-extended-collider-1.0/-/types-vrmc-springbone-extended-collider-1.0-3.5.5.tgz",
+      "integrity": "sha512-+6RxLaAvVguP7upjS/OT4viNPWvac1HBRQY1nmdvfYNQuCMdrMsCZqvy2af0Fcjnda4V9JbKFIpZDC0lrw1+uQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-vrm-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-3.5.5.tgz",
+      "integrity": "sha512-WnemHHo2375BcBdumEhvrupZzsMSzTfdWlokmV9sUX2oC+OAQqJFfBjLF8ppkOhzHpl4MAPJqEfuhBJtNPm9ww==",
+      "license": "MIT"
+    },
+    "node_modules/@pixiv/types-vrmc-vrm-animation-1.0": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-animation-1.0/-/types-vrmc-vrm-animation-1.0-3.5.5.tgz",
+      "integrity": "sha512-pyow6wBLdRZbLQbtHqu8uvYG+NXJbwIiLVK6pM6UvtaYotecOv43t6qIdMLYuieV+F+bEJcdfOLFZZVolrOOcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixiv/types-vrmc-vrm-1.0": "3.5.5"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5349,6 +5511,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.186.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.186.0.tgz",
+      "integrity": "sha512-cr/fIM2ddMSVbYVgkfD4jLJv7Fh/8ZTjvo+7gQeSVGUZHxpx9FDwoL5iC7hUz/LiRA8wMbqfnb90xKfm1/HHkQ==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/src/web/frontend/package.json
+++ b/src/web/frontend/package.json
@@ -10,12 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@pixiv/three-vrm": "^3.5.5",
+    "@pixiv/three-vrm-animation": "^3.5.5",
     "@tailwindcss/postcss": "^4.1.18",
     "framer-motion": "^12.34.1",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.0"
+    "react-router-dom": "^7.13.0",
+    "three": "^0.186.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/web/frontend/src/api.js
+++ b/src/web/frontend/src/api.js
@@ -112,5 +112,10 @@ export const api = {
     testLlm: () => request('/test/llm', { method: 'POST' }),
     testTts: () => request('/test/tts', { method: 'POST' }),
     testObs: () => request('/test/obs', { method: 'POST' }),
+    testVts: () => request('/test/vts', { method: 'POST' }),
     audioDevices: () => request('/audio/devices'),
+
+    // the stage: what she is drawn with
+    stageClips: () => request('/stage/clips'),
+    vtsModel: () => request('/vts/model'),
 };

--- a/src/web/frontend/src/pages/settings/StagePreview.jsx
+++ b/src/web/frontend/src/pages/settings/StagePreview.jsx
@@ -16,17 +16,24 @@ const STATES = [
     { value: 'talking', label: 'Talking' },
 ];
 
-// the alpha checkerboard, so a transparent avatar does not read as a white one
+// the alpha checkerboard: whatever is drawn over this is what OBS composites,
+// and everything else the panel is standing in for
 const CHECKS = {
-    backgroundImage:
-        'repeating-conic-gradient(color-mix(in srgb, var(--text) 8%, transparent) 0% 25%, transparent 0% 50%)',
+    backgroundColor: 'var(--bg-sunken)',
+    backgroundImage: [
+        'linear-gradient(45deg, var(--fill-3) 25%, transparent 25%)',
+        'linear-gradient(-45deg, var(--fill-3) 25%, transparent 25%)',
+        'linear-gradient(45deg, transparent 75%, var(--fill-3) 75%)',
+        'linear-gradient(-45deg, transparent 75%, var(--fill-3) 75%)',
+    ].join(', '),
     backgroundSize: '18px 18px',
+    backgroundPosition: '0 0, 0 9px, 9px -9px, -9px 0',
 };
 
 function Frame({ children, tall }) {
     return (
         <div
-            className="grid place-items-center overflow-hidden rounded-b2 border border-line bg-sunken"
+            className="grid place-items-center overflow-hidden rounded-b2 border border-line"
             style={{ ...CHECKS, minHeight: tall ? 420 : 260 }}
         >
             {children}
@@ -100,16 +107,23 @@ function ModelPreview({ hasModel }) {
         );
     }
     return (
-        <div
-            className="overflow-hidden rounded-b2 border border-line bg-sunken"
-            style={CHECKS}
-        >
-            <iframe
-                title="The browser source"
-                src="/stage?hud=0&bg=0"
-                className="block h-[420px] w-full border-0"
-            />
-        </div>
+        <>
+            {/* the page paints nothing but her, so the iframe must not lay its
+                own opaque white underneath it */}
+            <div className="overflow-hidden rounded-b2 border border-line" style={CHECKS}>
+                <iframe
+                    title="The browser source"
+                    src="/stage?hud=0"
+                    className="block h-[420px] w-full border-0"
+                    style={{ background: 'transparent', colorScheme: 'normal' }}
+                />
+            </div>
+            <p className="text-[11px] leading-snug text-faint">
+                This is the browser source itself, not a mock-up. The chequerboard is this
+                panel showing through — OBS composites her over your scene instead.
+                Saving a change here updates it live.
+            </p>
+        </>
     );
 }
 

--- a/src/web/frontend/src/pages/settings/StagePreview.jsx
+++ b/src/web/frontend/src/pages/settings/StagePreview.jsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import { AlertTriangle, Eye } from 'lucide-react';
+import { Group } from './parts';
+import { Segmented } from '../../components/ui/controls';
+
+/**
+ * What the audience will actually see, without opening OBS.
+ *
+ * For the 3D model the preview is not a mock-up of the browser source: it *is*
+ * the browser source, in an iframe. There is no second renderer to keep in
+ * sync, and what you approve here is exactly what OBS gets.
+ */
+
+const STATES = [
+    { value: 'idle', label: 'Idle' },
+    { value: 'talking', label: 'Talking' },
+];
+
+// the alpha checkerboard, so a transparent avatar does not read as a white one
+const CHECKS = {
+    backgroundImage:
+        'repeating-conic-gradient(color-mix(in srgb, var(--text) 8%, transparent) 0% 25%, transparent 0% 50%)',
+    backgroundSize: '18px 18px',
+};
+
+function Frame({ children, tall }) {
+    return (
+        <div
+            className="grid place-items-center overflow-hidden rounded-b2 border border-line bg-sunken"
+            style={{ ...CHECKS, minHeight: tall ? 420 : 260 }}
+        >
+            {children}
+        </div>
+    );
+}
+
+function Empty({ icon: Icon = Eye, children }) {
+    return (
+        <div className="flex max-w-xs flex-col items-center gap-2 p-6 text-center">
+            <Icon size={18} className="text-faint" />
+            <p className="text-[13px] leading-relaxed text-dim">{children}</p>
+        </div>
+    );
+}
+
+function PngPreview({ moods }) {
+    const [mood, setMood] = useState(moods[0] || 'normal');
+    const [state, setState] = useState('idle');
+    const [missing, setMissing] = useState(false);
+    const src = `/stage/preview?mood=${encodeURIComponent(mood)}&state=${state}&t=${state}`;
+
+    return (
+        <>
+            <div className="flex flex-wrap items-center gap-2">
+                <Segmented
+                    value={mood}
+                    onChange={(next) => { setMood(next); setMissing(false); }}
+                    options={moods.map((m) => ({ value: m, label: m }))}
+                    size="sm"
+                />
+                <div className="ml-auto">
+                    <Segmented
+                        value={state}
+                        onChange={(next) => { setState(next); setMissing(false); }}
+                        options={STATES}
+                        size="sm"
+                    />
+                </div>
+            </div>
+            <Frame>
+                {missing ? (
+                    <Empty icon={AlertTriangle}>
+                        Nothing is mapped for <span className="font-mono text-text">{mood} / {state}</span>,
+                        or the file is not on disk.
+                    </Empty>
+                ) : (
+                    <img
+                        key={src}
+                        src={src}
+                        alt={`${mood}, ${state}`}
+                        className="max-h-[380px] w-auto object-contain"
+                        onError={() => setMissing(true)}
+                    />
+                )}
+            </Frame>
+        </>
+    );
+}
+
+function ModelPreview({ hasModel }) {
+    if (!hasModel) {
+        return (
+            <Frame>
+                <Empty>
+                    Point <span className="font-mono text-text">Model file</span> at a .vrm below.
+                    No model ships with projectBEA — run <span className="font-mono text-text">make model</span> for
+                    the free sample, or bring your own.
+                </Empty>
+            </Frame>
+        );
+    }
+    return (
+        <div
+            className="overflow-hidden rounded-b2 border border-line bg-sunken"
+            style={CHECKS}
+        >
+            <iframe
+                title="The browser source"
+                src="/stage?hud=0&bg=0"
+                className="block h-[420px] w-full border-0"
+            />
+        </div>
+    );
+}
+
+function VtsPreview({ status }) {
+    return (
+        <Frame>
+            <Empty>
+                {status?.ok
+                    ? <>Connected to <span className="font-mono text-text">{status.model || 'VTube Studio'}</span>. The
+                        model is drawn by VTube Studio itself, so preview it in its own window.</>
+                    : <>VTube Studio renders in its own window, so there is nothing to show here.
+                        Use <span className="font-mono text-text">Test the connection</span> below to check she can reach it.</>}
+            </Empty>
+        </Frame>
+    );
+}
+
+export function StagePreview({ config, vtsStatus }) {
+    const stage = config.stage || {};
+    const backend = stage.avatar_backend || 'png';
+    const moods = Object.keys(config.avatar_map || {});
+
+    return (
+        <Group title="Preview" description="What the stream sees, before you go looking in OBS.">
+            {backend === 'png' && <PngPreview moods={moods} />}
+            {backend === 'model' && <ModelPreview hasModel={Boolean(stage.model_path)} />}
+            {backend === 'vtube_studio' && <VtsPreview status={vtsStatus} />}
+        </Group>
+    );
+}

--- a/src/web/frontend/src/pages/settings/parts.jsx
+++ b/src/web/frontend/src/pages/settings/parts.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Check, X } from 'lucide-react';
+import { Check, Copy, X } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Glass } from '../../components/glass/Glass';
 import { Button } from '../../components/ui/controls';
@@ -109,6 +109,31 @@ export function TestButton({ label, run }) {
                     </motion.span>
                 )}
             </AnimatePresence>
+        </div>
+    );
+}
+
+/** A value you are meant to paste somewhere else, with one click to take it. */
+export function CopyField({ value, help }) {
+    const toast = useToast();
+    const copy = async () => {
+        try {
+            await navigator.clipboard.writeText(value);
+            toast.success('Copied');
+        } catch {
+            // a browser that refuses the clipboard still lets you select the text
+            toast.error('Could not copy — select it and copy by hand');
+        }
+    };
+    return (
+        <div>
+            <div className="flex items-center gap-2 rounded-b2 border border-line bg-fill px-3 py-2">
+                <code className="flex-1 truncate font-mono text-[12px] text-text">{value}</code>
+                <Button variant="ghost" size="sm" onClick={copy} aria-label="Copy">
+                    <Copy size={13} />
+                </Button>
+            </div>
+            {help && <p className="mt-1.5 text-[11px] leading-snug text-faint">{help}</p>}
         </div>
     );
 }

--- a/src/web/frontend/src/pages/settings/sections.jsx
+++ b/src/web/frontend/src/pages/settings/sections.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { api } from '../../api';
 import { Field, SecretInput, Select, Slider, TextInput, CheckRow } from '../../components/ui/fields';
 import { Button } from '../../components/ui/controls';
-import { Group, ProviderChoice, SecretState, TestButton } from './parts';
+import { CopyField, Group, ProviderChoice, SecretState, TestButton } from './parts';
+import { StagePreview } from './StagePreview';
 import { PromptEditor } from './PromptEditor';
 import { createSchemaSection } from './SchemaSection';
 import { PersonalitySection } from './PersonalitySection';
@@ -297,83 +298,290 @@ function HearingSection({ config, update }) {
 
 // --- the stream -------------------------------------------------------------
 
+/** One row per mood, so a map is edited where the moods actually are. */
+function MoodMap({ moods, values, onChange, placeholder, options }) {
+    if (!moods.length) return <p className="text-[12px] text-faint">No moods are configured.</p>;
+    return (
+        <div className="grid gap-2">
+            {moods.map((mood) => (
+                <div key={mood} className="grid items-center gap-2 sm:grid-cols-[7rem_1fr]">
+                    <span className="font-mono text-[10px] uppercase tracking-wider text-dim">{mood}</span>
+                    {options ? (
+                        <Select value={values[mood] || ''} onChange={(e) => onChange(mood, e.target.value)}>
+                            <option value="">— none —</option>
+                            {options.map((o) => (
+                                <option key={o.id} value={o.id}>{o.label}</option>
+                            ))}
+                        </Select>
+                    ) : (
+                        <TextInput
+                            value={values[mood] || ''}
+                            onChange={(e) => onChange(mood, e.target.value)}
+                            placeholder={placeholder}
+                            className="font-mono text-[11px]"
+                        />
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function VTubeStudioGroups({ stage, moods, updateStage, updateStageMap }) {
+    const [model, setModel] = useState(null);
+
+    // one call does both jobs: it reports the connection and fills the pickers
+    const load = async () => {
+        const found = await api.vtsModel();
+        setModel(found);
+        return {
+            ok: found.ok,
+            message: found.message,
+            detail: found.ok
+                ? `${found.expressions.length} expressions, ${found.hotkeys.length} hotkeys`
+                : null,
+        };
+    };
+
+    return (
+        <>
+            <Group title="VTube Studio" description="Not bundled and not required: if you run it, she can drive it. Your model stays yours.">
+                <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+                    <Field label="Host">
+                        <TextInput value={stage.vts_host || ''} onChange={(e) => updateStage('vts_host', e.target.value)} className="font-mono" />
+                    </Field>
+                    <Field label="Port" help="8001 by default.">
+                        <TextInput type="number" value={stage.vts_port ?? 8001} onChange={(e) => updateStage('vts_port', parseInt(e.target.value, 10) || 0)} />
+                    </Field>
+                </div>
+                <p className="text-[11px] leading-snug text-faint">
+                    The first time she connects, VTube Studio asks you to allow the plugin. Say yes in its window;
+                    the token is stored under <span className="font-mono">data/</span> and never leaves this machine.
+                </p>
+                <TestButton label="Test the connection" run={load} />
+            </Group>
+
+            <Group title="A face per mood" description="Expressions come from your model, so pick from what it actually has.">
+                <MoodMap
+                    moods={moods}
+                    values={stage.vts_expressions || {}}
+                    onChange={(mood, value) => updateStageMap('vts_expressions', mood, value)}
+                    placeholder="angry.exp3.json"
+                    options={model?.expressions?.map((name) => ({ id: name, label: name }))}
+                />
+            </Group>
+
+            <Group title="A behaviour per mood" description="Hotkeys as your model defines them.">
+                <MoodMap
+                    moods={moods}
+                    values={stage.vts_clips || {}}
+                    onChange={(mood, value) => updateStageMap('vts_clips', mood, value)}
+                    placeholder="hotkey id"
+                    options={model?.hotkeys?.map((h) => ({ id: h.id, label: h.name || h.id }))}
+                />
+            </Group>
+        </>
+    );
+}
+
+const AVATAR_BACKENDS = [
+    { id: 'png', label: 'Images', blurb: 'One picture per mood, swapped in OBS.' },
+    { id: 'model', label: '3D model', blurb: 'A VRM you bring, rendered in a browser source.' },
+    { id: 'vtube_studio', label: 'VTube Studio', blurb: 'Your own Live2D model, driven over its API.' },
+];
+
+const CAPTION_BACKENDS = [
+    { id: 'obs', label: 'OBS text', blurb: 'Typed into a text source.' },
+    { id: 'stage', label: 'Browser source', blurb: 'Typed in the page, one message instead of one per letter.' },
+    { id: 'off', label: 'Off', blurb: 'She speaks, nothing is written.' },
+];
+
 function StreamSection({ config, update, setConfig }) {
+    const stage = config.stage || {};
+    const avatarBackend = stage.avatar_backend || 'png';
+    const captionBackend = stage.caption_backend || 'obs';
+
+    const updateStage = (key, value) => setConfig((prev) => ({
+        ...prev,
+        stage: { ...(prev.stage || {}), [key]: value },
+    }));
+    const updateStageMap = (key, mood, value) => setConfig((prev) => ({
+        ...prev,
+        stage: { ...(prev.stage || {}), [key]: { ...((prev.stage || {})[key] || {}), [mood]: value } },
+    }));
     const updateAvatar = (mood, state, value) => setConfig((prev) => ({
         ...prev,
         avatar_map: { ...prev.avatar_map, [mood]: { ...prev.avatar_map[mood], [state]: value } },
     }));
 
+    const needsObs = avatarBackend === 'png' || captionBackend === 'obs';
+    const moods = Object.keys(config.avatar_map || {});
+    const stageUrl = `${window.location.origin}/stage`;
+
+    // what is actually installed in the clips folder, so the picker offers real
+    // names instead of a text box where a typo is silent until you are live
+    const [clips, setClips] = useState([]);
+    useEffect(() => {
+        if (avatarBackend !== 'model') return;
+        api.stageClips().then(setClips).catch(() => setClips([]));
+    }, [avatarBackend, stage.clips_dir]);
+
     return (
         <>
-            <Group title="OBS" description="She swaps the avatar and types into a text source over WebSocket.">
-                <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
-                    <Field label="Host"><TextInput value={config.obs_host || ''} onChange={(e) => update('obs_host', e.target.value)} className="font-mono" /></Field>
-                    <Field label="Port">
-                        <TextInput
-                            type="number"
-                            value={config.obs_port ?? 4455}
-                            onChange={(e) => update('obs_port', parseInt(e.target.value, 10) || 0)}
-                        />
-                    </Field>
-                </div>
-                <Field label="Password">
-                    <SecretInput value={config.obs_password || ''} onChange={(e) => update('obs_password', e.target.value)} />
+            <Group title="How she appears" description="Two independent choices: the body, and the words on screen.">
+                <Field label="Avatar" help="What the audience actually sees of her.">
+                    <ProviderChoice
+                        value={avatarBackend}
+                        onChange={(id) => updateStage('avatar_backend', id)}
+                        options={AVATAR_BACKENDS}
+                        columns={3}
+                    />
                 </Field>
-                <TestButton label="Connect to OBS" run={api.testObs} />
-            </Group>
-
-            <Group title="Sources" description="The names exactly as they appear in your OBS scene.">
-                <ProviderChoice
-                    value={config.obs_source_type}
-                    onChange={(id) => update('obs_source_type', id)}
-                    options={[
-                        { id: 'image', label: 'Image source', blurb: 'Static PNG avatars.' },
-                        { id: 'media', label: 'Media source', blurb: 'Video or animated files.' },
-                    ]}
-                />
-                <Field label="Avatar source">
-                    <TextInput value={config.obs_avatar_source || ''} onChange={(e) => update('obs_avatar_source', e.target.value)} className="font-mono" />
-                </Field>
-                <Field label="Text source">
-                    <TextInput value={config.obs_text_source || ''} onChange={(e) => update('obs_text_source', e.target.value)} className="font-mono" />
+                <Field label="Speech bubble" help="How her words are shown while she talks.">
+                    <ProviderChoice
+                        value={captionBackend}
+                        onChange={(id) => updateStage('caption_backend', id)}
+                        options={CAPTION_BACKENDS}
+                        columns={3}
+                    />
                 </Field>
             </Group>
 
-            <Group title="The text bubble" description="How her words appear on screen while she talks.">
-                <div className="grid gap-3 sm:grid-cols-2">
-                    <Field label="Line width">
-                        <TextInput type="number" value={config.text_line_width ?? 0} onChange={(e) => update('text_line_width', parseInt(e.target.value, 10) || 0)} />
-                    </Field>
-                    <Field label="Font size">
-                        <TextInput type="number" value={config.text_font_size ?? 0} onChange={(e) => update('text_font_size', parseInt(e.target.value, 10) || 0)} />
-                    </Field>
-                    <Field label="Typing delay" help="Seconds between characters.">
-                        <TextInput type="number" step="0.01" value={config.typing_delay ?? 0} onChange={(e) => update('typing_delay', parseFloat(e.target.value))} />
-                    </Field>
-                    <Field label="Minimum time on screen" help="Seconds a short line stays up.">
-                        <TextInput type="number" step="0.1" value={config.text_min_duration ?? 2} onChange={(e) => update('text_min_duration', parseFloat(e.target.value))} />
-                    </Field>
-                </div>
-            </Group>
+            <StagePreview config={config} />
 
-            <Group title="Avatar" description="One image per mood, one for idle and one for talking.">
-                <Field label="Image folder">
-                    <TextInput value={config.png_dir || ''} onChange={(e) => update('png_dir', e.target.value)} className="font-mono" />
-                </Field>
-                {Object.entries(config.avatar_map || {}).map(([mood, paths]) => (
-                    <div key={mood} className="rounded-b2 border border-line bg-fill p-3">
-                        <p className="mb-2.5 font-mono text-[10px] uppercase tracking-wider text-dim">{mood}</p>
-                        <div className="grid gap-2.5 sm:grid-cols-2">
-                            <Field label="Idle">
-                                <TextInput value={paths.idle || ''} onChange={(e) => updateAvatar(mood, 'idle', e.target.value)} className="font-mono text-[11px]" />
+            {(avatarBackend === 'model' || captionBackend === 'stage') && (
+                <Group title="The browser source" description="Add this URL to OBS as a Browser Source. Tick 'Shutdown source when not visible' off, so she keeps her pose.">
+                    <CopyField value={stageUrl} />
+                </Group>
+            )}
+
+            {needsObs && (
+                <Group title="OBS" description="She swaps the avatar and types into a text source over WebSocket.">
+                    <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+                        <Field label="Host"><TextInput value={config.obs_host || ''} onChange={(e) => update('obs_host', e.target.value)} className="font-mono" /></Field>
+                        <Field label="Port">
+                            <TextInput
+                                type="number"
+                                value={config.obs_port ?? 4455}
+                                onChange={(e) => update('obs_port', parseInt(e.target.value, 10) || 0)}
+                            />
+                        </Field>
+                    </div>
+                    <Field label="Password">
+                        <SecretInput value={config.obs_password || ''} onChange={(e) => update('obs_password', e.target.value)} />
+                    </Field>
+                    <TestButton label="Connect to OBS" run={api.testObs} />
+                </Group>
+            )}
+
+            {(avatarBackend === 'png' || captionBackend === 'obs') && (
+                <Group title="Sources" description="The names exactly as they appear in your OBS scene.">
+                    {avatarBackend === 'png' && (
+                        <>
+                            <ProviderChoice
+                                value={config.obs_source_type}
+                                onChange={(id) => update('obs_source_type', id)}
+                                options={[
+                                    { id: 'image', label: 'Image source', blurb: 'Static PNG avatars.' },
+                                    { id: 'media', label: 'Media source', blurb: 'Video or animated files.' },
+                                ]}
+                            />
+                            <Field label="Avatar source">
+                                <TextInput value={config.obs_avatar_source || ''} onChange={(e) => update('obs_avatar_source', e.target.value)} className="font-mono" />
                             </Field>
-                            <Field label="Talking">
-                                <TextInput value={paths.talking || ''} onChange={(e) => updateAvatar(mood, 'talking', e.target.value)} className="font-mono text-[11px]" />
+                        </>
+                    )}
+                    {captionBackend === 'obs' && (
+                        <Field label="Text source">
+                            <TextInput value={config.obs_text_source || ''} onChange={(e) => update('obs_text_source', e.target.value)} className="font-mono" />
+                        </Field>
+                    )}
+                </Group>
+            )}
+
+            {captionBackend !== 'off' && (
+                <Group title="The text bubble" description="How her words appear on screen while she talks.">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <Field label="Line width">
+                            <TextInput type="number" value={config.text_line_width ?? 0} onChange={(e) => update('text_line_width', parseInt(e.target.value, 10) || 0)} />
+                        </Field>
+                        <Field label="Font size">
+                            <TextInput type="number" value={config.text_font_size ?? 0} onChange={(e) => update('text_font_size', parseInt(e.target.value, 10) || 0)} />
+                        </Field>
+                        <Field label="Typing delay" help="Seconds between characters.">
+                            <TextInput type="number" step="0.01" value={config.typing_delay ?? 0} onChange={(e) => update('typing_delay', parseFloat(e.target.value))} />
+                        </Field>
+                        <Field label="Minimum time on screen" help="Seconds a short line stays up.">
+                            <TextInput type="number" step="0.1" value={config.text_min_duration ?? 2} onChange={(e) => update('text_min_duration', parseFloat(e.target.value))} />
+                        </Field>
+                    </div>
+                </Group>
+            )}
+
+            {avatarBackend === 'png' && (
+                <Group title="Avatar" description="One image per mood, one for idle and one for talking.">
+                    <Field label="Image folder">
+                        <TextInput value={config.png_dir || ''} onChange={(e) => update('png_dir', e.target.value)} className="font-mono" />
+                    </Field>
+                    {Object.entries(config.avatar_map || {}).map(([mood, paths]) => (
+                        <div key={mood} className="rounded-b2 border border-line bg-fill p-3">
+                            <p className="mb-2.5 font-mono text-[10px] uppercase tracking-wider text-dim">{mood}</p>
+                            <div className="grid gap-2.5 sm:grid-cols-2">
+                                <Field label="Idle">
+                                    <TextInput value={paths.idle || ''} onChange={(e) => updateAvatar(mood, 'idle', e.target.value)} className="font-mono text-[11px]" />
+                                </Field>
+                                <Field label="Talking">
+                                    <TextInput value={paths.talking || ''} onChange={(e) => updateAvatar(mood, 'talking', e.target.value)} className="font-mono text-[11px]" />
+                                </Field>
+                            </div>
+                        </div>
+                    ))}
+                </Group>
+            )}
+
+            {avatarBackend === 'model' && (
+                <>
+                    <Group title="The model" description="A .vrm file on this machine. Nothing is bundled: the model is yours.">
+                        <Field label="Model file" help="Run `make model` to download the free sample, or point this at your own.">
+                            <TextInput value={stage.model_path || ''} onChange={(e) => updateStage('model_path', e.target.value)} placeholder="data/models/bea.vrm" className="font-mono" />
+                        </Field>
+                        <Field label="Framing" help="Computed from the head bone, so any model is framed the same way.">
+                            <ProviderChoice
+                                value={stage.shot || 'bust'}
+                                onChange={(id) => updateStage('shot', id)}
+                                options={[
+                                    { id: 'bust', label: 'Bust', blurb: 'Head and shoulders.' },
+                                    { id: 'half', label: 'Half', blurb: 'From the hips up.' },
+                                    { id: 'full', label: 'Full', blurb: 'All of her.' },
+                                ]}
+                                columns={3}
+                            />
+                        </Field>
+                        <div className="grid gap-3 sm:grid-cols-2">
+                            <Field label="Behaviours folder" help="The .vrma clips she can play.">
+                                <TextInput value={stage.clips_dir || ''} onChange={(e) => updateStage('clips_dir', e.target.value)} className="font-mono" />
+                            </Field>
+                            <Field label="Lip sync rate" help="Mouth updates per second.">
+                                <TextInput type="number" value={stage.lipsync_fps ?? 30} onChange={(e) => updateStage('lipsync_fps', parseInt(e.target.value, 10) || 30)} />
                             </Field>
                         </div>
-                    </div>
-                ))}
-            </Group>
+                    </Group>
+
+                    <Group title="A behaviour per mood" description="Optional. Leave one empty and she just changes expression.">
+                        <MoodMap
+                            moods={moods}
+                            values={stage.mood_clips || {}}
+                            onChange={(mood, value) => updateStageMap('mood_clips', mood, value)}
+                            placeholder="wave"
+                            options={(clips || []).map((name) => ({ id: name, label: name }))}
+                        />
+                    </Group>
+                </>
+            )}
+
+            {avatarBackend === 'vtube_studio' && (
+                <VTubeStudioGroups stage={stage} moods={moods} updateStage={updateStage} updateStageMap={updateStageMap} />
+            )}
         </>
     );
 }

--- a/src/web/frontend/src/stage/avatar.js
+++ b/src/web/frontend/src/stage/avatar.js
@@ -1,0 +1,190 @@
+/**
+ * The 3D body: a VRM, rendered transparent for an OBS browser source.
+ *
+ * The engine sends expression weights and a loudness envelope; nothing here
+ * knows what a mood is. Two things that look like details and are not:
+ *
+ *  - The 180° turn belongs to VRM 0.x only. `VRMUtils.rotateVRM0` applies it
+ *    where it is due; an unconditional `rotation.y = Math.PI` shows the back of
+ *    every VRM 1.0 model.
+ *  - The camera is framed off the `head` bone, never off numbers. That is what
+ *    makes the same code frame a 1.4 m model and a 1.8 m one the same way.
+ */
+
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from '@pixiv/three-vrm-animation';
+
+const EMOTIONS = ['happy', 'angry', 'sad', 'relaxed', 'surprised', 'neutral'];
+
+// how fast a face settles into a new mood. Slow enough to read as a change of
+// expression, fast enough that the line she is saying still matches it.
+const EASING = 8;
+
+// the shot, as a height in metres to fit in frame
+const SHOTS = { bust: 0.52, half: null, full: null };
+
+export async function createAvatar(root, config = {}) {
+    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setClearAlpha(config.background ? 1 : 0);
+    if (config.background) renderer.setClearColor(new THREE.Color(config.background), 1);
+    root.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 0.1, 20);
+
+    const key = new THREE.DirectionalLight(0xffffff, 2.0);
+    key.position.set(1, 2, 1.5);          // from the camera side, or the face goes dark
+    scene.add(key, new THREE.AmbientLight(0xffffff, 1.1));
+
+    const loader = new GLTFLoader();
+    loader.register((parser) => new VRMLoaderPlugin(parser));
+    loader.register((parser) => new VRMAnimationLoaderPlugin(parser));
+
+    const gltf = await loader.loadAsync('/stage/model');
+    const vrm = gltf.userData.vrm;
+    if (!vrm) throw new Error('that file loaded, but it is not a VRM');
+
+    VRMUtils.combineSkeletons(gltf.scene);
+    VRMUtils.rotateVRM0(vrm);             // only 0.x needs turning; 1.0 already faces us
+    scene.add(vrm.scene);
+
+    const mixer = new THREE.AnimationMixer(vrm.scene);
+    const clips = new Map();
+    let current = null;
+
+    frame(config.shot || 'bust');
+
+    function frame(shot) {
+        const bone = (name) => vrm.humanoid?.getNormalizedBoneNode(name)
+            || vrm.humanoid?.getRawBoneNode(name);
+        const head = bone('head');
+        const hips = bone('hips');
+        if (!head || !hips) {
+            camera.position.set(0, 1.3, 1.6);
+            camera.lookAt(0, 1.3, 0);
+            return;
+        }
+
+        vrm.scene.updateWorldMatrix(true, true);
+        const headY = head.getWorldPosition(new THREE.Vector3()).y;
+        const hipsY = hips.getWorldPosition(new THREE.Vector3()).y;
+
+        let centre;
+        let span;
+        if (shot === 'full') {
+            const box = new THREE.Box3().setFromObject(vrm.scene);
+            centre = (box.max.y + box.min.y) / 2;
+            span = (box.max.y - box.min.y) * 1.08;
+        } else if (shot === 'half') {
+            centre = (headY + hipsY) / 2;
+            span = (headY - hipsY) * 1.5;
+        } else {
+            centre = headY - 0.06;        // a little headroom, the way a shot is framed
+            span = SHOTS.bust;
+        }
+
+        const distance = span / (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2));
+        camera.position.set(0, centre, distance);
+        camera.lookAt(0, centre, 0);
+    }
+
+    async function play(name) {
+        if (!name) return;
+        try {
+            if (!clips.has(name)) {
+                const loaded = await loader.loadAsync(`/stage/clips/${encodeURIComponent(name)}`);
+                const [animation] = loaded.userData.vrmAnimations || [];
+                if (!animation) throw new Error('no animation inside it');
+                clips.set(name, createVRMAnimationClip(animation, vrm));
+            }
+            const action = mixer.clipAction(clips.get(name));
+            current?.fadeOut(0.25);
+            action.reset().fadeIn(0.25).play();
+            current = action;
+        } catch (error) {
+            console.warn(`[stage] behaviour "${name}" did not play:`, error.message);
+        }
+    }
+
+    // what the engine last said she is
+    const target = Object.fromEntries(EMOTIONS.map((name) => [name, 0]));
+    target.neutral = 1;
+    let mouth = { frames: [], fps: 30, startedAt: 0 };
+    let speaking = false;
+
+    function drive(delta) {
+        const manager = vrm.expressionManager;
+        if (!manager) return;
+
+        const k = 1 - Math.exp(-EASING * delta);
+        for (const name of EMOTIONS) {
+            const now = manager.getValue(name) ?? 0;
+            manager.setValue(name, THREE.MathUtils.lerp(now, target[name] ?? 0, k));
+        }
+
+        let open = 0;
+        if (speaking && mouth.frames.length) {
+            const index = Math.floor((performance.now() - mouth.startedAt) / 1000 * mouth.fps);
+            open = index < mouth.frames.length ? mouth.frames[index] : 0;
+        }
+        manager.setValue('aa', open);
+    }
+
+    const clock = new THREE.Clock();
+    renderer.setAnimationLoop(() => {
+        const delta = clock.getDelta();
+        mixer.update(delta);
+        drive(delta);
+        vrm.update(delta);
+        renderer.render(scene, camera);
+    });
+
+    const onResize = () => {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+    };
+    window.addEventListener('resize', onResize);
+
+    return {
+        /**
+         * @param patch what changed
+         * @param animate false when this is the state on connect: a page that
+         *        reloads mid-sentence must not replay the behaviour or the mouth
+         */
+        apply(patch, { animate = true } = {}) {
+            if (patch.expressions) Object.assign(target, patch.expressions);
+            if ('state' in patch) speaking = patch.state === 'talking';
+
+            if (!animate) {
+                // snap rather than ease, so a reconnect is invisible on stream
+                const manager = vrm.expressionManager;
+                for (const name of EMOTIONS) manager?.setValue(name, target[name] ?? 0);
+                mouth = { frames: [], fps: 30, startedAt: 0 };
+                return;
+            }
+
+            if (patch.envelope) {
+                mouth = {
+                    frames: patch.envelope,
+                    fps: patch.envelope_fps || 30,
+                    startedAt: performance.now(),
+                };
+            }
+            if (patch.perform) play(patch.perform);
+        },
+
+        reframe: frame,
+
+        dispose() {
+            window.removeEventListener('resize', onResize);
+            renderer.setAnimationLoop(null);
+            VRMUtils.deepDispose(vrm.scene);
+            renderer.dispose();
+        },
+    };
+}

--- a/src/web/frontend/src/stage/avatar.js
+++ b/src/web/frontend/src/stage/avatar.js
@@ -25,12 +25,18 @@ const EASING = 8;
 // the shot, as a height in metres to fit in frame
 const SHOTS = { bust: 0.52, half: null, full: null };
 
+function setBackground(renderer, colour) {
+    if (colour) renderer.setClearColor(new THREE.Color(colour), 1);
+    else renderer.setClearColor(0x000000, 0);
+}
+
 export async function createAvatar(root, config = {}) {
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setClearAlpha(config.background ? 1 : 0);
-    if (config.background) renderer.setClearColor(new THREE.Color(config.background), 1);
+    // transparent unless a colour was asked for: OBS composites the page over
+    // the scene, so anything painted here that is not her is on the stream
+    setBackground(renderer, config.background);
     root.appendChild(renderer.domElement);
 
     const scene = new THREE.Scene();
@@ -176,6 +182,12 @@ export async function createAvatar(root, config = {}) {
                 };
             }
             if (patch.perform) play(patch.perform);
+        },
+
+        /** Settings changed under a running page: shot and background apply live. */
+        setLook(next = {}) {
+            setBackground(renderer, next.background);
+            frame(next.shot || 'bust');
         },
 
         reframe: frame,

--- a/src/web/frontend/src/stage/caption.js
+++ b/src/web/frontend/src/stage/caption.js
@@ -1,0 +1,82 @@
+/**
+ * The speech bubble, typed here instead of over the wire.
+ *
+ * The OBS backend sends one request per character. This one receives the line
+ * once and animates it locally, which is both cheaper and smoother: the typing
+ * is driven by requestAnimationFrame rather than by network round trips.
+ */
+
+const DEFAULTS = {
+    typing_delay: 0.03,
+    text_line_width: 40,
+    text_lines: 4,
+    text_font_size: 75,
+};
+
+export function createCaption(root, config = {}) {
+    const settings = { ...DEFAULTS, ...config };
+
+    const el = document.createElement('div');
+    el.className = 'caption';
+    el.style.fontSize = `${settings.text_font_size}px`;
+    // the box is sized by the configured line width, so the OBS setup and this
+    // one wrap at the same place and moving between them changes nothing
+    el.style.maxWidth = `${settings.text_line_width}ch`;
+    root.appendChild(el);
+
+    let lastId = null;
+    let raf = null;
+
+    const stop = () => {
+        if (raf) cancelAnimationFrame(raf);
+        raf = null;
+    };
+
+    const type = (text) => {
+        stop();
+        const perChar = Math.max(settings.typing_delay, 0) * 1000;
+        const started = performance.now();
+        el.classList.add('is-visible');
+
+        const step = (now) => {
+            const shown = perChar > 0
+                ? Math.min(text.length, Math.floor((now - started) / perChar))
+                : text.length;
+            el.textContent = text.slice(0, shown);
+            if (shown < text.length) raf = requestAnimationFrame(step);
+            else raf = null;
+        };
+        raf = requestAnimationFrame(step);
+    };
+
+    return {
+        /** A line as it is being said: animate it. */
+        say(text, id) {
+            if (id && id === lastId) return;
+            lastId = id ?? null;
+            if (!text) return this.clear();
+            type(text);
+        },
+
+        /** A line that was already on screen when we connected: no animation. */
+        restore(text, id) {
+            stop();
+            lastId = id ?? null;
+            el.textContent = text || '';
+            el.classList.toggle('is-visible', Boolean(text));
+        },
+
+        clear() {
+            stop();
+            lastId = null;
+            el.textContent = '';
+            el.classList.remove('is-visible');
+        },
+
+        update(config) {
+            Object.assign(settings, config);
+            el.style.fontSize = `${settings.text_font_size}px`;
+            el.style.maxWidth = `${settings.text_line_width}ch`;
+        },
+    };
+}

--- a/src/web/frontend/src/stage/connection.js
+++ b/src/web/frontend/src/stage/connection.js
@@ -1,0 +1,46 @@
+/**
+ * The engine's side of the browser source.
+ *
+ * One EventSource, which reconnects on its own — that is the whole reason this
+ * is SSE and not a WebSocket. A snapshot arrives first and says how she looks
+ * right now; everything after it is a patch.
+ */
+
+export function connect({ onSnapshot, onPatch, onStatus }) {
+    let source = null;
+
+    const open = () => {
+        source = new EventSource('/stage/stream');
+
+        source.onopen = () => onStatus?.({ connected: true });
+
+        source.onerror = () => {
+            // EventSource retries by itself; say so rather than tearing it down
+            onStatus?.({ connected: false });
+        };
+
+        source.onmessage = (event) => {
+            let payload;
+            try {
+                payload = JSON.parse(event.data);
+            } catch {
+                return;
+            }
+            if (payload.type === 'snapshot') onSnapshot?.(payload);
+            else onPatch?.(payload);
+        };
+    };
+
+    open();
+    return () => source?.close();
+}
+
+export async function stageConfig() {
+    try {
+        const response = await fetch('/stage/config');
+        if (!response.ok) return {};
+        return await response.json();
+    } catch {
+        return {};
+    }
+}

--- a/src/web/frontend/src/stage/main.js
+++ b/src/web/frontend/src/stage/main.js
@@ -46,6 +46,26 @@ if (config.avatar_backend === 'model' && config.has_model) {
     }
 }
 
+let current = config;
+
+/** Settings were saved. Apply what can be applied; reload for what cannot. */
+function applyConfig(next) {
+    const before = current;
+    current = next;
+
+    // a different backend, or a different model, changes what the page *is*
+    // rather than how it draws, and a reload is both correct and cheap
+    if (next.avatar_backend !== before.avatar_backend
+        || next.has_model !== before.has_model
+        || next.model_id !== before.model_id) {
+        window.location.reload();
+        return;
+    }
+
+    caption.update(next);
+    avatar?.setLook(next);
+}
+
 connect({
     onStatus: ({ connected }) => (connected ? clearWarning() : warn('Not connected to the engine')),
 
@@ -56,6 +76,7 @@ connect({
     },
 
     onPatch: (patch) => {
+        if (patch.config) applyConfig(patch.config);
         if ('caption' in patch) caption.say(patch.caption, patch.caption_id);
         avatar?.apply(patch, { animate: true });
     },

--- a/src/web/frontend/src/stage/main.js
+++ b/src/web/frontend/src/stage/main.js
@@ -1,0 +1,47 @@
+/**
+ * The browser source: one page that draws whatever the engine says she is.
+ *
+ * For now it renders the caption; the body arrives behind the same connection.
+ */
+
+import './stage.css';
+import { createCaption } from './caption.js';
+import { connect, stageConfig } from './connection.js';
+
+const root = document.getElementById('stage');
+const params = new URLSearchParams(window.location.search);
+
+// ?hud=0 hides the connection warning, for the preview inside the dashboard
+const quiet = params.get('hud') === '0';
+
+const config = await stageConfig();
+const caption = createCaption(root, config);
+
+let offline = null;
+function warn(message) {
+    if (quiet) return;
+    if (!offline) {
+        offline = document.createElement('div');
+        offline.className = 'offline';
+        root.appendChild(offline);
+    }
+    offline.textContent = message;
+}
+
+function clearWarning() {
+    offline?.remove();
+    offline = null;
+}
+
+connect({
+    onStatus: ({ connected }) => (connected ? clearWarning() : warn('Not connected to the engine')),
+
+    // how she looks *now*: put it on screen without acting it out
+    onSnapshot: (state) => {
+        caption.restore(state.caption, state.caption_id);
+    },
+
+    onPatch: (patch) => {
+        if ('caption' in patch) caption.say(patch.caption, patch.caption_id);
+    },
+});

--- a/src/web/frontend/src/stage/main.js
+++ b/src/web/frontend/src/stage/main.js
@@ -1,7 +1,9 @@
 /**
  * The browser source: one page that draws whatever the engine says she is.
  *
- * For now it renders the caption; the body arrives behind the same connection.
+ * It always renders the caption, and the 3D body only when that is the chosen
+ * backend — the renderer is imported dynamically so a PNG setup never downloads
+ * three.js at all.
  */
 
 import './stage.css';
@@ -33,15 +35,28 @@ function clearWarning() {
     offline = null;
 }
 
+let avatar = null;
+if (config.avatar_backend === 'model' && config.has_model) {
+    try {
+        const { createAvatar } = await import('./avatar.js');
+        avatar = await createAvatar(root, config);
+    } catch (error) {
+        console.error('[stage] the 3D renderer did not start', error);
+        warn(`3D renderer: ${error.message}`);
+    }
+}
+
 connect({
     onStatus: ({ connected }) => (connected ? clearWarning() : warn('Not connected to the engine')),
 
     // how she looks *now*: put it on screen without acting it out
     onSnapshot: (state) => {
         caption.restore(state.caption, state.caption_id);
+        avatar?.apply(state, { animate: false });
     },
 
     onPatch: (patch) => {
         if ('caption' in patch) caption.say(patch.caption, patch.caption_id);
+        avatar?.apply(patch, { animate: true });
     },
 });

--- a/src/web/frontend/src/stage/stage.css
+++ b/src/web/frontend/src/stage/stage.css
@@ -1,0 +1,72 @@
+/* The browser source. Transparent by default: OBS composites it over the scene,
+   so anything painted here that is not her is something the stream will see. */
+
+:root {
+    --caption-ink: #ffffff;
+    --caption-shadow: 0 2px 0 rgba(0, 0, 0, 0.55), 0 0 18px rgba(0, 0, 0, 0.45);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    height: 100%;
+    background: transparent;
+    overflow: hidden;
+}
+
+#stage {
+    position: relative;
+    height: 100vh;
+    width: 100vw;
+}
+
+/* the renderer fills the frame; the caption sits over it */
+#stage canvas {
+    display: block;
+    position: absolute;
+    inset: 0;
+}
+
+.caption {
+    position: absolute;
+    left: 50%;
+    bottom: 6vh;
+    transform: translateX(-50%);
+    margin: 0;
+    padding: 0.35em 0.6em;
+    text-align: center;
+    font-family: "Bricolage Grotesque", "Inter", system-ui, -apple-system, sans-serif;
+    font-weight: 700;
+    line-height: 1.25;
+    color: var(--caption-ink);
+    text-shadow: var(--caption-shadow);
+    white-space: pre-wrap;
+    opacity: 0;
+    transition: opacity 140ms ease-out;
+}
+
+.caption.is-visible {
+    opacity: 1;
+}
+
+/* shown only when the page cannot reach the engine; never during a stream */
+.offline {
+    position: absolute;
+    left: 12px;
+    top: 12px;
+    padding: 6px 9px;
+    border-radius: 6px;
+    background: rgba(10, 12, 17, 0.85);
+    color: #ff7a85;
+    font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .caption {
+        transition: none;
+    }
+}

--- a/src/web/frontend/stage.html
+++ b/src/web/frontend/stage.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bea — Stage</title>
+  <!--
+    The page an OBS Browser Source points at. Deliberately not part of the
+    dashboard bundle: this one loads a 3D renderer and must not drag React,
+    the router and the whole control room into a source that runs all stream.
+  -->
+</head>
+
+<body>
+  <div id="stage"></div>
+  <script type="module" src="/src/stage/main.js"></script>
+</body>
+
+</html>

--- a/src/web/frontend/vite.config.js
+++ b/src/web/frontend/vite.config.js
@@ -1,7 +1,18 @@
+import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      // two entry points, not one page with a route: the OBS browser source runs
+      // for a whole stream and must not carry React, the router or the dashboard
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        stage: resolve(__dirname, 'stage.html'),
+      },
+    },
+  },
 })

--- a/src/web/frontend/vite.config.js
+++ b/src/web/frontend/vite.config.js
@@ -1,17 +1,20 @@
-import { resolve } from 'path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+// this config is an ES module, where __dirname does not exist
+const here = (file) => fileURLToPath(new URL(file, import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   build: {
     rollupOptions: {
-      // two entry points, not one page with a route: the OBS browser source runs
+      // two entry points, not one app with a route: the OBS browser source runs
       // for a whole stream and must not carry React, the router or the dashboard
       input: {
-        main: resolve(__dirname, 'index.html'),
-        stage: resolve(__dirname, 'stage.html'),
+        main: here('./index.html'),
+        stage: here('./stage.html'),
       },
     },
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,21 @@ class _SilentDevice:
 
 
 @pytest.fixture(autouse=True)
+def isolated_config(monkeypatch, tmp_path):
+    """No test reads the config.json of whoever is running it.
+
+    `BrainConfig()` loads the file from the working directory, so a developer
+    who has configured their own stream would see tests fail on their machine
+    and pass in CI. Pointed at this test's own `tmp_path`, which starts empty —
+    so the defaults are the defaults, and a test that wants a config file can
+    still write one there.
+    """
+    from src.core import config as config_module
+
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(tmp_path / "config.json"))
+
+
+@pytest.fixture(autouse=True)
 def silent_audio(monkeypatch):
     """No test plays sound. Not quiet sound: none."""
     device = _SilentDevice()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,43 @@
 import sys
+import types
 from pathlib import Path
+
+import pytest
 
 # tests import `src.*` directly; keep them runnable without an editable install
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+class _SilentDevice:
+    """Stands in for PortAudio so the suite never reaches the sound card.
+
+    `Expression._play_audio` imports sounddevice where it is used and hands it
+    whatever the TTS produced. A test that returns real samples rather than
+    zeros would play them — out loud, on the machine running the tests — and a
+    headless box has no PortAudio to import in the first place.
+    """
+
+    def __init__(self):
+        self.played = []
+        self.stops = 0
+        self.default = types.SimpleNamespace(device=(0, 0))
+
+    def play(self, data, samplerate=None, device=None, blocking=False):
+        self.played.append((len(data), samplerate, device))
+
+    def stop(self):
+        self.stops += 1
+
+    def query_devices(self, index=None):
+        device = {"name": "silent", "max_output_channels": 2, "max_input_channels": 2}
+        return device if index is not None else [device]
+
+
+@pytest.fixture(autouse=True)
+def silent_audio(monkeypatch):
+    """No test plays sound. Not quiet sound: none."""
+    device = _SilentDevice()
+    monkeypatch.setitem(sys.modules, "sounddevice", device)
+    return device

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -78,7 +78,7 @@ class FakeExpression:
         self.felt: List[Any] = []
         self.is_speaking = False
         self.interrupts = 0
-        self.mood_avatar: Optional[str] = None
+        self.state: Optional[tuple] = None
         self.call = None
 
     def set_call(self, call):
@@ -97,8 +97,54 @@ class FakeExpression:
         self.interrupts += 1
         return True
 
-    def set_mood_avatar(self, mood):
-        self.mood_avatar = mood
+    def set_state(self, state, mood=None):
+        self.state = (state, mood)
+
+
+class FakeAvatar:
+    """Records what she was made to look like; touches nothing."""
+
+    def __init__(self):
+        self.shown: List[tuple] = []
+        self.performed: List[str] = []
+        self.envelopes: List[tuple] = []
+        self.closed = False
+
+    def show(self, mood, state):
+        self.shown.append((mood, state))
+
+    def perform(self, clip):
+        self.performed.append(clip)
+
+    def mouth(self, envelope, fps):
+        self.envelopes.append((list(envelope), fps))
+
+    def reload_config(self, config):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    @property
+    def states(self) -> List[str]:
+        return [state for _mood, state in self.shown]
+
+
+class FakeCaption:
+    """Records the lines put on screen, without animating them."""
+
+    def __init__(self):
+        self.said: List[str] = []
+        self.clears = 0
+
+    async def say(self, text):
+        self.said.append(text)
+
+    def clear(self):
+        self.clears += 1
+
+    def reload_config(self, config):
+        pass
 
 
 class FakeHistory:

--- a/tests/test_avatar_backends.py
+++ b/tests/test_avatar_backends.py
@@ -1,0 +1,96 @@
+"""Choosing how she appears is configuration, not a code change.
+
+The factories are the only place that knows a backend by name; everything above
+them sees `AvatarInterface` and `CaptionInterface` and nothing else.
+"""
+
+import pytest
+
+from src.core.config import BrainConfig
+from src.interfaces.base_interfaces import AvatarInterface, CaptionInterface
+from src.modules.avatar.factory import BUILDERS as AVATAR_BUILDERS
+from src.modules.avatar.factory import backend_name as avatar_backend
+from src.modules.avatar.factory import build_avatar
+from src.modules.caption.factory import BUILDERS as CAPTION_BUILDERS
+from src.modules.caption.factory import backend_name as caption_backend
+from src.modules.caption.factory import build_caption
+
+
+class Obs:
+    def set_image(self, *a, **k):
+        pass
+
+    def set_media(self, *a, **k):
+        pass
+
+    def set_text(self, *a, **k):
+        pass
+
+    async def type_text(self, **kwargs):
+        return 0
+
+
+def config(**stage) -> BrainConfig:
+    cfg = BrainConfig()
+    cfg.stage = {**cfg.stage, **stage}
+    return cfg
+
+
+# --- the defaults ------------------------------------------------------------
+
+
+def test_the_default_setup_is_the_one_that_already_worked():
+    """Upgrading must not move anybody's stream."""
+    cfg = BrainConfig()
+    assert cfg.stage["avatar_backend"] == "png"
+    assert cfg.stage["caption_backend"] == "obs"
+
+
+def test_a_config_written_before_the_stage_existed_still_loads():
+    """`deep_merge` fills the block in; an old config.json has no `stage` key."""
+    cfg = BrainConfig()
+    cfg.stage.pop("avatar_backend")
+    assert avatar_backend(cfg) == "png"
+
+
+# --- the dispatch ------------------------------------------------------------
+
+
+def test_every_registered_backend_builds_something_that_honours_the_port():
+    for name in AVATAR_BUILDERS:
+        avatar = build_avatar(config(avatar_backend=name), Obs())
+        assert isinstance(avatar, AvatarInterface), f"{name} is not an avatar"
+    for name in CAPTION_BUILDERS:
+        caption = build_caption(config(caption_backend=name), Obs())
+        assert isinstance(caption, CaptionInterface), f"{name} is not a caption"
+
+
+@pytest.mark.parametrize("name", ["", "3d", "Png", "vtube studio", None])
+def test_an_unknown_backend_falls_back_instead_of_leaving_her_invisible(name, caplog):
+    """A typo in config.json must cost a warning, not a whole stream."""
+    with caplog.at_level("WARNING"):
+        avatar = build_avatar(config(avatar_backend=name), Obs())
+    assert isinstance(avatar, AvatarInterface)
+    assert any("Unknown avatar backend" in r.message for r in caplog.records)
+
+
+def test_the_caption_can_be_turned_off_on_purpose():
+    """"Off" is a choice, not a blanked-out source name."""
+    caption = build_caption(config(caption_backend="off"), Obs())
+    assert isinstance(caption, CaptionInterface)
+
+
+async def test_a_silent_caption_writes_nothing_and_raises_nothing():
+    caption = build_caption(config(caption_backend="off"), Obs())
+    await caption.say("qualcosa")
+    caption.clear()
+
+
+# --- the two choices are independent ----------------------------------------
+
+
+def test_the_avatar_and_the_caption_are_chosen_separately():
+    """"PNG avatar with the nicer browser caption" has to be expressible."""
+    cfg = config(avatar_backend="png", caption_backend="off")
+    assert avatar_backend(cfg) == "png"
+    assert caption_backend(cfg) == "off"

--- a/tests/test_avatar_port.py
+++ b/tests/test_avatar_port.py
@@ -1,0 +1,267 @@
+"""How Bea appears is a port, not a branch in the speech path.
+
+`Expression` used to resolve file paths itself and ask `if obs_source_type ==
+"media"` in six different places. It now hands down a mood and a state and never
+learns what they turn into.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.core.expression import Expression
+from src.interfaces.base_interfaces import AvatarInterface, CaptionInterface
+from src.modules.avatar.png import PngAvatar
+from src.modules.caption.obs_text import ObsTextCaption
+from tests.fakes import FakeAvatar, FakeCaption
+
+
+class RecordingObs:
+    """Records the OBS calls an adapter makes, and nothing else."""
+
+    def __init__(self):
+        self.images = []
+        self.media = []
+        self.texts = []
+        self.typed = []
+        self.font_size = 42
+
+    def set_image(self, path):
+        self.images.append(str(path))
+
+    def set_media(self, path):
+        self.media.append(str(path))
+
+    def set_text(self, text, source_name, font_size=None):
+        self.texts.append((text, source_name, font_size))
+
+    async def type_text(self, **kwargs):
+        self.typed.append(kwargs)
+        return self.font_size
+
+
+class Config:
+    obs_source_type = "image"
+    obs_text_source = "AIText"
+    text_line_width = 30
+    text_lines = 3
+    text_font_size = 75
+    text_min_font_size = 20
+    text_font_step = 2
+    typing_delay = 0.0
+    text_min_duration = 0.0
+    audio_device_id = None
+
+    def __init__(self, **avatar_map):
+        self.avatar_map = avatar_map or {
+            "normal": {"idle": "n/idle.png", "talking": "n/talk.png"},
+            "angry": {"idle": "a/idle.png", "talking": "a/talk.png"},
+        }
+
+
+class SilentTTS:
+    async def generate_audio(self, text, prosody=None):
+        return np.zeros(240, dtype=np.float32), 24000
+
+    async def speak(self, text, output_device_id):
+        pass
+
+    def reload_config(self, config):
+        pass
+
+
+class Events:
+    def publish(self, *a, **k):
+        pass
+
+
+def name_of(path: str) -> str:
+    return "/".join(Path(path).parts[-2:])
+
+
+# --- the port itself ---------------------------------------------------------
+
+
+def test_both_backends_satisfy_the_port_they_claim():
+    """A backend that forgets a method must fail at import, not on stream."""
+    assert issubclass(PngAvatar, AvatarInterface)
+    assert issubclass(ObsTextCaption, CaptionInterface)
+
+
+def test_a_png_avatar_ignores_the_behaviours_it_cannot_perform():
+    """A still image has no gestures and no mouth; it must not raise over it."""
+    obs = RecordingObs()
+    avatar = PngAvatar(Config(), obs)
+
+    avatar.perform("wave")
+    avatar.mouth([0.1, 0.9, 0.2], fps=30)
+
+    assert obs.images == []
+    assert obs.media == []
+
+
+def test_the_media_branch_now_lives_in_exactly_one_place():
+    """The same `if` used to be copied into six methods of the speech path."""
+    config = Config()
+    config.obs_source_type = "media"
+    obs = RecordingObs()
+
+    PngAvatar(config, obs).show("angry", "talking")
+
+    assert obs.media and not obs.images
+    assert name_of(obs.media[0]) == "a/talk.png"
+
+
+def test_talking_and_idle_pick_the_two_slots_the_mood_declares():
+    obs = RecordingObs()
+    avatar = PngAvatar(Config(), obs)
+
+    avatar.show("angry", "talking")
+    avatar.show("angry", "idle")
+
+    assert [name_of(p) for p in obs.images] == ["a/talk.png", "a/idle.png"]
+
+
+# --- the bug this port closes ------------------------------------------------
+
+
+def test_sleeping_is_a_state_with_its_own_slot_not_a_mood():
+    """`set_mood_avatar("sleeping")` resolved to `normal` and was never seen.
+
+    "sleeping" is not in MOODS, is not a near miss, and default_avatar_map()
+    gives it no slot — so the sleeping avatar silently showed her normal face
+    for as long as the feature has existed.
+    """
+    config = Config(
+        normal={"idle": "n/idle.png", "talking": "n/talk.png"},
+        sleeping={"idle": "z/sleep.png", "talking": "z/sleep.png"},
+    )
+    obs = RecordingObs()
+
+    PngAvatar(config, obs).show("angry", "sleeping")
+
+    assert name_of(obs.images[0]) == "z/sleep.png"
+
+
+def test_an_unmapped_state_falls_back_to_the_mood_and_says_so_once(caplog):
+    """Silence was the bug. Falling back is fine; doing it quietly is not."""
+    obs = RecordingObs()
+    avatar = PngAvatar(Config(), obs)
+
+    with caplog.at_level("WARNING"):
+        avatar.show("angry", "sleeping")
+        avatar.show("angry", "sleeping")
+
+    assert name_of(obs.images[0]) == "a/idle.png"
+    warnings = [r for r in caplog.records if "sleeping" in r.message]
+    assert len(warnings) == 1, "one warning per missing state, not one per frame"
+
+
+# --- the caption -------------------------------------------------------------
+
+
+async def test_the_caption_keeps_the_font_size_instead_of_handing_it_back():
+    """`type_text` returned it only so Expression could pass it back on clear."""
+    obs = RecordingObs()
+    obs.font_size = 55
+    caption = ObsTextCaption(Config(), obs)
+
+    await caption.say("una battuta lunga abbastanza da rimpicciolire il testo")
+    caption.clear()
+
+    assert obs.texts[-1] == ("", "AIText", 55)
+
+
+async def test_a_caption_with_no_source_configured_does_nothing():
+    """An empty `obs_text_source` is how you turn the bubble off."""
+    config = Config()
+    config.obs_text_source = ""
+    obs = RecordingObs()
+    caption = ObsTextCaption(config, obs)
+
+    await caption.say("ciao")
+    caption.clear()
+
+    assert obs.typed == [] and obs.texts == []
+
+
+# --- what Expression is left knowing ----------------------------------------
+
+
+async def test_expression_drives_the_ports_and_never_a_file_path():
+    avatar, caption = FakeAvatar(), FakeCaption()
+    e = Expression(Config(), SilentTTS(), avatar, caption, Events())
+
+    await e.speak("angry", "ma dai")
+
+    assert avatar.shown == [("angry", "talking"), ("angry", "idle")]
+    assert caption.said == ["ma dai"]
+    assert not hasattr(e, "png_map")
+    assert not hasattr(e, "obs")
+
+
+async def test_a_resumed_line_keeps_the_mood_it_was_cut_off_in():
+    """Resume used to hardcode `normal`: an angry sentence finished neutral."""
+    avatar, caption = FakeAvatar(), FakeCaption()
+    e = Expression(Config(), SilentTTS(), avatar, caption, Events())
+
+    await e.speak("angry", "stavo dicendo")
+    e.resume_buffer = np.zeros(24000, dtype=np.float32)
+    await e.resume()
+
+    assert ("normal", "talking") not in avatar.shown
+    assert avatar.shown[-2:] == [("angry", "talking"), ("angry", "idle")]
+
+
+def test_a_state_change_does_not_reset_the_face_she_was_wearing():
+    avatar, caption = FakeAvatar(), FakeCaption()
+    e = Expression(Config(), SilentTTS(), avatar, caption, Events())
+
+    e.set_state("listening", mood="angry")
+    e.set_state("sleeping")
+
+    assert avatar.shown == [("angry", "listening"), ("angry", "sleeping")]
+
+
+def test_waking_up_is_allowed_to_reset_the_mood_because_it_says_so():
+    avatar, caption = FakeAvatar(), FakeCaption()
+    e = Expression(Config(), SilentTTS(), avatar, caption, Events())
+
+    e.set_state("sleeping", mood="cry")
+    e.set_state("idle", mood="normal")
+
+    assert avatar.shown[-1] == ("normal", "idle")
+
+
+async def test_an_interruption_clears_the_caption_and_settles_the_avatar():
+    avatar, caption = FakeAvatar(), FakeCaption()
+    e = Expression(Config(), SilentTTS(), avatar, caption, Events())
+
+    await e.speak("shock", "aspetta")
+    caption.clears = 0
+    await e.interrupt()
+
+    assert caption.clears == 1
+    assert avatar.shown[-1] == ("shock", "idle")
+
+
+def test_reloading_the_config_reaches_both_ports():
+    class Recorder(FakeAvatar):
+        reloaded = 0
+
+        def reload_config(self, config):
+            type(self).reloaded += 1
+
+    avatar, caption = Recorder(), FakeCaption()
+    e = Expression(Config(), SilentTTS(), avatar, caption, Events())
+    e.reload_config(Config())
+
+    assert Recorder.reloaded == 1
+
+
+@pytest.mark.parametrize("state", ["idle", "talking", "listening", "sleeping"])
+def test_every_state_the_engine_uses_resolves_to_something_showable(state):
+    obs = RecordingObs()
+    PngAvatar(Config(), obs).show("normal", state)
+    assert obs.images, f"the '{state}' state showed nothing at all"

--- a/tests/test_avatar_port.py
+++ b/tests/test_avatar_port.py
@@ -265,3 +265,14 @@ def test_every_state_the_engine_uses_resolves_to_something_showable(state):
     obs = RecordingObs()
     PngAvatar(Config(), obs).show("normal", state)
     assert obs.images, f"the '{state}' state showed nothing at all"
+
+
+def test_swapping_the_backend_mid_run_keeps_the_face_she_was_wearing():
+    """Changing the dropdown must not reset her to neutral on stream."""
+    e = Expression(Config(), SilentTTS(), FakeAvatar(), FakeCaption(), Events())
+    e.set_state("idle", mood="angry")
+
+    replacement = FakeAvatar()
+    e.set_ports(replacement, FakeCaption())
+
+    assert replacement.shown == [("angry", "idle")]

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -19,7 +19,14 @@ from src.core.perception.types import Perception, PerceptionKind
 from src.core.skills.base import SkillRegistry
 from src.core.skills.voice.channel import VoiceChannel
 from src.interfaces.base_interfaces import TTSInterface
-from tests.fakes import FakeExpression, FakeHistory, FakeLLMClient, RecordingEvents
+from tests.fakes import (
+    FakeAvatar,
+    FakeCaption,
+    FakeExpression,
+    FakeHistory,
+    FakeLLMClient,
+    RecordingEvents,
+)
 
 # --- how much of it landed ---------------------------------------------------
 
@@ -131,20 +138,6 @@ class SilentTTS(TTSInterface):
         pass
 
 
-class Obs:
-    def set_image(self, *a, **k):
-        pass
-
-    def set_media(self, *a, **k):
-        pass
-
-    def set_text(self, *a, **k):
-        pass
-
-    async def type_text(self, **kwargs):
-        return 0
-
-
 class Config:
     text_font_size = 40
     text_line_width = 30
@@ -173,7 +166,7 @@ class Socket:
 
 def test_the_call_has_the_last_word_on_whether_she_is_talking():
     """The OBS animation only ever knew the *estimated* length of the audio."""
-    e = Expression(Config(), SilentTTS(), Obs(), Events())
+    e = Expression(Config(), SilentTTS(), FakeAvatar(), FakeCaption(), Events())
     channel = VoiceChannel()
     channel.attach(Socket())
     channel.on_message({"type": "joined", "channel_id": "c1", "listeners": 1})
@@ -190,7 +183,7 @@ def test_the_call_has_the_last_word_on_whether_she_is_talking():
 
 
 async def test_an_interruption_reaches_the_call_and_not_only_the_speakers():
-    e = Expression(Config(), SilentTTS(), Obs(), Events())
+    e = Expression(Config(), SilentTTS(), FakeAvatar(), FakeCaption(), Events())
     channel = VoiceChannel()
     channel.attach(Socket())
     channel.on_message({"type": "joined", "channel_id": "c1", "listeners": 1})

--- a/tests/test_face.py
+++ b/tests/test_face.py
@@ -1,0 +1,124 @@
+"""A mood has to look like what it feels like.
+
+`moods.py` already places every mood on two axes, and `prosody.py` already reads
+them to colour her voice. The expression weights are the third reader of the
+same numbers, and these tests are what stop them drifting apart — the same
+reflex as the `assert set(VECTORS) == set(MOODS)` at the bottom of `moods.py`.
+"""
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from src.core.expression.face import VRM_EMOTIONS, VRM_VISEMES, WEIGHTS, weights_for
+from src.core.mind.moods import MOODS, VECTORS
+
+# fetched by `make model`, gitignored: present on a developer's machine, absent in CI
+SAMPLE = Path("data/models/VRM1_Constraint_Twist_Sample.vrm")
+
+
+def positive(weights) -> float:
+    return weights.get("happy", 0.0) + weights.get("relaxed", 0.0)
+
+
+def negative(weights) -> float:
+    return weights.get("sad", 0.0) + weights.get("angry", 0.0)
+
+
+# --- the shape ---------------------------------------------------------------
+
+
+def test_every_mood_has_a_face():
+    assert set(WEIGHTS) == set(MOODS)
+
+
+def test_nothing_is_invented_that_vrm_does_not_standardise():
+    for mood, weights in WEIGHTS.items():
+        for name in weights:
+            assert name in VRM_EMOTIONS, f"{mood} asks for {name!r}, which is not a VRM preset"
+
+
+def test_every_weight_is_a_weight():
+    for mood, weights in WEIGHTS.items():
+        for name, value in weights.items():
+            assert 0.0 <= value <= 1.0, f"{mood}.{name} is {value}"
+
+
+def test_a_face_is_handed_every_emotion_so_none_is_left_behind():
+    """A face given only what changed keeps whatever it was wearing."""
+    face = weights_for("angry")
+    assert set(face) == set(VRM_EMOTIONS)
+    assert face["angry"] == 1.0
+    assert face["happy"] == 0.0
+
+
+def test_whatever_the_model_invents_still_lands_on_a_real_face():
+    assert weights_for("happy") == weights_for("love")
+    assert weights_for("nonsense-the-model-made-up") == weights_for("normal")
+
+
+# --- agreement with how she actually feels ----------------------------------
+
+
+@pytest.mark.parametrize("mood", MOODS)
+def test_a_mood_does_not_look_the_opposite_of_how_it_feels(mood):
+    """Caught a real mistake: `bored` first read as `relaxed`, which is serene.
+
+    `relaxed` in VRM means at ease. Bored has negative valence, so a face built
+    mostly out of `relaxed` made her look pleased to be ignoring you.
+    """
+    valence, _arousal = VECTORS[mood]
+    weights = WEIGHTS[mood]
+
+    if valence > 0.2:
+        assert positive(weights) > negative(weights), f"{mood} feels good but looks bad"
+    if valence < -0.2:
+        assert negative(weights) > positive(weights), f"{mood} feels bad but looks good"
+
+
+def test_the_only_neutral_face_is_the_neutral_mood():
+    for mood, weights in WEIGHTS.items():
+        if mood == "normal":
+            assert weights == {"neutral": 1.0}
+        else:
+            assert "neutral" not in weights, f"{mood} would sit under a neutral face"
+
+
+def test_the_two_moods_vrm_has_no_preset_for_are_blends():
+    """`ew` and `bored` are the only judgement calls in the table."""
+    assert len(WEIGHTS["ew"]) > 1
+    assert len(WEIGHTS["bored"]) > 1
+
+
+# --- against a model that actually exists -----------------------------------
+
+
+def gltf_json(path: Path) -> dict:
+    raw = path.read_bytes()
+    offset = 12
+    while offset < len(raw):
+        length, kind = struct.unpack_from("<II", raw, offset)
+        offset += 8
+        if kind == 0x4E4F534A:
+            return json.loads(raw[offset:offset + length].decode("utf-8"))
+        offset += length
+    raise ValueError("no JSON chunk")
+
+
+@pytest.mark.skipif(not SAMPLE.is_file(), reason="run `make model` to fetch the sample")
+def test_the_sample_model_really_has_every_face_the_table_asks_for():
+    preset = gltf_json(SAMPLE)["extensions"]["VRMC_vrm"]["expressions"]["preset"]
+
+    for mood, weights in WEIGHTS.items():
+        for name in weights:
+            assert name in preset, f"{mood} wants {name!r}, the sample model has no such expression"
+            assert preset[name].get("morphTargetBinds"), f"{name!r} drives no morph target"
+
+
+@pytest.mark.skipif(not SAMPLE.is_file(), reason="run `make model` to fetch the sample")
+def test_the_sample_model_has_a_mouth_the_lip_sync_can_move():
+    preset = gltf_json(SAMPLE)["extensions"]["VRMC_vrm"]["expressions"]["preset"]
+    assert "aa" in preset, "no 'aa' viseme: her mouth cannot move while she talks"
+    assert set(VRM_VISEMES) <= set(preset)

--- a/tests/test_model_avatar.py
+++ b/tests/test_model_avatar.py
@@ -1,0 +1,230 @@
+"""The 3D body, and the mouth that moves with it.
+
+Everything here runs without a browser: the backend publishes what she is, and
+the page is the only thing that knows what three.js is.
+"""
+
+import json
+import time
+
+import numpy as np
+import pytest
+
+from src.core.config import BrainConfig
+from src.core.expression import Expression
+from src.core.expression.pcm import envelope
+from src.core.stage import StageChannel
+from src.modules.avatar.factory import build_avatar
+from src.modules.avatar.model3d import Model3DAvatar
+from src.modules.avatar.png import PngAvatar
+from tests.fakes import FakeCaption
+
+
+class Obs:
+    def set_image(self, *a, **k):
+        pass
+
+    def set_media(self, *a, **k):
+        pass
+
+
+class SilentTTS:
+    def __init__(self, samples=24000):
+        self.samples = samples
+
+    async def generate_audio(self, text, prosody=None):
+        rng = np.random.default_rng(0)
+        return rng.normal(0, 0.2, self.samples).astype(np.float32), 24000
+
+    async def speak(self, text, output_device_id):
+        pass
+
+    def reload_config(self, config):
+        pass
+
+
+class Events:
+    def publish(self, *a, **k):
+        pass
+
+
+def config(**stage) -> BrainConfig:
+    cfg = BrainConfig()
+    cfg.stage = {**cfg.stage, "avatar_backend": "model", "model_path": "data/models/x.vrm", **stage}
+    cfg.obs_text_source = ""
+    return cfg
+
+
+# --- the lip sync ------------------------------------------------------------
+
+
+def test_the_envelope_is_cheap_enough_to_compute_before_she_speaks():
+    """It runs on the turn's critical path, between synthesis and playback."""
+    rate, seconds = 24000, 6.0
+    t = np.linspace(0, seconds, int(rate * seconds), dtype=np.float32)
+    speech = (np.sin(2 * np.pi * 180 * t) * (0.5 + 0.5 * np.sin(2 * np.pi * 4 * t)) ** 2)
+
+    started = time.perf_counter()
+    frames = envelope(speech.astype(np.float32), rate, 30)
+    elapsed = (time.perf_counter() - started) * 1000
+
+    assert len(frames) == int(seconds * 30)
+    assert max(frames) == 1.0 and min(frames) >= 0.0
+    assert elapsed < 25.0, f"{elapsed:.1f} ms is too long to sit in front of playback"
+
+
+def test_the_envelope_is_small_enough_to_send_whole():
+    rate = 24000
+    frames = envelope(np.random.default_rng(0).normal(0, 0.2, rate * 6).astype(np.float32), rate, 30)
+    payload = len(json.dumps(frames))
+    assert payload < 4000, f"{payload} bytes for six seconds is too much for one message"
+
+
+def test_silence_closes_her_mouth():
+    """Or she talks through her own pauses."""
+    rate = 24000
+    loud = np.random.default_rng(0).normal(0, 0.3, rate).astype(np.float32)
+    quiet = np.zeros(rate // 2, dtype=np.float32)
+    frames = envelope(np.concatenate([loud, quiet, loud]), rate, 30)
+
+    assert np.mean(frames[:30]) > 0.5
+    assert max(frames[30:45]) < 0.01
+    assert np.mean(frames[45:]) > 0.5
+
+
+@pytest.mark.parametrize("audio", [None, np.zeros(0, dtype=np.float32)])
+def test_nothing_to_say_moves_no_mouth(audio):
+    assert envelope(audio, 24000) == []
+
+
+def test_a_silent_buffer_does_not_divide_by_its_own_peak():
+    frames = envelope(np.zeros(24000, dtype=np.float32), 24000, 30)
+    assert frames and set(frames) == {0.0}
+
+
+# --- what the backend publishes ---------------------------------------------
+
+
+def test_the_backend_publishes_weights_not_a_mood_name():
+    """The vocabulary of moods stays in Python, where it is tested."""
+    channel = StageChannel()
+    Model3DAvatar(config(), channel).show("angry", "talking")
+
+    snapshot = channel.snapshot()
+    assert snapshot["expressions"]["angry"] == 1.0
+    assert snapshot["expressions"]["happy"] == 0.0
+    assert snapshot["state"] == "talking"
+
+
+def test_a_behaviour_plays_when_she_starts_talking_and_not_while_idle():
+    channel = StageChannel()
+    avatar = Model3DAvatar(config(mood_clips={"angry": "lean_in"}), channel)
+
+    queue = channel.subscribe()
+    avatar.show("angry", "idle")
+    avatar.show("angry", "talking")
+
+    patches = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert "perform" not in patches[0]
+    assert patches[1]["perform"] == "lean_in"
+
+
+def test_a_mood_with_no_behaviour_just_changes_face():
+    channel = StageChannel()
+    queue = channel.subscribe()
+    Model3DAvatar(config(mood_clips={}), channel).show("love", "talking")
+
+    assert "perform" not in queue.get_nowait()
+
+
+def test_an_empty_mouth_is_not_published():
+    channel = StageChannel()
+    queue = channel.subscribe()
+    Model3DAvatar(config(), channel).mouth([], 30)
+
+    assert queue.empty()
+
+
+def test_a_missing_model_is_a_warning_not_a_crash(caplog):
+    channel = StageChannel()
+    with caplog.at_level("WARNING"):
+        avatar = Model3DAvatar(config(model_path=""), channel)
+    avatar.show("normal", "idle")
+
+    assert any("model_path" in r.message for r in caplog.records)
+
+
+def test_the_backend_needs_a_channel_and_says_so_rather_than_going_quiet(caplog):
+    with caplog.at_level("WARNING"):
+        avatar = build_avatar(config(), Obs(), publisher=None)
+    assert isinstance(avatar, PngAvatar)
+
+
+# --- end to end through Expression ------------------------------------------
+
+
+async def test_speaking_hands_the_body_a_face_and_a_mouth():
+    channel = StageChannel()
+    avatar = Model3DAvatar(config(), channel)
+    expression = Expression(config(), SilentTTS(), avatar, FakeCaption(), Events())
+    queue = channel.subscribe()
+
+    await expression.speak("cry", "non ce la faccio piu")
+
+    patches = [queue.get_nowait() for _ in range(queue.qsize())]
+    faces = [p for p in patches if "expressions" in p]
+    mouths = [p for p in patches if "envelope" in p]
+
+    assert faces[0]["expressions"]["sad"] == 1.0
+    assert mouths and len(mouths[0]["envelope"]) == 30, "one second of audio at 30 fps"
+    assert mouths[0]["envelope_fps"] == 30
+
+
+async def test_the_mouth_is_told_between_the_talking_face_and_the_idle_one():
+    """The page runs the envelope off its own clock; late is out of sync.
+
+    The order on the wire is the contract: she starts talking, the mouth gets
+    the shape of the line, and only then does she settle back to idle.
+    """
+    channel = StageChannel()
+    queue = channel.subscribe()
+    expression = Expression(config(), SilentTTS(), Model3DAvatar(config(), channel),
+                            FakeCaption(), Events())
+
+    await expression.speak("normal", "ciao")
+
+    patches = [queue.get_nowait() for _ in range(queue.qsize())]
+    talking = next(i for i, p in enumerate(patches) if p.get("state") == "talking")
+    mouth = next(i for i, p in enumerate(patches) if "envelope" in p)
+    idle = next(i for i, p in enumerate(patches) if p.get("state") == "idle")
+
+    assert talking < mouth < idle
+
+
+async def test_a_lip_sync_failure_never_stops_her_from_speaking(caplog):
+    class BrokenMouth(Model3DAvatar):
+        def mouth(self, envelope, fps=30):
+            raise RuntimeError("the renderer went away")
+
+    channel = StageChannel()
+    expression = Expression(config(), SilentTTS(), BrokenMouth(config(), channel),
+                            FakeCaption(), Events())
+
+    with caplog.at_level("ERROR"):
+        await expression.speak("normal", "vado avanti comunque")
+
+    assert any("Lip sync failed" in r.message for r in caplog.records)
+    assert channel.snapshot()["state"] == "idle", "she finished the line anyway"
+
+
+def test_the_lip_sync_rate_is_configurable():
+    channel = StageChannel()
+    queue = channel.subscribe()
+    expression = Expression(config(lipsync_fps=60), SilentTTS(),
+                            Model3DAvatar(config(), channel), FakeCaption(), Events())
+
+    expression._move_mouth(np.random.default_rng(0).normal(0, 0.2, 24000).astype(np.float32), 24000)
+
+    patch = queue.get_nowait()
+    assert patch["envelope_fps"] == 60
+    assert len(patch["envelope"]) == 60

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -109,6 +109,46 @@ def test_apply_answers_applies_obs_when_it_was_accepted(tmp_path, monkeypatch):
     assert (cfg.obs_host, cfg.obs_port, cfg.obs_avatar_source) == ("10.0.0.2", 4466, "Avatar")
 
 
+# --- how she appears -------------------------------------------------------
+
+
+def test_apply_answers_leaves_the_stage_alone_when_it_was_not_asked(tmp_path, monkeypatch):
+    cfg = apply_answers(config(tmp_path, monkeypatch), base_answers())
+    assert cfg.stage["avatar_backend"] == "png"
+    assert cfg.stage["caption_backend"] == "obs"
+
+
+def test_apply_answers_takes_the_two_choices_the_wizard_offers(tmp_path, monkeypatch):
+    cfg = apply_answers(config(tmp_path, monkeypatch), base_answers(
+        stage={"avatar_backend": "model", "caption_backend": "stage",
+               "model_path": "data/models/bea.vrm"}))
+
+    assert cfg.stage["avatar_backend"] == "model"
+    assert cfg.stage["caption_backend"] == "stage"
+    assert cfg.stage["model_path"] == "data/models/bea.vrm"
+
+
+def test_the_wizard_never_has_to_ask_about_every_key_in_the_block(tmp_path, monkeypatch):
+    """It asks two questions; the rest of the block keeps its defaults."""
+    cfg = apply_answers(config(tmp_path, monkeypatch),
+                        base_answers(stage={"avatar_backend": "vtube_studio"}))
+
+    assert cfg.stage["avatar_backend"] == "vtube_studio"
+    assert cfg.stage["lipsync_fps"] == 30
+    assert cfg.stage["vts_mouth_param"] == "MouthOpen"
+
+
+def test_every_backend_the_wizard_offers_is_one_the_engine_can_build():
+    """A wizard that offers a name the factory has never heard of is a dead end."""
+    from src.modules.avatar.factory import BUILDERS as AVATARS
+    from src.modules.caption.factory import BUILDERS as CAPTIONS
+    from src.setup.wizard import AVATARS as OFFERED_AVATARS
+    from src.setup.wizard import CAPTIONS as OFFERED_CAPTIONS
+
+    assert {a[0] for a in OFFERED_AVATARS} <= set(AVATARS)
+    assert {c[0] for c in OFFERED_CAPTIONS} <= set(CAPTIONS)
+
+
 def test_saved_config_carries_no_secret(tmp_path, monkeypatch):
     cfg = apply_answers(config(tmp_path, monkeypatch), base_answers())
     cfg.save_to_file()

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -307,3 +307,56 @@ def test_a_configured_model_that_is_not_on_disk_names_the_path(client, tmp_path)
     response = api.get("/stage/model")
     assert response.status_code == 404
     assert str(missing) in response.json()["detail"]
+
+
+# --- settings reaching a running page ----------------------------------------
+
+
+def test_the_public_config_is_the_same_whether_read_or_pushed(client):
+    """The endpoint and the live patch must not describe her differently."""
+    from src.core.stage import public_config
+
+    api, stub = client
+    assert api.get("/stage/config").json() == public_config(stub.config)
+
+
+def test_the_page_is_told_when_the_model_changes(tmp_path):
+    """A different file under the same path still has to reach the renderer."""
+    from src.core.config import BrainConfig
+    from src.core.stage import public_config
+
+    model = tmp_path / "bea.vrm"
+    model.write_bytes(b"glTF-ish")
+    config = BrainConfig()
+    config.stage = {**config.stage, "model_path": str(model)}
+
+    before = public_config(config)["model_id"]
+    import os
+    os.utime(model, (0, 0))
+    after = public_config(config)["model_id"]
+
+    assert before and after and before != after
+
+
+def test_a_model_that_is_not_there_still_has_an_id(tmp_path):
+    from src.core.config import BrainConfig
+    from src.core.stage import public_config
+
+    config = BrainConfig()
+    config.stage = {**config.stage, "model_path": str(tmp_path / "gone.vrm")}
+    assert public_config(config)["model_id"] == "gone.vrm"
+
+
+def test_no_model_configured_means_no_id():
+    from src.core.config import BrainConfig
+    from src.core.stage import public_config
+
+    assert public_config(BrainConfig())["model_id"] == ""
+
+
+def test_the_transparent_background_is_the_default():
+    """OBS composites the page, so anything painted is on the stream."""
+    from src.core.config import BrainConfig
+    from src.core.stage import public_config
+
+    assert public_config(BrainConfig())["background"] == ""

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -258,3 +258,52 @@ async def test_the_engine_is_never_slowed_down_by_a_page(monkeypatch):
             channel.publish({"mood": f"m{i}"})
 
     await asyncio.wait_for(publish_many(), timeout=1.0)
+
+
+# --- the model and the behaviours it plays ----------------------------------
+
+
+def test_a_behaviour_name_cannot_walk_out_of_the_clips_folder(client, tmp_path):
+    """The name comes from a page, so it is untrusted input.
+
+    Driven through the route function rather than through the test client:
+    httpx normalises `..` out of a URL before it is ever sent, so going through
+    a client would test httpx and not the guard that has to hold when something
+    less polite asks.
+    """
+    from fastapi import HTTPException
+
+    from src.web import app as web
+
+    _api, stub = client
+    (tmp_path / "clips").mkdir()
+    (tmp_path / "secret.vrma").write_text("not a clip")
+    stub.config.stage = {**stub.config.stage, "clips_dir": str(tmp_path / "clips")}
+
+    for name in ("../secret", "../../etc/passwd", "/etc/passwd"):
+        with pytest.raises(HTTPException) as raised:
+            web.stage_clip(name)
+        assert raised.value.status_code == 404
+
+
+def test_the_clip_list_is_empty_rather_than_broken_without_a_folder(client):
+    api, stub = client
+    stub.config.stage = {**stub.config.stage, "clips_dir": "no/such/folder"}
+    assert api.get("/stage/clips").json() == []
+
+
+def test_asking_for_a_model_that_is_not_configured_says_so(client):
+    api, stub = client
+    stub.config.stage = {**stub.config.stage, "model_path": ""}
+    response = api.get("/stage/model")
+    assert response.status_code == 404
+    assert "configured" in response.json()["detail"].lower()
+
+
+def test_a_configured_model_that_is_not_on_disk_names_the_path(client, tmp_path):
+    api, stub = client
+    missing = tmp_path / "bea.vrm"
+    stub.config.stage = {**stub.config.stage, "model_path": str(missing)}
+    response = api.get("/stage/model")
+    assert response.status_code == 404
+    assert str(missing) in response.json()["detail"]

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,0 +1,260 @@
+"""The channel the browser source listens on.
+
+Deliberately not the dashboard's event stream: OBS reloads a browser source
+whenever you toggle it, and a backlog replay would have her act out the last
+minute of the stream again.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from src.core.config import BrainConfig
+from src.core.stage import QUEUE_LIMIT, StageChannel
+from src.modules.caption.factory import build_caption
+from src.modules.caption.obs_text import ObsTextCaption
+from src.modules.caption.stage import StageCaption
+from src.modules.obs.obs_websocket import OBSController
+
+
+class Obs:
+    def set_image(self, *a, **k):
+        pass
+
+    def set_media(self, *a, **k):
+        pass
+
+    def set_text(self, *a, **k):
+        pass
+
+    async def type_text(self, **kwargs):
+        return 0
+
+
+# --- the channel -------------------------------------------------------------
+
+
+def test_a_page_that_connects_is_told_how_she_looks_now():
+    channel = StageChannel()
+    channel.publish({"mood": "angry", "state": "talking"})
+
+    assert channel.snapshot()["mood"] == "angry"
+    assert channel.snapshot()["state"] == "talking"
+
+
+def test_a_reconnecting_page_gets_no_backlog_to_act_out():
+    """The whole reason this is not EventManager."""
+    channel = StageChannel()
+    for mood in ("love", "cry", "angry"):
+        channel.publish({"mood": mood})
+
+    queue = channel.subscribe()
+
+    assert queue.empty(), "a fresh subscriber must start from the snapshot, not a log"
+    assert channel.snapshot()["mood"] == "angry"
+
+
+def test_a_moment_is_not_remembered_as_a_state():
+    """An envelope kept in the snapshot would mouth a sentence long finished."""
+    channel = StageChannel()
+    channel.publish({"mood": "love", "envelope": [0.1, 0.2], "perform": "wave"})
+
+    snapshot = channel.snapshot()
+    assert snapshot["mood"] == "love"
+    assert "envelope" not in snapshot
+    assert "perform" not in snapshot
+
+
+def test_subscribers_are_handed_the_patch_and_not_the_whole_state():
+    channel = StageChannel()
+    queue = channel.subscribe()
+
+    channel.publish({"mood": "shock"})
+
+    assert queue.get_nowait() == {"mood": "shock"}
+
+
+def test_a_page_that_stopped_reading_is_dropped_not_waited_for():
+    """The engine must never block on a browser source that walked away."""
+    channel = StageChannel()
+    channel.subscribe()
+
+    for i in range(QUEUE_LIMIT + 5):
+        channel.publish({"mood": f"m{i}"})
+
+    assert channel.subscriber_count == 0
+
+
+def test_closing_the_channel_lets_go_of_every_page():
+    channel = StageChannel()
+    channel.subscribe()
+    channel.close()
+    assert channel.subscriber_count == 0
+
+
+# --- the caption backends compared ------------------------------------------
+
+
+async def test_a_caption_crosses_the_wire_once_instead_of_once_per_character():
+    """The measurement that justified the whole browser source.
+
+    `OBSController.type_text` calls `set_input_settings` for every character of
+    every page, re-sending the font block each time.
+    """
+    line = ("Ok allora sentite questa, perche' e' veramente assurda: "
+            "ieri sera uno in chat mi ha detto che non sono una vera vtuber "
+            "solo perche' non ho un corpo. Ridicolo.")
+
+    class CountingClient:
+        def __init__(self):
+            self.calls = 0
+
+        def set_input_settings(self, name, settings, overlay):
+            self.calls += 1
+
+        def send(self, *a, **k):
+            return {"inputSettings": {"font": {"face": "Arial", "size": 75}}}
+
+    class Config:
+        obs_text_source = "AIText"
+        text_line_width = 40
+        text_lines = 4
+        text_font_size = 75
+        text_min_font_size = 55
+        text_font_step = 2
+        typing_delay = 0.0
+        text_min_duration = 0.0
+
+    obs = OBSController("localhost", 4455, "", "BeaPNG")
+    obs.client = CountingClient()
+    await ObsTextCaption(Config(), obs).say(line)
+
+    channel = StageChannel()
+    queue = channel.subscribe()
+    await StageCaption(Config(), channel).say(line)
+
+    assert obs.client.calls > len(line), "the OBS path is one request per character"
+    assert queue.qsize() == 1, "the stage path is one message per line"
+
+
+async def test_each_line_carries_an_id_so_a_reload_does_not_retype_it():
+    channel = StageChannel()
+    caption = StageCaption(BrainConfig(), channel)
+
+    await caption.say("prima")
+    first = channel.snapshot()["caption_id"]
+    await caption.say("seconda")
+
+    assert first and channel.snapshot()["caption_id"] != first
+
+
+async def test_clearing_leaves_nothing_for_a_reconnecting_page_to_show():
+    channel = StageChannel()
+    caption = StageCaption(BrainConfig(), channel)
+
+    await caption.say("qualcosa")
+    caption.clear()
+
+    assert channel.snapshot()["caption"] == ""
+
+
+def test_the_stage_caption_refuses_to_be_built_without_somewhere_to_publish():
+    """Better the OBS bubble than a caption that silently goes nowhere."""
+    config = BrainConfig()
+    config.stage = {**config.stage, "caption_backend": "stage"}
+
+    caption = build_caption(config, Obs(), publisher=None)
+
+    assert isinstance(caption, ObsTextCaption)
+
+
+# --- the endpoint ------------------------------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from src.web import app as web
+
+    class BrainStub:
+        def __init__(self):
+            self.config = BrainConfig()
+            self.stage = StageChannel()
+
+    stub = BrainStub()
+    previous = web.brain_instance
+    web.brain_instance = stub
+    try:
+        yield TestClient(web.app), stub
+    finally:
+        web.brain_instance = previous
+
+
+async def test_the_stream_opens_with_a_snapshot_before_any_patch(client):
+    """Driven directly: an SSE endpoint never ends, so a client would hang."""
+    from src.web import app as web
+
+    _api, stub = client
+    stub.stage.publish({"mood": "cry", "state": "talking"})
+
+    class Disconnected:
+        async def is_disconnected(self):
+            return True
+
+    response = await web.stage_stream(Disconnected())
+    first = await response.body_iterator.__anext__()
+
+    payload = json.loads(first[len("data: "):])
+    assert payload["type"] == "snapshot"
+    assert payload["mood"] == "cry"
+    assert payload["state"] == "talking"
+
+
+async def test_the_stream_lets_go_of_the_queue_when_the_page_leaves(client):
+    from src.web import app as web
+
+    _api, stub = client
+
+    class Disconnected:
+        async def is_disconnected(self):
+            return True
+
+    response = await web.stage_stream(Disconnected())
+    async for _chunk in response.body_iterator:
+        pass
+
+    assert stub.stage.subscriber_count == 0
+
+
+def test_the_stage_config_never_carries_a_secret(client):
+    api, _ = client
+    payload = api.get("/stage/config").json()
+
+    flat = json.dumps(payload).lower()
+    for word in ("key", "token", "password", "secret"):
+        assert word not in flat, f"the browser source must not be told the {word}"
+
+
+def test_the_preview_only_serves_images_the_avatar_map_names(client, tmp_path):
+    """A preview that served any path in the query string would read any file."""
+    api, stub = client
+    secret = tmp_path / "id_rsa"
+    secret.write_text("not an avatar")
+    stub.config.avatar_map = {"normal": {"idle": "", "talking": ""}}
+
+    assert api.get("/stage/preview", params={"mood": "normal"}).status_code == 404
+    assert api.get("/stage/preview", params={"mood": str(secret)}).status_code == 404
+
+
+async def test_the_engine_is_never_slowed_down_by_a_page(monkeypatch):
+    """Publishing is synchronous and must stay non-blocking under any reader."""
+    channel = StageChannel()
+    channel.subscribe()
+
+    async def publish_many():
+        for i in range(50):
+            channel.publish({"mood": f"m{i}"})
+
+    await asyncio.wait_for(publish_many(), timeout=1.0)

--- a/tests/test_voice_prosody.py
+++ b/tests/test_voice_prosody.py
@@ -12,6 +12,7 @@ from src.core.expression.prosody import Prosody, for_mood
 from src.core.expression.voice import Expression
 from src.interfaces.base_interfaces import TTSInterface
 from src.modules.tts.edge_tts_wrapper import EdgeTTSWrapper
+from tests.fakes import FakeAvatar, FakeCaption
 
 T0 = 1_000_000.0
 
@@ -47,20 +48,6 @@ class Affects:
         self.enabled = enabled
 
 
-class Obs:
-    def set_image(self, *a, **k):
-        pass
-
-    def set_media(self, *a, **k):
-        pass
-
-    def set_text(self, *a, **k):
-        pass
-
-    async def type_text(self, **kwargs):
-        return 0
-
-
 class Events:
     def publish(self, *a, **k):
         pass
@@ -80,8 +67,7 @@ class Config:
 
 
 def expression(tts) -> Expression:
-    e = Expression(Config(), tts, Obs(), Events())
-    e.set_png_map({})
+    e = Expression(Config(), tts, FakeAvatar(), FakeCaption(), Events())
     return e
 
 

--- a/tests/test_voice_streaming.py
+++ b/tests/test_voice_streaming.py
@@ -13,6 +13,7 @@ from src.core.expression.pcm import duration_ms
 from src.core.expression.voice import Expression
 from src.core.skills.voice.channel import VoiceChannel, unframe
 from src.interfaces.base_interfaces import TTSInterface
+from tests.fakes import FakeAvatar, FakeCaption
 
 # --- where a line gets cut ---------------------------------------------------
 
@@ -101,20 +102,6 @@ class ChunkedTTS(OneShotTTS):
             yield np.zeros(800, dtype=np.float32), 24000
 
 
-class Obs:
-    def set_image(self, *a, **k):
-        pass
-
-    def set_media(self, *a, **k):
-        pass
-
-    def set_text(self, *a, **k):
-        pass
-
-    async def type_text(self, **kwargs):
-        return 0
-
-
 class Events:
     def publish(self, *a, **k):
         pass
@@ -134,8 +121,7 @@ class Config:
 
 
 def expression(tts) -> Expression:
-    e = Expression(Config(), tts, Obs(), Events())
-    e.set_png_map({})
+    e = Expression(Config(), tts, FakeAvatar(), FakeCaption(), Events())
     return e
 
 

--- a/tests/test_vtube_studio.py
+++ b/tests/test_vtube_studio.py
@@ -335,3 +335,65 @@ async def test_vtube_studio_not_running_is_reported_and_not_raised(tmp_path, mon
     assert found["ok"] is False
     assert "refused" in found["message"]
     assert found["expressions"] == [] and found["hotkeys"] == []
+
+
+# --- the endpoints the dashboard calls ---------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    from fastapi.testclient import TestClient
+
+    from src.web import app as web
+
+    class BrainStub:
+        def __init__(self):
+            self.config = config()
+
+    stub = BrainStub()
+    previous = web.brain_instance
+    web.brain_instance = stub
+    try:
+        yield TestClient(web.app), stub
+    finally:
+        web.brain_instance = previous
+
+
+def test_the_connection_test_reports_a_failure_instead_of_blowing_up(client, monkeypatch):
+    """`detail` is a str: answering None here raised where it should report.
+
+    This is the path that runs when VTube Studio is not open — the single most
+    likely thing to happen when somebody first tries the backend.
+    """
+    async def refuse(url, **kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("websockets.connect", refuse)
+    api, _ = client
+
+    response = api.post("/test/vts")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert "refused" in body["message"]
+    assert body["detail"] == ""
+
+
+def test_the_connection_test_counts_what_the_model_offers(client, monkeypatch):
+    socket = FakeSocket(answers={
+        "CurrentModelRequest": {"modelLoaded": True, "modelName": "Hiyori"},
+        "ExpressionStateRequest": {"expressions": [{"name": "a", "file": "a.exp3.json"}]},
+        "HotkeysInCurrentModelRequest": {"availableHotkeys": [{"hotkeyID": "h", "name": "Wave"}]},
+    })
+
+    async def fake_connect(url, **kwargs):
+        return socket
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+    api, _ = client
+
+    body = api.post("/test/vts").json()
+
+    assert body["ok"] is True
+    assert body["detail"] == "1 expressions, 1 hotkeys"

--- a/tests/test_vtube_studio.py
+++ b/tests/test_vtube_studio.py
@@ -1,0 +1,337 @@
+"""Driving a Live2D model that belongs to the user, over the VTube Studio API.
+
+Nothing here talks to a real VTube Studio: the socket is faked, and what is
+checked is the protocol projectBEA speaks and the promises the port makes —
+above all that a slow or absent VTube Studio never makes her wait.
+
+Protocol reference: https://github.com/DenchiSoft/VTubeStudio
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from src.core.config import BrainConfig
+from src.modules.avatar.vtube_studio import (
+    API_NAME,
+    API_VERSION,
+    VTubeStudioAvatar,
+    VTubeStudioClient,
+    VTubeStudioError,
+    probe,
+)
+
+
+class FakeSocket:
+    """A VTube Studio that answers whatever the test tells it to."""
+
+    def __init__(self, answers=None, authenticated=True, token="tok-123"):
+        self.sent = []
+        self.closed = False
+        self.answers = answers or {}
+        self.authenticated = authenticated
+        self.token = token
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+    async def recv(self):
+        request = self.sent[-1]
+        kind = request["messageType"]
+        if kind in self.answers:
+            data = self.answers[kind]
+        elif kind == "AuthenticationTokenRequest":
+            data = {"authenticationToken": self.token}
+        elif kind == "AuthenticationRequest":
+            data = {"authenticated": self.authenticated, "reason": "nope"}
+        else:
+            data = {}
+        return json.dumps({"messageType": f"{kind[:-7]}Response", "data": data})
+
+    async def close(self):
+        self.closed = True
+
+    def of_type(self, kind):
+        return [m for m in self.sent if m["messageType"] == kind]
+
+
+def client_with(socket, tmp_path, **kwargs) -> VTubeStudioClient:
+    client = VTubeStudioClient("127.0.0.1", 8001, tmp_path / "token.json", **kwargs)
+    client._socket = socket
+    return client
+
+
+def config(**stage) -> BrainConfig:
+    cfg = BrainConfig()
+    cfg.stage = {**cfg.stage, "avatar_backend": "vtube_studio", **stage}
+    return cfg
+
+
+# --- the protocol ------------------------------------------------------------
+
+
+async def test_every_request_carries_the_envelope_the_api_documents(tmp_path):
+    socket = FakeSocket()
+    await client_with(socket, tmp_path).trigger("hk-1")
+
+    sent = socket.sent[-1]
+    assert sent["apiName"] == API_NAME
+    assert sent["apiVersion"] == API_VERSION
+    assert sent["messageType"] == "HotkeyTriggerRequest"
+    assert sent["requestID"]
+    assert sent["data"] == {"hotkeyID": "hk-1"}
+
+
+async def test_the_mouth_is_set_rather_than_added_to(tmp_path):
+    """"add" lets other plugins move it too; while she talks the mouth is hers."""
+    socket = FakeSocket()
+    await client_with(socket, tmp_path).set_parameter("MouthOpen", 0.6667)
+
+    data = socket.sent[-1]["data"]
+    assert data["mode"] == "set"
+    assert data["faceFound"] is False
+    assert data["parameterValues"] == [{"id": "MouthOpen", "value": 0.667}]
+
+
+async def test_an_api_error_is_raised_and_not_read_as_a_result(tmp_path):
+    class Angry(FakeSocket):
+        async def recv(self):
+            return json.dumps({"messageType": "APIError",
+                               "data": {"errorID": 8, "message": "no model loaded"}})
+
+    with pytest.raises(VTubeStudioError, match="no model loaded"):
+        await client_with(Angry(), tmp_path).current_model()
+
+
+# --- being allowed in --------------------------------------------------------
+
+
+async def test_the_first_connection_asks_to_be_allowed_and_keeps_the_token(tmp_path, monkeypatch):
+    socket = FakeSocket()
+    client = VTubeStudioClient("127.0.0.1", 8001, tmp_path / "token.json")
+
+    async def fake_connect(url, **kwargs):
+        return socket
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+    await client.connect()
+
+    assert socket.of_type("AuthenticationTokenRequest"), "it must ask the user"
+    assert json.loads((tmp_path / "token.json").read_text())["token"] == "tok-123"
+
+
+async def test_a_stored_token_is_reused_instead_of_asking_again(tmp_path, monkeypatch):
+    (tmp_path / "token.json").write_text(json.dumps({"token": "already-allowed"}))
+    socket = FakeSocket()
+
+    async def fake_connect(url, **kwargs):
+        return socket
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+    await VTubeStudioClient("127.0.0.1", 8001, tmp_path / "token.json").connect()
+
+    assert not socket.of_type("AuthenticationTokenRequest")
+    assert socket.of_type("AuthenticationRequest")[0]["data"]["authenticationToken"] == "already-allowed"
+
+
+async def test_a_token_that_no_longer_works_is_thrown_away(tmp_path, monkeypatch):
+    """Otherwise she would fail with the same dead token forever."""
+    token_file = tmp_path / "token.json"
+    token_file.write_text(json.dumps({"token": "revoked"}))
+
+    async def fake_connect(url, **kwargs):
+        return FakeSocket(authenticated=False)
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+    with pytest.raises(VTubeStudioError):
+        await VTubeStudioClient("127.0.0.1", 8001, token_file).connect()
+
+    assert not token_file.exists()
+
+
+def test_the_token_is_never_kept_in_the_config(tmp_path):
+    """`/config` is unauthenticated, so a credential must not live there."""
+    flat = json.dumps(BrainConfig().stage).lower()
+    assert "token" not in flat
+
+
+# --- the port's promises -----------------------------------------------------
+
+
+def test_nothing_blocks_when_vtube_studio_is_not_there():
+    """Every call is synchronous and must return whether or not it is running."""
+    avatar = VTubeStudioAvatar(config(vts_expressions={"angry": "angry.exp3.json"}))
+
+    avatar.show("angry", "talking")
+    avatar.perform("wave")
+    avatar.mouth([0.2, 0.9], 30)
+    avatar.close()
+
+
+async def test_a_mood_becomes_the_expression_file_the_users_model_has(tmp_path):
+    avatar = VTubeStudioAvatar(
+        config(vts_expressions={"angry": "furious.exp3.json"}), tmp_path / "token.json")
+
+    avatar.show("angry", "talking")
+    kind, value = avatar._commands.get_nowait()
+
+    assert (kind, value) == ("expression", "furious.exp3.json")
+
+
+async def test_a_mood_with_no_expression_mapped_asks_for_none(tmp_path):
+    avatar = VTubeStudioAvatar(config(vts_expressions={}), tmp_path / "token.json")
+    avatar.show("angry", "idle")
+    assert avatar._commands.get_nowait() == ("expression", None)
+
+
+async def test_a_behaviour_becomes_the_hotkey_id_it_is_mapped_to(tmp_path):
+    avatar = VTubeStudioAvatar(config(vts_clips={"wave": "hk-42"}), tmp_path / "token.json")
+    avatar.perform("wave")
+    assert avatar._commands.get_nowait() == ("hotkey", "hk-42")
+
+
+async def test_an_unmapped_behaviour_is_passed_through_as_a_hotkey_name(tmp_path):
+    """VTube Studio accepts a hotkey's name as well as its id."""
+    avatar = VTubeStudioAvatar(config(vts_clips={}), tmp_path / "token.json")
+    avatar.perform("Wave hand")
+    assert avatar._commands.get_nowait() == ("hotkey", "Wave hand")
+
+
+async def test_a_backlog_keeps_the_newest_face_not_the_oldest(tmp_path):
+    """If she outruns VTube Studio, the face she has now is the right one."""
+    avatar = VTubeStudioAvatar(config(), tmp_path / "token.json")
+    for i in range(avatar._commands.maxsize + 5):
+        avatar._enqueue(("expression", f"e{i}.exp3.json"))
+
+    queued = []
+    while not avatar._commands.empty():
+        queued.append(avatar._commands.get_nowait()[1])
+
+    assert queued[-1] == f"e{avatar._commands.maxsize + 4}.exp3.json"
+    assert len(queued) <= avatar._commands.maxsize
+
+
+async def test_only_one_expression_is_active_at_a_time(tmp_path):
+    """VTS leaves an expression on until told otherwise; they would stack up."""
+    socket = FakeSocket()
+    client = client_with(socket, tmp_path)
+    avatar = VTubeStudioAvatar(config(), tmp_path / "token.json")
+
+    await avatar._apply_expression(client, "a.exp3.json")
+    await avatar._apply_expression(client, "b.exp3.json")
+
+    calls = [m["data"] for m in socket.of_type("ExpressionActivationRequest")]
+    assert calls[0] == {"expressionFile": "a.exp3.json", "fadeTime": 0.25, "active": True}
+    assert calls[1] == {"expressionFile": "a.exp3.json", "fadeTime": 0.25, "active": False}
+    assert calls[2] == {"expressionFile": "b.exp3.json", "fadeTime": 0.25, "active": True}
+
+
+async def test_asking_for_the_same_face_twice_says_nothing_twice(tmp_path):
+    socket = FakeSocket()
+    client = client_with(socket, tmp_path)
+    avatar = VTubeStudioAvatar(config(), tmp_path / "token.json")
+
+    await avatar._apply_expression(client, "a.exp3.json")
+    await avatar._apply_expression(client, "a.exp3.json")
+
+    assert len(socket.of_type("ExpressionActivationRequest")) == 1
+
+
+# --- the mouth ---------------------------------------------------------------
+
+
+async def test_the_mouth_is_paced_here_because_vtube_studio_has_no_clock(tmp_path):
+    """The browser gets the whole envelope; VTS needs one message per frame."""
+    socket = FakeSocket()
+    avatar = VTubeStudioAvatar(config(), tmp_path / "token.json")
+    avatar._connected = client_with(socket, tmp_path)
+
+    await avatar._run_mouth([0.1, 0.5, 0.9], fps=1000)
+
+    values = [m["data"]["parameterValues"][0]["value"]
+              for m in socket.of_type("InjectParameterDataRequest")]
+    assert values[:3] == [0.1, 0.5, 0.9]
+    assert values[-1] == 0.0, "her mouth must close when the line ends"
+
+
+async def test_an_interrupted_line_closes_her_mouth(tmp_path):
+    socket = FakeSocket()
+    avatar = VTubeStudioAvatar(config(), tmp_path / "token.json")
+    avatar._connected = client_with(socket, tmp_path)
+
+    task = asyncio.get_running_loop().create_task(avatar._run_mouth([0.5] * 100, fps=50))
+    await asyncio.sleep(0.03)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    values = [m["data"]["parameterValues"][0]["value"]
+              for m in socket.of_type("InjectParameterDataRequest")]
+    assert values[-1] == 0.0
+
+
+async def test_a_mouth_with_nowhere_to_go_is_not_an_error(tmp_path):
+    avatar = VTubeStudioAvatar(config(), tmp_path / "token.json")
+    await avatar._run_mouth([0.5], fps=1000)
+
+
+async def test_the_mouth_parameter_is_configurable(tmp_path):
+    socket = FakeSocket()
+    avatar = VTubeStudioAvatar(config(vts_mouth_param="ParamMouthOpenY"), tmp_path / "token.json")
+    avatar._connected = client_with(socket, tmp_path)
+
+    await avatar._run_mouth([0.4], fps=1000)
+
+    assert socket.sent[0]["data"]["parameterValues"][0]["id"] == "ParamMouthOpenY"
+
+
+# --- what the dashboard asks -------------------------------------------------
+
+
+async def test_the_dashboard_is_told_what_the_users_model_actually_has(tmp_path, monkeypatch):
+    socket = FakeSocket(answers={
+        "CurrentModelRequest": {"modelLoaded": True, "modelName": "Hiyori"},
+        "ExpressionStateRequest": {"expressions": [
+            {"name": "angry", "file": "angry.exp3.json"},
+            {"name": "smile", "file": "smile.exp3.json"},
+        ]},
+        "HotkeysInCurrentModelRequest": {"availableHotkeys": [
+            {"hotkeyID": "hk-1", "name": "Wave"},
+        ]},
+    })
+
+    async def fake_connect(url, **kwargs):
+        return socket
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+    found = await probe(config(), tmp_path / "token.json")
+
+    assert found["ok"] and found["model"] == "Hiyori"
+    assert found["expressions"] == ["angry.exp3.json", "smile.exp3.json"]
+    assert found["hotkeys"] == [{"id": "hk-1", "name": "Wave"}]
+
+
+async def test_vtube_studio_running_with_no_model_says_exactly_that(tmp_path, monkeypatch):
+    socket = FakeSocket(answers={"CurrentModelRequest": {"modelLoaded": False}})
+
+    async def fake_connect(url, **kwargs):
+        return socket
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+    found = await probe(config(), tmp_path / "token.json")
+
+    assert found["ok"] and found["model"] is None
+    assert "no model is loaded" in found["message"].lower()
+
+
+async def test_vtube_studio_not_running_is_reported_and_not_raised(tmp_path, monkeypatch):
+    async def refuse(url, **kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("websockets.connect", refuse)
+    found = await probe(config(), tmp_path / "token.json")
+
+    assert found["ok"] is False
+    assert "refused" in found["message"]
+    assert found["expressions"] == [] and found["hotkeys"] == []

--- a/tools/fetch_model.py
+++ b/tools/fetch_model.py
@@ -1,0 +1,79 @@
+"""Downloads the free sample model and the free sample clip.
+
+No model ships with projectBEA, for the same reason no speech model does: it is
+11 MB of binary that most people will replace with their own, and a repository
+is a bad place to keep either. `.gitignore` already treats large models this way.
+
+The default is pixiv's VRM 1.0 sample, from the MIT-licensed `pixiv/three-vrm`
+repository. Its own embedded metadata allows redistribution, commercial use and
+requires no credit — run `tools/inspect_vrm.py` on it and it will tell you so
+itself.
+"""
+
+import argparse
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+RAW = "https://raw.githubusercontent.com/pixiv/three-vrm/dev/packages/three-vrm-animation/examples/models"
+
+DOWNLOADS = [
+    ("VRM1_Constraint_Twist_Sample.vrm", f"{RAW}/VRM1_Constraint_Twist_Sample.vrm", "data/models"),
+    ("test.vrma", f"{RAW}/test.vrma", "data/clips"),
+]
+
+
+def fetch(name: str, url: str, into: Path) -> bool:
+    into.mkdir(parents=True, exist_ok=True)
+    target = into / name
+
+    if target.exists():
+        print(f"  {target} is already here ({target.stat().st_size / 1e6:.2f} MB)")
+        return True
+
+    print(f"  {name} -> {target}")
+    try:
+        with urllib.request.urlopen(url, timeout=120) as response:
+            total = int(response.headers.get("content-length") or 0)
+            written = 0
+            # written next to the target and renamed, so an interrupted download
+            # never leaves a half a model behind for the engine to choke on
+            partial = target.with_suffix(target.suffix + ".part")
+            with open(partial, "wb") as out:
+                while True:
+                    chunk = response.read(1 << 16)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    written += len(chunk)
+                    if total:
+                        print(f"\r    {written * 100 // total}%", end="", flush=True)
+            print("\r    done   ")
+            partial.rename(target)
+        return True
+    except (urllib.error.URLError, OSError) as e:
+        print(f"    failed: {e}")
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models-dir", type=Path, default=Path("data/models"))
+    parser.add_argument("--clips-dir", type=Path, default=Path("data/clips"))
+    args = parser.parse_args()
+
+    print("Fetching the sample model and clip (nothing is committed to the repo):")
+    ok = True
+    for name, url, default_dir in DOWNLOADS:
+        into = args.models_dir if default_dir.endswith("models") else args.clips_dir
+        ok = fetch(name, url, into) and ok
+
+    if ok:
+        print("\nPoint `stage.model_path` at the .vrm in the dashboard, under Stream.")
+        print("Read what it allows:  uv run python tools/inspect_vrm.py data/models/*.vrm")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/inspect_vrm.py
+++ b/tools/inspect_vrm.py
@@ -1,0 +1,192 @@
+"""What a .vrm or .vrma actually contains, and what its licence allows.
+
+A VRM carries its own terms of use inside the file — who may use the avatar,
+whether commercial use is allowed, whether it may be redistributed. That is
+worth reading *before* you put a model on stream, and it is the only model
+format that lets you.
+
+    uv run python tools/inspect_vrm.py data/models/bea.vrm
+"""
+
+import argparse
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+GLB_MAGIC = 0x46546C67
+CHUNK_JSON = 0x4E4F534A
+
+# the five emotions and the five mouth shapes VRM 1.0 standardises
+EMOTIONS = ("happy", "angry", "sad", "relaxed", "surprised", "neutral")
+VISEMES = ("aa", "ih", "ou", "ee", "oh")
+
+# what the licence fields mean, in words rather than enum values
+MEANING = {
+    "avatarPermission": {
+        "onlyAuthor": "only the author may use this avatar",
+        "onlySeparatelyLicensedPerson": "only people licensed separately by the author",
+        "everyone": "anyone may use this avatar",
+    },
+    "commercialUsage": {
+        "personalNonProfit": "personal, non-profit use only",
+        "personalProfit": "an individual may use it commercially",
+        "corporation": "companies may use it commercially",
+    },
+    "creditNotation": {
+        "required": "you must credit the author",
+        "unnecessary": "no credit required",
+    },
+}
+
+
+def gltf_json(path: Path) -> Dict[str, Any]:
+    """The JSON chunk of a GLB container. Both .vrm and .vrma are GLB files."""
+    raw = path.read_bytes()
+    if len(raw) < 12:
+        raise ValueError(f"{path.name} is too small to be a glTF binary")
+    magic, _version, total = struct.unpack_from("<III", raw, 0)
+    if magic != GLB_MAGIC:
+        raise ValueError(f"{path.name} is not a glTF binary (.vrm/.vrma/.glb)")
+
+    offset = 12
+    while offset < min(total, len(raw)):
+        length, kind = struct.unpack_from("<II", raw, offset)
+        offset += 8
+        if kind == CHUNK_JSON:
+            return json.loads(raw[offset:offset + length].decode("utf-8"))
+        offset += length
+    raise ValueError(f"{path.name} has no JSON chunk")
+
+
+def triangles(gltf: Dict[str, Any]) -> int:
+    accessors = gltf.get("accessors", [])
+    total = 0
+    for mesh in gltf.get("meshes", []):
+        for primitive in mesh.get("primitives", []):
+            index = primitive.get("indices")
+            if index is not None and index < len(accessors):
+                total += accessors[index].get("count", 0) // 3
+    return total
+
+
+def report_model(path: Path, gltf: Dict[str, Any]) -> int:
+    """Prints what the file is and returns the number of problems found."""
+    problems = 0
+    extensions = gltf.get("extensions", {})
+    vrm1 = extensions.get("VRMC_vrm")
+    vrm0 = extensions.get("VRM")
+
+    if not vrm1 and not vrm0:
+        print("  NOT a VRM. It is a plain glTF/GLB: no standard bone names, no")
+        print("  standard expressions, so nothing can be mapped onto it.")
+        print("  Convert it to VRM first (UniVRM in Unity, or the Blender VRM add-on).")
+        return 1
+
+    if vrm0:
+        print("  VRM 0.x — supported, and turned to face the camera automatically.")
+        groups = vrm0.get("blendShapeMaster", {}).get("blendShapeGroups", [])
+        names = [g.get("presetName") or g.get("name") for g in groups]
+        print(f"  blend shape groups: {', '.join(n for n in names if n) or 'NONE'}")
+        return problems
+
+    print(f"  VRM {vrm1.get('specVersion', '1.0')}")
+
+    meta = vrm1.get("meta", {})
+    print("\n  Licence, as the file itself declares it")
+    print(f"    name:     {meta.get('name', '(unnamed)')}")
+    print(f"    authors:  {', '.join(meta.get('authors', [])) or '(none)'}")
+    for key in ("avatarPermission", "commercialUsage", "creditNotation"):
+        value = meta.get(key)
+        if value is not None:
+            print(f"    {key}: {value} — {MEANING.get(key, {}).get(value, '?')}")
+    redistribution = meta.get("allowRedistribution")
+    if redistribution is not None:
+        allowed = "yes" if redistribution else "NO"
+        print(f"    allowRedistribution: {allowed}"
+              + ("" if redistribution else "  <- do not commit this file"))
+    if meta.get("licenseUrl"):
+        print(f"    licenceUrl: {meta['licenseUrl']}")
+
+    bones = vrm1.get("humanoid", {}).get("humanBones", {})
+    print(f"\n  Rig: {len(bones)} humanoid bones")
+    for required in ("hips", "spine", "head"):
+        if required not in bones:
+            print(f"    MISSING {required} — clips and framing will not work")
+            problems += 1
+
+    preset = vrm1.get("expressions", {}).get("preset", {})
+    emotions = [n for n in EMOTIONS if n in preset]
+    visemes = [n for n in VISEMES if n in preset]
+    print(f"\n  Expressions: {len(preset)} presets")
+    print(f"    emotions: {', '.join(emotions) or 'NONE'}")
+    print(f"    visemes:  {', '.join(visemes) or 'NONE'}")
+    if not emotions:
+        print("    She will have one face for every mood.")
+        problems += 1
+    if "aa" not in preset:
+        print("    No 'aa' viseme: her mouth cannot move while she talks.")
+        problems += 1
+
+    print(f"\n  Geometry: {triangles(gltf):,} triangles, "
+          f"{len(gltf.get('textures', []))} textures, "
+          f"{path.stat().st_size / 1e6:.2f} MB")
+    return problems
+
+
+def report_clip(path: Path, gltf: Dict[str, Any]) -> int:
+    animation = gltf["extensions"]["VRMC_vrm_animation"]
+    bones = animation.get("humanoid", {}).get("humanBones", {})
+    expressions = list(animation.get("expressions", {}).get("preset", {}))
+
+    print(f"  VRM Animation {animation.get('specVersion', '1.0')}")
+    print(f"  {len(bones)} humanoid bones driven by standard name, so it plays on")
+    print("  any VRM — which is why clips can ship with projectBEA and models cannot.")
+    if expressions:
+        print(f"  expressions driven: {', '.join(expressions)}")
+    if "lookAt" in animation:
+        print("  drives where she looks")
+
+    channels = sum(len(a.get("channels", [])) for a in gltf.get("animations", []))
+    print(f"  {channels} channels, {path.stat().st_size / 1024:.1f} KB")
+    if channels < 10:
+        print("  Few channels: everything it does not drive stays in the rest pose")
+        print("  (the T-pose arms). A full idle clip animates all of them.")
+    return 0
+
+
+def inspect(path: Path) -> int:
+    print(f"\n=== {path.name} ===")
+    try:
+        gltf = gltf_json(path)
+    except (ValueError, OSError) as e:
+        print(f"  {e}")
+        return 1
+
+    if "VRMC_vrm_animation" in gltf.get("extensions", {}):
+        return report_clip(path, gltf)
+    return report_model(path, gltf)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Read what a .vrm model or .vrma clip contains, and what its licence allows.",
+    )
+    parser.add_argument("files", nargs="+", type=Path, help=".vrm or .vrma files")
+    args = parser.parse_args()
+
+    problems = 0
+    for path in args.files:
+        if not path.is_file():
+            print(f"\n=== {path} ===\n  not found")
+            problems += 1
+            continue
+        problems += inspect(path)
+
+    print()
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this changes

How Bea appears on screen becomes a choice instead of the only thing she could
ever be. Two ports, `AvatarInterface` and `CaptionInterface`, and three avatar
backends behind them:

| backend | what it draws | what it needs |
|---|---|---|
| `png` | one image per mood, swapped in OBS | nothing new |
| `model` | a VRM in an OBS browser source | a `.vrm` the user brings |
| `vtube_studio` | the user's Live2D model, over the VTS plugin API | VTube Studio running |

The caption is a second, independent choice — `obs`, `stage` (the browser
source) or `off` — so images with the browser caption, or a 3D body with the
bubble still in OBS, are both expressible.

`Expression` calls `show(mood, state)`, `perform(clip)` and `mouth(envelope)`
and no longer knows what any of them turn into. The six copies of
`if obs_source_type == "media"` in the speech path collapse into one method, and
`type_text` stops handing its font size back to the caller.

**The 3D backend.** Weights and a behaviour name go over a dedicated SSE channel
to a page served at `/stage`. VRM because the format fixes the names of 54 bones
and 18 expressions, which is what lets a mapping written here work on a model
the code has never seen. Behaviours are `.vrma` clips, which carry no mesh and
play on any VRM, so they can live in the repo. The page is a second Vite entry
with three.js behind a dynamic import — the dashboard bundle is unchanged at
558 kB and only pays for the renderer when the backend is selected.

**VTube Studio.** Nothing bundled. `AuthenticationTokenRequest` once, token in
`data/vtube_studio_token.json`, then expressions, hotkeys and mouth parameter
injection over one queued connection that reconnects with backoff. The dashboard
reads the connected model's expressions and hotkeys so those maps are pickers
rather than text boxes.

**Lip sync.** `envelope()` in `pcm.py` is the per-frame RMS of the audio she is
about to say. 180 frames for six seconds, ~0.2 ms, ~1.2 KB, sent once before
playback so the page runs it on its own clock.

**Mood to face.** `expression/face.py` maps the seven moods onto VRM's five
emotion presets, `ew` and `bored` as blends. The table is asserted against the
valence/arousal vectors already in `moods.py`.

Also here: a `stage` step in the setup wizard, a preview in Settings → Stream
(the real browser source in an iframe for 3D, the mapped images for PNG),
`tools/inspect_vrm.py` to read a model's rig, expressions and embedded licence,
and `make model` to fetch a free one into gitignored `data/`.

Three fixes found on the way:

- `consciousness.sleep()` passed `"sleeping"` as a mood. It is not in `MOODS`,
  has no slot in `default_avatar_map()`, and resolved to `normal` silently — the
  sleeping avatar had never been visible. States now have their own slot and
  warn once when they have none.
- `resume()` hardcoded `normal`, so a sentence cut off mid-anger finished with a
  neutral face.
- The dead `ALIASES` entry in `resources.py`, which could never resolve.

## What breaks if it is wrong

The default config is `png` + `obs` and produces the same requests as before, so
an existing setup should not move at all. If the port is wrong, it is wrong for
everyone: `Expression` is the single output sink and every spoken line goes
through it.

Sharp edges I would look at first:

- **Backend switching at runtime.** `_reload_stage` rebuilds only the port whose
  backend changed. If that comparison is wrong it either drops a loaded model on
  every save, or silently keeps the old backend.
- **A browser source reloading mid-sentence.** The stage channel deliberately
  sends a snapshot and no backlog; `envelope` and `perform` are never stored. If
  that split is wrong she re-acts the last line every time OBS toggles the
  source.
- **VTube Studio not running.** Every port method is synchronous and must return
  whether or not the socket is there. If a call blocks, it blocks the turn she is
  speaking in.
- **Untrusted names.** `/stage/clips/{name}` and `/stage/preview` take input from
  a page. Both are restricted — the clips folder and `avatar_map` respectively.

Not verified end to end: a real OBS browser source, and a real VTube Studio.
Everything else is covered.

## Checks

- [x] `make test` passes — 1411 tests, 106 new
- [x] `make lint` passes; `npm run lint` has 0 errors
- [x] New behaviour has a test named after the behaviour
- [x] `docs/` updated — new `docs/modules/avatar.md`, plus `obs.md`,
      `architecture.md`, `configuration.md`, `web/api.md` and the README

One test-suite fix worth calling out on its own: an autouse fixture in
`conftest.py` stubs `sounddevice`, because a test returning real samples instead
of zeros played them out loud on the machine running the suite.
