### PR TITLE
Safe in-place updater, and a maintenance screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,15 @@ data/vtube_studio_token.json
 data/embeddings_cache/
 data/turns/
 
+# the updater: what it puts aside, what it is tracking, and the new version of
+# a prompt it could not merge into yours
+data/.backups/
+data/.prompt_base.json
+data/.update.lock
+data/.update.journal.json
+data/prompts/*.new
+data/prompts/*.bak
+
 
 # Frontend
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install setup docker docker-up docker-down run web frontend lock clean test lint migrate model
+.PHONY: help install setup update docker docker-up docker-down run web frontend lock clean test lint migrate model
 
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -9,6 +9,9 @@ install: ## create the venv and install python deps
 
 setup: install ## interactive first-run setup: writes .env and config.json
 	uv run bea --setup
+
+update: ## pull the new version, keeping your prompts, config and memory
+	uv run bea --update
 
 docker: ## build the image and run the setup wizard inside it
 	@# a missing bind-mount target makes docker create a directory in its place

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ untouched and the new one is left beside it to compare.
 The dashboard does the same with a button, tells you when there is something
 new, and shows you the two versions side by side when a file needs your call.
 
+Updating in place is the only thing here that needs `git` installed. Without it
+she runs exactly the same, and `uv run bea --doctor` tells you what you are
+missing.
+
 **[What it does, and what it refuses to do →](docs/updating.md)**
 
 ---
@@ -420,7 +424,7 @@ make test          # uv run pytest -q
 make lint          # uv run ruff check src tests
 ```
 
-1696 tests, and they run without network access or API keys: every model
+1707 tests, and they run without network access or API keys: every model
 client, surface and transport is faked. CI runs exactly `make test` and `make lint`.
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ Already cloned the repo? `make setup` does the same thing.
 
 ---
 
+## Updating without losing her
+
+```bash
+make update
+```
+
+Not `git pull`. The files that hold who she is — her soul, her operating manual
+— ship with the engine *and* are yours to rewrite. A plain pull either refuses
+to run or writes conflict markers straight into the text her personality is read
+from, and nobody finds out until she starts talking like someone else.
+
+`make update` backs up your prompts, your config and your memory first, then
+merges the new version *into* your edits the way git merges a branch: you keep
+the character you wrote, and the engine still gets the improvements to its own
+instructions. If a change lands on the exact lines you rewrote, yours stays
+untouched and the new one is left beside it to compare.
+
+The dashboard does the same with a button, tells you when there is something
+new, and shows you the two versions side by side when a file needs your call.
+
+**[What it does, and what it refuses to do →](docs/updating.md)**
+
+---
+
 ## She remembers you
 
 <img src="assets/remembers.png" align="right" width="290" alt="Bea" />
@@ -244,6 +268,7 @@ answering before it lets you in, then on a bento overview of everything at once.
 - **Activity.** The attention gate drawn live, over a filterable, freezable event stream, plus a full Turn Log of every decision she makes
 - **Memory.** Who she knows, everyone she has met, a search over what she remembers, and the things she has worked out about herself
 - **Abilities.** Every capability on or off at runtime, plus the Minecraft cockpit
+- **Maintenance.** Whether there is a new version and what is in it, with a button that installs it; and the same diagnostic `--doctor` runs, streamed as it goes
 - **Settings.** Eight sections with connection tests, and one save for all of them
 
 `⌘K` opens the command palette from anywhere.
@@ -395,11 +420,15 @@ make test          # uv run pytest -q
 make lint          # uv run ruff check src tests
 ```
 
-1302 tests, and they run without network access or API keys: every model
+1696 tests, and they run without network access or API keys: every model
 client, surface and transport is faked. CI runs exactly `make test` and `make lint`.
 
 > [!TIP]
-> **Something broken?** If she stops answering, you lose audio, or the avatar breaks, run `uv run bea doctor`. It runs a full diagnostic of your environment and tells you exactly what to type to fix it.
+> **Something broken?** If she stops answering, you lose audio, or the avatar
+> breaks, run `uv run bea --doctor` — or open **Maintenance** in the dashboard
+> and press the button. Thirteen checks in the order the pieces depend on each
+> other, stopping at the first thing that would stop her, each failure carrying
+> the exact command that fixes it.
 
 **[Setup guide →](docs/setup.md)** · **[Configuration →](docs/configuration.md)**
 
@@ -431,6 +460,7 @@ same source.
 | [Architecture](docs/architecture.md) | System design, data flow, the event system |
 | [Setup & Install](docs/setup.md) | Installation, OBS setup, audio routing |
 | [Configuration](docs/configuration.md) | Every config field, CLI arg and `.env` var |
+| [Updating](docs/updating.md) | How an update keeps the prompts you edited |
 | [Skills Overview](docs/skills/overview.md) | The `Skill` API, the registry, every tool |
 | [Modules](docs/modules/llm.md) | [LLM](docs/modules/llm.md) · [TTS](docs/modules/tts.md) · [STT](docs/modules/stt.md) · [Avatar](docs/modules/avatar.md) · [OBS](docs/modules/obs.md) |
 | [Skills](docs/skills/overview.md) | [Memory](docs/skills/memory.md) · [Social](docs/skills/social.md) · [Dream](docs/skills/dream.md) · [Plan](docs/skills/plan.md) · [Discord](docs/skills/discord.md) · [Telegram](docs/skills/telegram.md) · [Twitch](docs/skills/twitch.md) · [Minecraft](docs/skills/minecraft.md) · [Donations](docs/skills/donations.md) · [Monologue](docs/skills/monologue.md) |

--- a/config.example.json
+++ b/config.example.json
@@ -81,6 +81,10 @@
     "text_font_step": 2,
     "typing_delay": 0.03,
     "text_min_duration": 2,
+    "updates": {
+        "check": true,
+        "allow_web_apply": true
+    },
     "skills": {
         "monologue": {
             "enabled": false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,7 @@ ProjectBEA/
     │   ├── expression/     # the single output sink + humanizer + the face
     │   ├── stage.py        # fan-out to the OBS browser source
     │   ├── agent/          # LLMClient, role pools, tools, runner
+    │   ├── update/         # the in-place updater: git, three-way merge, backups
     │   └── skills/         # one package per capability
     ├── interfaces/         # TTS · STT · OBS · Avatar · Caption contracts
     ├── modules/            # llm · tts · stt · obs · avatar · caption implementations
@@ -92,6 +93,8 @@ ProjectBEA/
     ├── utils/
     └── web/
         ├── app.py          # FastAPI
+        ├── updates.py      # the updater over HTTP
+        ├── health.py       # `--doctor` over HTTP
         └── frontend/       # React + Vite + Tailwind
             ├── index.html  # the dashboard
             ├── stage.html  # the OBS browser source (separate bundle)
@@ -530,7 +533,8 @@ arrives with its tests in the same commit.**
 make install        # uv sync
 make run            # CLI
 make web            # build the frontend + dashboard on :8000
-uv run bea doctor   # diagnose and fix issues with the setup
+make update         # fast-forward, preserving edited prompts (see updating.md)
+uv run bea --doctor # diagnose and fix issues with the setup
 make test           # pytest
 make lint           # ruff
 make migrate        # one-shot: import a chroma/json store into data/bea.db

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,10 @@ This is `config.example.json` verbatim; it matches the dataclass defaults in
     "text_font_step": 2,
     "typing_delay": 0.03,
     "text_min_duration": 2,
+    "updates": {
+        "check": true,
+        "allow_web_apply": true
+    },
     "skills": {
         "monologue": {
             "enabled": false,
@@ -408,6 +412,24 @@ back to `neutral`. `png_dir` (`data/pngs`) is where they live.
 | `text_font_step` | `2` | Shrink step |
 | `typing_delay` | `0.03` | Seconds per character |
 | `text_min_duration` | `2.0` | Minimum seconds a page stays up |
+
+---
+
+## Updates
+
+```json
+"updates": { "check": true, "allow_web_apply": true }
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `check` | `true` | Ask `origin` whether there is a newer commit. The only outbound call, and only to the remote this copy was cloned from. Off means the dashboard never asks and never shows the pill |
+| `allow_web_apply` | `true` | Whether `POST /update/apply` is open. Off leaves `make update` working and closes the button — the endpoint runs `git pull`, `uv sync` and `npm install`, so it is separately revocable |
+
+Neither affects the CLI. Docker installs are refused regardless: the source tree
+is the image.
+
+**[The updater →](updating.md)**
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,8 +96,16 @@ makes her behaviour testable. Keep them that way.
 | **A new TTS engine** | Implement `TTSInterface`, add the branch and the CLI choice in `src/cli.py` |
 | **A new skill** | Extend `Skill`, register it in `AIVtuberBrain._build_consciousness()` |
 | **A new text platform** | Extend `PlatformSkill`, and the roster, person cards, attention gate and scoped conversations then work with no extra code |
+| **A change to `data/prompts/soul.md`** | Update `SHIPPED_SOUL_SHA256` in `src/core/persona.py` to match. The test fails with the value to paste |
 
 [Skills Overview](skills/overview.md) has the full plugin API.
+
+The soul hash is the one thing in this repository that has to be edited in two
+places. It is what separates "still the character we ship" from "someone wrote
+their own", and it cannot be derived at runtime: reading the live file compares
+it to itself, a value in the database goes stale the next time an update changes
+the file, and reading it out of git assumes a `.git` that a tarball install does
+not have. So it travels with the code, and a test stops it drifting.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -326,6 +326,10 @@ The dashboard's **Maintenance** screen does the same thing with a button, shows
 the changelog before you commit to it, and gives you a side-by-side diff for
 anything that needs a decision.
 
+Updating in place needs `git` — it is the only feature that does. Without it
+she runs exactly the same and `bea --doctor` tells you what you are missing;
+nothing installs it for you, because doing so needs root.
+
 **[How it works, and what it refuses to do →](updating.md)**
 
 ---

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -304,15 +304,48 @@ brain.
 
 ---
 
-## Troubleshooting
-
-The fastest way to figure out what is wrong is to run the built-in diagnostic tool:
+## Staying up to date
 
 ```bash
-uv run bea doctor
+make update          # or: uv run bea --update
 ```
 
-It checks the environment, API keys, audio devices, models, and dependencies, and tells you exactly what to type to fix any issue it finds.
+Not `git pull`. The prompts under `data/prompts/` are tracked *and* meant to be
+edited, so a pull either refuses to run or writes conflict markers into the file
+her personality is read from. `--update` backs up your prompts, config and
+database, fast-forwards, then puts your edits back through a three-way merge —
+so an edited `operating.md` keeps your changes *and* receives the engine's. Any
+file it cannot merge is left exactly as you wrote it, with the new version
+dropped beside it as `<name>.new`.
+
+It also runs `uv sync` and rebuilds the dashboard when the update touched them.
+`src/web/frontend/dist/` is gitignored, so a pull without that rebuild leaves
+the old dashboard on screen.
+
+The dashboard's **Maintenance** screen does the same thing with a button, shows
+the changelog before you commit to it, and gives you a side-by-side diff for
+anything that needs a decision.
+
+**[How it works, and what it refuses to do →](updating.md)**
+
+---
+
+## Troubleshooting
+
+The fastest way to figure out what is wrong is to run the built-in diagnostic:
+
+```bash
+uv run bea --doctor
+```
+
+Thirteen checks, run in the order the pieces depend on each other and stopped at
+the first blocking failure — there is no point testing the voice when there is
+no config file. Every failure carries the exact command that fixes it. The exit
+code is non-zero when something is blocking, so it works in a script.
+
+The same sequence runs from **Maintenance** in the dashboard, findings streamed
+as they land. It builds the voice, transcribes a line and calls the mind, so it
+costs a handful of provider requests and never runs on its own.
 
 | Problem | Solution |
 |---|---|
@@ -324,3 +357,6 @@ It checks the environment, API keys, audio devices, models, and dependencies, an
 | A model in `mind` "does not support tool calling" | Remove it from the pool. Bea speaks only through tools, so a model without them never says anything |
 | She never starts anything in Minecraft | Give her objectives on the dashboard's Stream Plan page — with an empty plan she only ever reacts |
 | OBS avatar source not updating after config migration | If your `config.json` still contains the old key `obs_image_source`, it is silently renamed to `obs_avatar_source` by `load_from_file()`. Delete the old key from your `config.json` and re-save to avoid ambiguity. |
+| `make update` says you have local changes to the engine | You have edited a tracked file outside `data/prompts/`. Commit, stash or revert it — the updater merges prompts, not source |
+| The dashboard looks unchanged after an update | The build is gitignored. Run `make frontend`, or check whether the `dashboard` step reported a missing `npm` |
+| A prompt has a `.new` beside it | An update changed the same lines you had. Yours is in use; compare them in Maintenance, or with `diff data/prompts/operating.md data/prompts/operating.md.new` |

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -228,6 +228,27 @@ the log.
 
 ---
 
+## Without git
+
+Nothing in the engine shells out to git. `src/core/update/gitrepo.py` is the
+only module that runs it, so on a machine without git she starts, thinks,
+speaks, remembers and serves the dashboard exactly as she does anywhere else —
+the suite proves it: 1668 pass, and the 39 that skip are the updater's own,
+which build real repositories to test against.
+
+What is lost is updating in place. `runner.supported()` returns the reason,
+`GET /update` reports `supported: false` with it, the Maintenance screen
+explains instead of going blank, and `bea --doctor`'s **Updates** check says so
+non-blockingly with the install command for the platform.
+
+git is not installed for the user by anything here. Every package manager that
+could do it wants root, there is no portable way to do it across macOS, Linux
+and Windows, and `install.sh` is a script people pipe from `curl` — one that
+silently escalates to `sudo` is not one worth trusting. The installers refuse
+with the exact command instead.
+
+---
+
 ## What it does not do
 
 * **Restart her.** The new code is on disk; the running process keeps the old

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,251 @@
+# Updating
+
+← [Back to README](../README.md) | [Setup →](setup.md) | [Configuration →](configuration.md)
+
+---
+
+## Why `git pull` is not the update command
+
+Six files under `data/prompts/` are tracked by git *and* meant to be edited by
+the person running the engine:
+
+| File | Read by | What an edit means |
+|---|---|---|
+| `soul.md` | every context, via `persona_store` | prose the user wrote; the character |
+| `operating.md` | `src/core/mind/operating.py` | the speak tool, moods, how perception is phrased |
+| `chat.md` | fallback when the operating manual is absent | legacy system prompt |
+| `monologue.md` | the monologue skill | what she says into silence |
+| `minecraft.md`, `minecraft_body.md` | the Minecraft agent | goal reasoning and the body loop |
+
+`soul.md` is content and `operating.md` is machinery, but both ship with the
+repository and both keep changing upstream. That combination is what breaks a
+plain pull: git either refuses the merge, or writes `<<<<<<<` conflict markers
+into a file that `src/utils/prompts.py:load_text` will read verbatim into a
+system prompt on the next turn. The second outcome is silent — she simply starts
+behaving strangely.
+
+Everything else a user owns is already outside git: `.env`, `config.json`,
+`data/bea.db`, `data/conversations/`, `data/models/`, `data/clips/` are all
+ignored, and `BrainConfig.load_from_file` deep-merges `config.json` over the
+dataclass defaults, so settings added upstream appear without migration. The
+updater exists for the prompts, and for the rebuild steps a pull leaves undone.
+
+---
+
+## The state a file can be in
+
+```
+                 │ upstream unchanged │ upstream changed
+ ────────────────┼────────────────────┼──────────────────
+  user untouched │ nothing to do      │ git updates it
+  user edited    │ keep theirs        │ three-way merge
+```
+
+The bottom-right cell is the whole feature. Both naive answers are wrong: taking
+upstream discards the character someone wrote, keeping the local copy freezes
+`operating.md` at whatever it was the first time it was touched, so the engine's
+own instructions stop improving while the engine does not.
+
+`src/core/update/reconcile.py` runs `git merge-file` per file with three inputs —
+the user's version, the version it was based on, the new version — and produces
+one of five outcomes:
+
+| Outcome | Meaning | Base advances |
+|---|---|---|
+| `untouched` | the local edit is byte-identical to the new version | yes |
+| `kept` | upstream did not change this file | yes |
+| `merged` | both sides changed, disjoint regions, combined | yes |
+| `conflict` | both sides changed overlapping lines | **no** |
+| `removed` | upstream deleted the file; the local copy stands | no |
+
+### The conflict rule
+
+On `conflict` the user's file is written back byte-for-byte and the new version
+is written beside it as `<name>.new`. Conflict markers are never written into a
+prompt — a marker in `soul.md` is not a merge to resolve later, it is a system
+prompt containing garbage.
+
+`.new` is tool-owned: regenerated on every update, overwritten rather than
+accumulated, deleted the moment the file stops conflicting or a decision is
+recorded. It is always reproducible with `git show HEAD:<path>`, so nothing is
+lost by replacing it.
+
+---
+
+## The base map
+
+A three-way merge needs a base, and the base is **not** `HEAD`. If an update
+conflicts and nobody resolves it, that file is still built on the revision from
+before that update. Merging the next update from the new `HEAD` would present
+the changes the user never took as deletions the user made, and drop them for
+good — the second time, silently.
+
+Git cannot supply this: to git the file is simply modified. So it is recorded in
+`data/.prompt_base.json` (untracked):
+
+```json
+{ "format": 1, "bases": { "data/prompts/operating.md": "a1b2c3…" } }
+```
+
+Rules, in `runner._base_for` and `reconcile`:
+
+* recorded → use it
+* no record, no `.new` beside the file → the pre-merge `HEAD`. A checkout nobody
+  has updated holds files that came out of the commit it sits on, so that commit
+  *is* the base. Without this, the first update of every install would conflict.
+* no record, `.new` present → refuse to merge. A pending conflict is on disk, we
+  do not know what it was based on, and guessing `HEAD` is the data loss above.
+* on conflict the base is rewritten unchanged, not omitted — an absent entry
+  would later be read as "based on whatever `HEAD` is now".
+
+The base also advances on an explicit resolution, which is the only place a
+human decides instead of the merge. Without that endpoint, someone who
+reconciles by hand leaves no trace, and the next update replays changes their
+file already contains.
+
+---
+
+## The run
+
+`src/core/update/runner.py:apply`. Seven steps, named once in `STEPS` and
+rendered by both the terminal and the dashboard.
+
+| Step | Does | Refuses when |
+|---|---|---|
+| `preflight` | recovers an interrupted run, classifies local changes | not a git checkout, no `origin`, detached HEAD, Docker, git missing, **any modified tracked file outside `data/prompts/`** |
+| `download` | `fetch` (un-shallowing a `--depth 1` clone first), resolves the target | the target is not a descendant of `HEAD` — a diverged checkout is reported, never rewritten |
+| `backup` | snapshots edited prompts, `config.json`, `.env` and the database; opens the journal | — |
+| `apply` | re-reads the prompts, `checkout HEAD -- data/prompts`, `merge --ff-only` | a prompt changed between the first read and this one |
+| `reconcile` | three-way merge per file, writes the base map, closes the journal | — |
+| `dependencies` | `uv sync`, when `uv.lock` or `pyproject.toml` changed | `uv` not on PATH — reported, run continues |
+| `dashboard` | `npm install && npm run build`, when `src/web/frontend/` changed | `npm` not on PATH — reported, run continues |
+
+The target is the tracking branch (`@{u}`), falling back to `origin/main`. The
+merge is `--ff-only`: there is no scenario in which the updater creates a merge
+commit in somebody's install.
+
+The last two steps can fail without failing the run. Rolling back a successful
+fast-forward because `npm` is missing would trade a small problem for a large
+one, so the report says which steps ran and the exit code is non-zero.
+`src/web/frontend/dist/` is gitignored, so **skipping the rebuild leaves the old
+dashboard on screen** — that is why a missing `npm` is reported loudly rather
+than ignored.
+
+### Refusals
+
+Local modifications to tracked files outside `data/prompts/` abort the run with
+the list. The updater merges prose, not source: if someone has patched the
+engine, that is their patch to reconcile.
+
+### Interruption
+
+`data/.update.journal.json` records the phase before it starts and is deleted on
+success. Only `reset`, `merge` and `reconcile` leave the working copy holding
+something the user did not write; finding a journal in one of those phases makes
+the next run restore the snapshot before doing anything else. A crash anywhere
+else left the files alone and only the journal is cleared.
+
+### Concurrency
+
+`data/.update.lock` is created with `O_EXCL`, carries the pid and the source
+(`cli` / `dashboard`), and expires by age after 45 minutes. Liveness is
+deliberately not checked: `os.kill(pid, 0)` does not probe on Windows, it
+terminates.
+
+Two narrower races are handled in the run itself:
+
+* **A prompt saved mid-update.** The dashboard can write `soul.md` at any moment,
+  including between the updater reading it and handing the path to
+  `git checkout`. The contents are re-read immediately before the reset and the
+  run aborts if anything drifted.
+* **A torn read.** `persona_store.SoulFile.write` and every write the updater
+  makes go through `src/utils/files.py:atomic_write_text` (temp file in the same
+  directory, `os.replace`), so a reader sees the old file or the new one, never
+  a truncated one.
+
+A check that runs while the lock is held skips the fetch rather than reading
+refs another process is rewriting.
+
+---
+
+## Entry points
+
+```bash
+make update                     # uv run bea --update
+uv run bea --update --no-rebuild   # git half only
+```
+
+`--update` is dispatched in `src/cli.py:run` before the engine is imported, for
+the same reason `--setup` and `--doctor` are: it exists to repair the tree
+everything else is imported from.
+
+### HTTP
+
+All under `src/web/updates.py`, mounted before the SPA catch-all.
+
+| Endpoint | Notes |
+|---|---|
+| `GET /update?force=` | availability, `can_apply`, pending reviews, the live run. Cached 30 min server-side |
+| `POST /update/check` | forces a fetch |
+| `POST /update/apply` | 202; runs on a worker thread. 409 when one is in flight, 403 when disabled |
+| `GET /update/run` | step-by-step progress, then the finished report |
+| `GET /update/reviews` | files carrying a `.new` |
+| `GET /update/reviews/{name}` | both versions, for the diff view |
+| `POST /update/reviews/{name}` | `{"choice": "mine" \| "theirs"}` — advances the base, clears the `.new`, reloads the config |
+
+`{name}` is matched against the list of files the updater itself flagged; a name
+from the browser is never joined onto a path. The run is threaded because it
+blocks on git, uv and npm for minutes, and the event loop is also drawing the
+progress bar for that run.
+
+`POST /update/apply` executes code. It is loopback-only like the rest of the
+API, it refuses to touch anything modified outside `data/prompts/`, and it can
+be switched off entirely:
+
+```json
+"updates": { "check": true, "allow_web_apply": true }
+```
+
+`check` is the only part that reaches the network, and only to the remote the
+copy was cloned from. `allow_web_apply` closes the dashboard door without
+affecting `make update`.
+
+---
+
+## Files on disk
+
+| Path | Lifetime |
+|---|---|
+| `data/.prompt_base.json` | permanent; losing it costs one manual reconciliation |
+| `data/prompts/*.new` | until the conflict is settled |
+| `data/.backups/<utc-stamp>/` | last 8 runs; carries `manifest.json` with the base sha |
+| `data/.update.lock` | duration of a run, or 45 minutes |
+| `data/.update.journal.json` | duration of a run |
+
+The database is copied with the SQLite backup API rather than `cp`: the engine
+holds it open in WAL mode, so the file on disk is missing whatever is still in
+the log.
+
+---
+
+## What it does not do
+
+* **Restart her.** The new code is on disk; the running process keeps the old
+  one until someone restarts it. A self-`exec` from inside the request that
+  triggered it races the memory flush in `cli.main`'s `finally` block, which is
+  worse than a banner saying "restart to finish".
+* **Merge anything outside `data/prompts/`.**
+* **Rewrite history, stash, or create merge commits.** `git stash pop` writes
+  conflict markers on collision, which is the one outcome forbidden here.
+* **Work in Docker.** The source tree is the image; the update is
+  `docker compose build`.
+
+---
+
+## Version
+
+`src/core/update/version.py` reads the installed package metadata, falling back
+to `pyproject.toml`. It is the single source of truth: `GET /status` carries it
+and the dashboard renders what it is told. The dashboard used to hardcode its
+own string, which disagreed with `pyproject.toml` — two version numbers is the
+same as none, and an update check has nothing to compare against.

--- a/docs/web/api.md
+++ b/docs/web/api.md
@@ -32,11 +32,15 @@ Returns the current brain state.
   "is_sleeping": false,
   "active_skills": ["memory", "discord"],
   "session_id": "session_1750000000",
-  "uptime": 1832.4
+  "uptime": 1832.4,
+  "version": "2.0.0"
 }
 ```
 
 `uptime` is seconds since the web process started, not since she was created.
+`version` comes from `src/core/update/version.py` — the installed package
+metadata, or `pyproject.toml` in a checkout that was never synced. It is the
+only version string in the system; the dashboard renders what it is told.
 
 ---
 
@@ -500,6 +504,102 @@ Returns a simple liveness check. Used to verify the server is running.
 ```json
 { "status": "ok" }
 ```
+
+---
+
+### Updating
+
+Implemented in `src/web/updates.py`, mounted before the SPA catch-all. See
+**[Updating](../updating.md)** for the merge semantics these endpoints expose.
+
+#### `GET /update`
+Everything the update screens need, in one request. Server-side cached for 30
+minutes; `?force=true` refetches.
+
+**Response:**
+```json
+{
+  "supported": true, "available": true, "reason": "",
+  "behind": 3, "current": "4523164a", "latest": "96f7125b", "version": "2.0.0",
+  "commits": [ { "sha": "96f7125b", "subject": "…", "author": "…", "date": "2026-09-10" } ],
+  "reviews": [ { "name": "operating.md", "path": "data/prompts/operating.md" } ],
+  "can_apply": true, "busy": false, "run": null
+}
+```
+
+`supported` is false with a populated `reason` for a zip download, a missing
+`origin`, a detached HEAD, a Docker container, or `updates.check` switched off.
+`reviews` lists prompts carrying a `.new` — an unresolved conflict from an
+earlier run.
+
+#### `POST /update/check`
+Forces a fetch and returns the same payload.
+
+#### `POST /update/apply` → `202`
+Starts the run on a worker thread and returns the initial step list. `409` while
+one is in flight, `403` when `updates.allow_web_apply` is false.
+
+> This endpoint runs `git pull`, `uv sync` and `npm install`, which is to say it
+> executes code. It is loopback-only like the rest of the API, the run refuses
+> to touch any tracked file modified outside `data/prompts/`, and the config
+> flag closes it entirely.
+
+#### `GET /update/run`
+Progress while it runs, the finished report afterwards.
+
+```json
+{
+  "state": "done",
+  "steps": [ { "id": "reconcile", "label": "Putting your edits back",
+               "status": "done", "detail": "1 file(s) need your eyes" } ],
+  "report": {
+    "status": "updated", "ok": true, "headline": "Updated — some prompts need a look",
+    "prompts": [ { "name": "operating.md", "state": "conflict",
+                   "detail": "your edits and the new version touch the same lines",
+                   "needs_review": true } ],
+    "backup": "20260911-104500", "restart_required": true, "needs_review": 1
+  }
+}
+```
+
+`report.status` is one of `updated`, `up-to-date`, `blocked`, `failed`. A
+`blocked` report carries `blocked_paths`. `restart_required` means the new code
+is on disk and the running process is still on the old one.
+
+#### `GET /update/reviews/{name}` · `POST /update/reviews/{name}`
+
+`GET` returns `{ "mine": "…", "theirs": "…" }` for the diff view. `POST` takes
+`{"choice": "mine" | "theirs"}`, advances that file's recorded base, deletes the
+`.new` and reloads the config so the decision is live without a restart.
+
+`{name}` is matched against the flagged list rather than joined onto a path, so
+a name from the browser never addresses a file the updater did not itself
+report.
+
+---
+
+### Diagnostics
+
+#### `GET /doctor` · `POST /doctor/run` → `202`
+
+The checks behind `bea --doctor`, in `src/web/health.py`. `POST` starts the run
+as an asyncio task; `GET` returns findings as they land, then a verdict.
+
+```json
+{
+  "state": "done", "total": 13,
+  "findings": [ { "title": "The mind", "ok": false, "detail": "…",
+                  "fix": "…", "blocking": true, "stops": true } ],
+  "verdict": { "level": "blocked", "headline": "The mind is in the way",
+               "detail": "9 check(s) below it never ran.",
+               "blocking": ["The mind"], "warnings": [] }
+}
+```
+
+The sequence stops at the first blocking failure, so `findings` is shorter than
+`total` on a `blocked` verdict and the checks that never ran must not be read as
+passes. `409` when a run is already going. It is never triggered automatically:
+the checks build a voice, transcribe a line and call the mind.
 
 ---
 

--- a/docs/web/frontend.md
+++ b/docs/web/frontend.md
@@ -52,7 +52,8 @@ src/web/frontend/
     │   ├── BrainProvider.jsx   the single SSE + status/overview + controls
     │   ├── AppearanceProvider  theme and the liquid-glass parameters
     │   ├── ToastProvider.jsx   non-blocking feedback
-    │   └── DialogProvider.jsx  confirmations only
+    │   ├── DialogProvider.jsx  confirmations only
+    │   └── UpdateProvider.jsx  is there a new version, and the run installing it
     ├── layouts/
     │   └── AppShell.jsx        sidebar + status bar + outlet + ⌘K
     ├── components/
@@ -61,6 +62,7 @@ src/web/frontend/
     │   ├── motion/             CountUp, SplitText, Magnetic, Spotlight, rings
     │   ├── ui/                 controls, fields, feedback, Modal
     │   ├── console/            the Minecraft cockpit
+    │   ├── maintenance/        the updater and the diagnostics, plus the prompt diff
     │   ├── AttentionFlux.jsx   the attention gate, live
     │   ├── Sidebar.jsx
     │   ├── TopBar.jsx          presence + global controls, on every page
@@ -73,6 +75,7 @@ src/web/frontend/
     │   ├── ActivityPage.jsx
     │   ├── MemoryPage.jsx
     │   ├── SkillsPage.jsx
+    │   ├── MaintenancePage.jsx updates and the health checks
     │   ├── SettingsPage.jsx
     │   └── settings/           one component per settings section
     └── hooks/
@@ -92,6 +95,7 @@ src/web/frontend/
 | `/dashboard/activity` | Attention gate and the event stream |
 | `/dashboard/memory` | People, roster, recall, her self-lore |
 | `/dashboard/skills` | Abilities on and off |
+| `/dashboard/maintenance` | The updater, and the `--doctor` checks |
 | `/dashboard/settings/:section` | `mind · engine · voice · hearing · stream · channels · world · appearance` |
 
 Every screen is a real URL: refreshing keeps you where you were, and the back

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,17 @@ if ((Test-Path "pyproject.toml") -and (Select-String -Path "pyproject.toml" -Pat
     Ok "already inside the repository"
 } else {
     Step "Downloading ProjectBEA"
-    if (-not (Get-Command git -ErrorAction SilentlyContinue)) { Die "git is required. Install it and run this again." }
+    # not installed for you on purpose: it needs admin, and a script people pipe
+    # from irm should not be asking for it. A single-quoted here-string, so
+    # nothing in the message is read as an escape or a variable.
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Die @'
+git is required to download ProjectBEA.
+    winget install --id Git.Git -e
+  Then run this again. You can also download the repository as a zip, but then
+  "make update" cannot keep your prompts across a new version.
+'@
+    }
     if (Test-Path $TargetDir) { Die "$TargetDir already exists. Remove it, or run .\install.ps1 from inside it." }
     git clone --depth 1 $RepoUrl $TargetDir
     Set-Location $TargetDir

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,13 @@ warn() { printf '  %s!%s %s\n' "$YELLOW" "$RESET" "$1"; }
 die()  { printf '\n  %s✗%s %s\n\n' "$RED" "$RESET" "$1" >&2; exit 1; }
 
 REPO_URL="https://github.com/emqnuele/projectBEA.git"
+
+git_hint() {
+  case "$(uname -s)" in
+    Darwin) printf '  brew install git   (or: xcode-select --install)' ;;
+    *)      printf '  sudo apt install git   (or your distribution'\''s package manager)' ;;
+  esac
+}
 TARGET_DIR="${BEA_DIR:-projectBEA}"
 
 printf '\n%sProjectBEA%s %s— an AI persona engine%s\n' "$BOLD" "$RESET" "$DIM" "$RESET"
@@ -32,7 +39,12 @@ if [ -f "pyproject.toml" ] && grep -q 'name = "projectbea"' pyproject.toml 2>/de
   ok "already inside the repository"
 else
   step "Downloading ProjectBEA"
-  command -v git >/dev/null 2>&1 || die "git is required. Install it and run this again."
+  # not installed for you on purpose: every package manager that can do it
+  # wants root, and a script people pipe from curl should not be asking for it
+  command -v git >/dev/null 2>&1 || die "git is required to download ProjectBEA.
+    $(git_hint)
+  Then run this again. You can also download the repository as a zip, but then
+  \`make update\` cannot keep your prompts across a new version."
   [ -d "$TARGET_DIR" ] && die "$TARGET_DIR already exists. Remove it, or run ./install.sh from inside it."
   git clone --depth 1 "$REPO_URL" "$TARGET_DIR"
   cd "$TARGET_DIR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "projectbea"
-version = "0.1.0"
+version = "2.0.0"
 description = "ProjectBEA - AI Vtuber Engine"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/cli.py
+++ b/src/cli.py
@@ -30,6 +30,10 @@ def parse_args():
                         help="Interactive first-run setup: writes .env and config.json")
     parser.add_argument("--doctor", action="store_true",
                         help="Check this machine: keys, voice, ears, body, and what to fix")
+    parser.add_argument("--update", action="store_true",
+                        help="Pull the new version without overwriting your prompts or your config")
+    parser.add_argument("--no-rebuild", action="store_true",
+                        help="With --update: skip `uv sync` and the dashboard build")
     parser.add_argument("--web", action="store_true", help="Start Web Interface (FastAPI + React)")
     parser.add_argument("--host", default="127.0.0.1",
                         help="Bind address for the web interface (default: loopback only)")
@@ -204,6 +208,11 @@ def run():
         config = BrainConfig()
         apply_cli_overrides(config, args)
         raise SystemExit(run_doctor(config=config))
+    # and again: an update exists to repair the tree everything below is
+    # imported from, so it must not import any of it
+    if args.update:
+        from src.core.update.console import run_update
+        raise SystemExit(run_update(rebuild=not args.no_rebuild))
     asyncio.run(main(args))
 
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -130,6 +130,15 @@ class BrainConfig:
     typing_delay: float = 0.03
     text_min_duration: float = 2.0
 
+    # staying current. `check` is the only thing here that reaches the network,
+    # and it only ever talks to the remote this copy was cloned from; `apply`
+    # is a button that runs `git pull` and a build, so it is separately
+    # revocable for anyone who would rather update from a terminal.
+    updates: Dict[str, Any] = field(default_factory=lambda: {
+        "check": True,
+        "allow_web_apply": True,
+    })
+
     # who she is called. The prose lives in soul.md; this is the structured part
     # every other path needs — the gate's trigger words, the prompt placeholders,
     # the name her own messages are filed under, the dashboard chrome.

--- a/src/core/persona.py
+++ b/src/core/persona.py
@@ -17,6 +17,21 @@ from typing import Any, Dict, List
 DEFAULT_NAME = "Bea"
 DEFAULT_PRONOUNS = "she/her"
 
+# sha256 of `data/prompts/soul.md` as this version ships it, used to tell "still
+# the character we ship" from "someone wrote their own".
+#
+# A constant rather than a lookup, because every other way of answering that
+# question is wrong somewhere. Reading the live file and comparing it to itself
+# — which is what this replaced — can only ever answer "unchanged". Recording a
+# hash in the database goes stale the first time an update changes the file
+# underneath it. Reading the shipped version out of git assumes a `.git`, which
+# an install unzipped from a tarball does not have.
+#
+# This travels with the code: a release that changes the soul changes the hash
+# in the same commit. `test_the_shipped_soul_hash_matches_the_file_we_ship`
+# fails the build if it does not.
+SHIPPED_SOUL_SHA256 = "f1828541b0cfc3e0b699ed429397bc61db1ec6d66e3a6115238beffdd24be45e"
+
 # what a prompt file may write. Anything else is left alone: these files are
 # hand-edited, and a typo must not eat the line it is on
 _PLACEHOLDER = re.compile(r"\{(name|pronouns|subject|object|possessive)\}")

--- a/src/core/persona_store.py
+++ b/src/core/persona_store.py
@@ -5,11 +5,12 @@ This is the other way in — the dashboard — which means a web request ends up
 writing to disk, so most of what is here is about refusing to.
 """
 
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from src.core.persona import DEFAULT_PRONOUNS, persona_of
+from src.core.persona import DEFAULT_PRONOUNS, SHIPPED_SOUL_SHA256, persona_of
 from src.utils.files import atomic_write_text
 from src.utils.logger import get_logger
 
@@ -74,12 +75,25 @@ def soul_file(config) -> SoulFile:
     return SoulFile(resolved)
 
 
-def _shipped_soul() -> str:
-    """The persona we ship, used to tell "never touched" from "set up"."""
-    try:
-        return (Path(__file__).parents[2] / "data/prompts/soul.md").read_text(encoding="utf-8")
-    except OSError:
-        return ""
+def is_customised(soul: str) -> bool:
+    """Whether somebody has made her theirs, or she is still the one we ship.
+
+    Compared by hash against `SHIPPED_SOUL_SHA256`, and deliberately not
+    against the file on disk: that is the same file, so the comparison could
+    only ever say "unchanged" and the banners asking people to set her up never
+    went away.
+
+    Whitespace is normalised the same way the text is read, so re-saving a soul
+    from the dashboard — which strips nothing but may end it with a newline —
+    does not count as writing one.
+    """
+    text = soul.strip()
+    return bool(text) and soul_digest(text) != SHIPPED_SOUL_SHA256
+
+
+def soul_digest(soul: str) -> str:
+    """The one definition of the hash, so the constant and its test cannot drift."""
+    return hashlib.sha256(soul.strip().encode("utf-8")).hexdigest()
 
 
 ONBOARDING_KEY = "onboarding.completed"
@@ -121,7 +135,7 @@ def describe(config) -> Dict[str, Any]:
         **persona.as_dict(),
         "soul": soul,
         # "the file exists" is not the question: it always does, we ship it
-        "customised": bool(soul.strip()) and soul.strip() != _shipped_soul().strip(),
+        "customised": is_customised(soul),
     }
 
 

--- a/src/core/persona_store.py
+++ b/src/core/persona_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.core.persona import DEFAULT_PRONOUNS, persona_of
+from src.utils.files import atomic_write_text
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.persona.store")
@@ -55,8 +56,10 @@ class SoulFile:
                 self.backup.write_text(self.read(), encoding="utf-8")
             except OSError as e:
                 logger.warning(f"Could not back up the soul: {e}")
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(text, encoding="utf-8")
+        # atomically: the engine reads this file on every turn and the updater
+        # reads it to decide what to merge, so a truncate-then-write would give
+        # one of them half a persona
+        atomic_write_text(self.path, text)
 
 
 def soul_file(config) -> SoulFile:

--- a/src/core/update/__init__.py
+++ b/src/core/update/__init__.py
@@ -1,0 +1,37 @@
+"""Updating her without overwriting anything the user wrote.
+
+`git pull` is not an updater. The prompts under `data/prompts` ship with the
+engine *and* are meant to be edited, so a pull either refuses to run or leaves
+conflict markers inside the file her personality is read from. Everything here
+exists to make the same operation safe for someone who has never used git.
+
+    from src.core.update import check, apply
+
+    status = check()          # is there anything new? (cached, read-only)
+    report = apply()          # do it, and tell me exactly what happened
+
+`reconcile.resolve` is the other entry point: the human ending to a conflict the
+merge could not settle on its own.
+"""
+
+from src.core.update.runner import (
+    STEPS,
+    Availability,
+    Report,
+    apply,
+    check,
+    in_docker,
+    invalidate,
+)
+from src.core.update.version import current_version
+
+__all__ = [
+    "STEPS",
+    "Availability",
+    "Report",
+    "apply",
+    "check",
+    "current_version",
+    "in_docker",
+    "invalidate",
+]

--- a/src/core/update/__init__.py
+++ b/src/core/update/__init__.py
@@ -22,6 +22,7 @@ from src.core.update.runner import (
     check,
     in_docker,
     invalidate,
+    supported,
 )
 from src.core.update.version import current_version
 
@@ -34,4 +35,5 @@ __all__ = [
     "current_version",
     "in_docker",
     "invalidate",
+    "supported",
 ]

--- a/src/core/update/backup.py
+++ b/src/core/update/backup.py
@@ -1,0 +1,196 @@
+"""What is put aside before anything is touched, and the note that says so.
+
+Two separate jobs live here because they answer two different fears.
+
+The **snapshot** is for the user: their prompts, their config, their memory,
+copied whole before the first write. Nothing in the update is supposed to need
+it — the reconciliation is careful — but "supposed to" is not an argument you
+can make to someone who lost the character they spent a week writing.
+
+The **journal** is for the machine: a note recording which phase the update had
+reached, written before the phase starts and deleted when the run succeeds.
+Finding one on startup means a previous update died between resetting the
+prompts and putting them back, which is the one window where the working copy
+is worse than either end state. The next run reads it and restores.
+"""
+
+import json
+import shutil
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from src.utils.files import atomic_write_text
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.update.backup")
+
+BACKUP_ROOT = Path("data/.backups")
+JOURNAL_FILE = Path("data/.update.journal.json")
+
+# enough to go back through a bad week, few enough to not quietly eat a disk
+KEEP_BACKUPS = 8
+
+# copied alongside the prompts even though git never touches them: an update is
+# the moment people are most afraid, and the answer to "can I go back" should
+# not have an asterisk
+EXTRAS = ("config.json", ".env")
+
+DATABASE = "data/bea.db"
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    directory: Path
+    files: List[str]
+
+    @property
+    def name(self) -> str:
+        return self.directory.name
+
+
+def take(root: Path, files: Sequence[str], base_sha: str) -> Snapshot:
+    """Copies `files` (repo-relative) plus config, env and the memory database."""
+    root = Path(root)
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    directory = root / BACKUP_ROOT / stamp
+    directory.mkdir(parents=True, exist_ok=True)
+
+    saved: List[str] = []
+    for relative in list(files) + list(EXTRAS):
+        source = root / relative
+        if not source.is_file():
+            continue
+        target = directory / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy2(source, target)
+            saved.append(relative)
+        except OSError as e:
+            logger.warning(f"Could not back up {relative}: {e}")
+
+    if _copy_database(root / DATABASE, directory / DATABASE):
+        saved.append(DATABASE)
+
+    manifest = {
+        "created_at": time.time(),
+        "base": base_sha,
+        "files": saved,
+    }
+    atomic_write_text(directory / "manifest.json", json.dumps(manifest, indent=2) + "\n")
+    _prune(root)
+    return Snapshot(directory=directory, files=saved)
+
+
+def _copy_database(source: Path, target: Path) -> bool:
+    """A live SQLite database in WAL mode cannot be copied with `cp` and trusted.
+
+    The engine holds it open while this runs, so the file on disk is missing
+    whatever is still in the write-ahead log. The backup API takes a consistent
+    copy of a database someone else is using, which is exactly the case here.
+    """
+    if not source.is_file():
+        return False
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with sqlite3.connect(f"file:{source}?mode=ro", uri=True) as live, sqlite3.connect(target) as copy:
+            live.backup(copy)
+        return True
+    except sqlite3.Error as e:
+        logger.warning(f"Could not back up the memory database: {e}")
+        target.unlink(missing_ok=True)
+        return False
+
+
+def _prune(root: Path) -> None:
+    directory = Path(root) / BACKUP_ROOT
+    try:
+        existing = sorted((d for d in directory.iterdir() if d.is_dir()), key=lambda d: d.name)
+    except OSError:
+        return
+    for old in existing[:-KEEP_BACKUPS]:
+        shutil.rmtree(old, ignore_errors=True)
+
+
+def restore(root: Path, snapshot_dir: Path, files: Sequence[str]) -> List[str]:
+    """Puts named files back from a snapshot. Returns what was actually restored."""
+    root, snapshot_dir = Path(root), Path(snapshot_dir)
+    restored = []
+    for relative in files:
+        source = snapshot_dir / relative
+        if not source.is_file():
+            continue
+        try:
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+            restored.append(relative)
+        except OSError as e:
+            logger.error(f"Could not restore {relative}: {e}")
+    return restored
+
+
+# --- the journal -------------------------------------------------------------
+
+
+def open_journal(root: Path, phase: str, snapshot: Snapshot, base_sha: str, files: Sequence[str]) -> None:
+    atomic_write_text(
+        Path(root) / JOURNAL_FILE,
+        json.dumps({
+            "phase": phase,
+            "snapshot": snapshot.name,
+            "base": base_sha,
+            "files": list(files),
+            "at": time.time(),
+        }, indent=2) + "\n",
+    )
+
+
+def mark_phase(root: Path, phase: str) -> None:
+    path = Path(root) / JOURNAL_FILE
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    payload["phase"] = phase
+    try:
+        atomic_write_text(path, json.dumps(payload, indent=2) + "\n")
+    except OSError as e:
+        logger.warning(f"Could not update the update journal: {e}")
+
+
+def close_journal(root: Path) -> None:
+    (Path(root) / JOURNAL_FILE).unlink(missing_ok=True)
+
+
+def read_journal(root: Path) -> Optional[Dict]:
+    try:
+        payload = json.loads((Path(root) / JOURNAL_FILE).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def recover(root: Path) -> List[str]:
+    """Undoes an update that died mid-flight, by putting the user's files back.
+
+    Only the phases between the reset and the reconciliation leave the working
+    copy holding something the user did not write; a crash anywhere else left
+    their files alone and there is nothing to do but forget the journal.
+    """
+    journal = read_journal(root)
+    if not journal:
+        return []
+
+    restored: List[str] = []
+    if journal.get("phase") in ("reset", "merge", "reconcile"):
+        snapshot_dir = Path(root) / BACKUP_ROOT / str(journal.get("snapshot", ""))
+        files = [f for f in journal.get("files", []) if isinstance(f, str)]
+        restored = restore(root, snapshot_dir, files)
+        if restored:
+            logger.warning(f"Recovered {len(restored)} file(s) from an interrupted update")
+
+    close_journal(root)
+    return restored

--- a/src/core/update/console.py
+++ b/src/core/update/console.py
@@ -1,0 +1,119 @@
+"""`bea --update` on a terminal: a live list of steps and a verdict.
+
+The report is the same object the dashboard renders; this only decides how it
+looks on a terminal. The one rule it follows is the one `--doctor` follows: a
+failure that does not say what to type next is a failure that becomes an issue.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from src.core.update import runner
+from src.core.update.reconcile import CONFLICT, KEPT, MERGED, REMOVED, UNTOUCHED
+from src.core.update.runner import DONE, FAILED, SKIPPED, Report
+
+MARKS = {
+    runner.RUNNING: "[dim]·[/dim]",
+    DONE: "[green]✓[/green]",
+    SKIPPED: "[dim]–[/dim]",
+    FAILED: "[red]✗[/red]",
+}
+
+PROMPT_MARKS = {
+    UNTOUCHED: "[dim]·[/dim]",
+    KEPT: "[green]✓[/green]",
+    MERGED: "[green]✓[/green]",
+    REMOVED: "[yellow]![/yellow]",
+    CONFLICT: "[yellow]![/yellow]",
+}
+
+
+def run_update(root: Optional[Path] = None, console=None, rebuild: bool = True) -> int:
+    """The command. Returns a shell exit code: 0 when she is on the new version."""
+    from rich.console import Console
+
+    from src.utils.logger import quieten
+
+    quieten()
+    console = console or Console()
+    root = root or runner.ROOT
+
+    console.print()
+    console.rule("[bold]Updating[/bold]", align="left", style="dim")
+    console.print()
+
+    drawn = set()
+
+    def show(step: runner.Step) -> None:
+        # a step is drawn once it has settled, so the list does not scroll past
+        # itself on a terminal that cannot repaint
+        if step.status == runner.RUNNING or step.id in drawn:
+            return
+        drawn.add(step.id)
+        console.print(f"  {MARKS.get(step.status, ' ')} [bold]{step.label}[/bold]"
+                      + (f"  [dim]{step.detail}[/dim]" if step.detail else ""))
+
+    report = runner.apply(root=root, source="cli", progress=show, rebuild=rebuild)
+    return _verdict(console, report)
+
+
+def _verdict(console, report: Report) -> int:
+    console.print()
+
+    if report.status == runner.CURRENT:
+        console.print("  [green]Nothing to do — she is already up to date.[/green]")
+        console.print()
+        return 0
+
+    if report.status == runner.BLOCKED:
+        console.print(f"  [yellow]{report.headline}.[/yellow] {report.detail}")
+        for path in report.blocked_paths:
+            console.print(f"      [cyan]{path}[/cyan]")
+        console.print()
+        return 1
+
+    if report.status == runner.FAILED_RUN:
+        console.print(f"  [red]{report.headline}.[/red] {report.detail}")
+        if report.backup:
+            console.print(f"  [dim]Your files are in data/.backups/{report.backup}[/dim]")
+        console.print()
+        return 1
+
+    if report.commits:
+        console.print(f"  [bold]What is new[/bold] [dim]({len(report.commits)} commits)[/dim]")
+        for commit in report.commits[:10]:
+            console.print(f"      [dim]{commit['sha']}[/dim]  {commit['subject']}")
+        if len(report.commits) > 10:
+            console.print(f"      [dim]… and {len(report.commits) - 10} more[/dim]")
+        console.print()
+
+    if report.prompts:
+        console.print("  [bold]Your prompts[/bold]")
+        for outcome in report.prompts:
+            mark = PROMPT_MARKS.get(outcome.state, " ")
+            console.print(f"      {mark} [bold]{Path(outcome.path).name}[/bold]  [dim]{outcome.detail}[/dim]")
+        console.print()
+
+    reviews = report.reviews
+    if reviews:
+        console.print(f"  [yellow]{len(reviews)} prompt(s) kept your version and could not take the new one.[/yellow]")
+        console.print("  [dim]Yours is still in place and she runs exactly as before. The new version "
+                      "is beside it:[/dim]")
+        for outcome in reviews:
+            console.print(f"      [cyan]{outcome.path}.new[/cyan]")
+        console.print("  [dim]Compare them in Settings → Personality, or with:[/dim]")
+        console.print(f"      [cyan]diff {reviews[0].path} {reviews[0].path}.new[/cyan]")
+        console.print()
+
+    failed = [s for s in report.steps if s.status == FAILED]
+    if failed:
+        console.print("  [yellow]She is on the new version, but part of the rebuild did not run:[/yellow]")
+        for step in failed:
+            console.print(f"      [cyan]{step.detail}[/cyan]")
+        console.print()
+        return 1
+
+    console.print("  [green]Updated.[/green] Restart her to load it:")
+    console.print("      [cyan]uv run bea --web[/cyan]")
+    console.print()
+    return 0

--- a/src/core/update/console.py
+++ b/src/core/update/console.py
@@ -101,7 +101,7 @@ def _verdict(console, report: Report) -> int:
                       "is beside it:[/dim]")
         for outcome in reviews:
             console.print(f"      [cyan]{outcome.path}.new[/cyan]")
-        console.print("  [dim]Compare them in Settings → Personality, or with:[/dim]")
+        console.print("  [dim]Compare them on the dashboard's Maintenance screen, or with:[/dim]")
         console.print(f"      [cyan]diff {reviews[0].path} {reviews[0].path}.new[/cyan]")
         console.print()
 

--- a/src/core/update/gitrepo.py
+++ b/src/core/update/gitrepo.py
@@ -1,0 +1,266 @@
+"""Every call the updater makes to the git binary, and nothing else.
+
+Keeping them here is not tidiness. Two of the arguments below are the
+difference between an update and a hung dashboard: `GIT_TERMINAL_PROMPT=0` and
+`ssh -oBatchMode=yes` mean a clone over SSH with a passphrase-protected key
+fails in a second instead of waiting forever for a password nobody will ever
+type into a web request. Scatter the subprocess calls and one of them will
+eventually be written without those.
+
+Nothing here decides anything: it answers questions about the repository and
+performs the two writes the updater is allowed to make (`checkout` of paths it
+has already backed up, and a fast-forward). The policy lives in `runner`.
+"""
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.update.git")
+
+# a local git command answers in milliseconds; anything reaching the network
+# gets its own, larger budget. Both exist so a wedged git never wedges the API.
+LOCAL_TIMEOUT = 30
+NETWORK_TIMEOUT = 180
+
+
+class GitError(Exception):
+    """A git command that failed, carrying what it printed."""
+
+    def __init__(self, message: str, stderr: str = ""):
+        super().__init__(message)
+        self.message = message
+        self.stderr = stderr.strip()
+
+    def __str__(self) -> str:
+        return f"{self.message}: {self.stderr}" if self.stderr else self.message
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+    author: str
+    date: str
+
+    def describe(self) -> Dict[str, str]:
+        return {"sha": self.sha[:8], "subject": self.subject, "author": self.author, "date": self.date}
+
+
+def _environment() -> Dict[str, str]:
+    env = dict(os.environ)
+    # never ask a human anything: there is nobody at the other end of an HTTP
+    # request, and an interactive prompt would hang until the timeout
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env.setdefault("GIT_SSH_COMMAND", "ssh -oBatchMode=yes")
+    # parsing porcelain output in the user's locale is a bug waiting for a
+    # non-English machine
+    env["LC_ALL"] = "C"
+    return env
+
+
+class Repo:
+    """The working copy the engine is running from."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root).resolve()
+
+    # --- running git ---------------------------------------------------------
+
+    def run(self, *args: str, timeout: int = LOCAL_TIMEOUT, check: bool = True) -> subprocess.CompletedProcess:
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=str(self.root),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+                env=_environment(),
+            )
+        except FileNotFoundError as e:
+            raise GitError("git is not installed, or not on PATH") from e
+        except subprocess.TimeoutExpired as e:
+            raise GitError(f"git {args[0]} timed out after {timeout}s") from e
+
+        if check and result.returncode != 0:
+            raise GitError(f"git {args[0]} failed", result.stderr or result.stdout)
+        return result
+
+    def out(self, *args: str, timeout: int = LOCAL_TIMEOUT) -> str:
+        return self.run(*args, timeout=timeout).stdout.strip()
+
+    def raw(self, *args: str, timeout: int = LOCAL_TIMEOUT) -> Optional[bytes]:
+        """Bytes, undecoded. For blobs, where a lossy decode would be a silent edit."""
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=str(self.root),
+                capture_output=True,
+                timeout=timeout,
+                env=_environment(),
+            )
+        except FileNotFoundError as e:
+            raise GitError("git is not installed, or not on PATH") from e
+        except subprocess.TimeoutExpired as e:
+            raise GitError(f"git {args[0]} timed out after {timeout}s") from e
+        return result.stdout if result.returncode == 0 else None
+
+    # --- what kind of checkout is this --------------------------------------
+
+    def available(self) -> bool:
+        try:
+            self.run("--version")
+            return True
+        except GitError:
+            return False
+
+    def is_repo(self) -> bool:
+        try:
+            return self.out("rev-parse", "--is-inside-work-tree") == "true"
+        except GitError:
+            return False
+
+    def is_shallow(self) -> bool:
+        try:
+            return self.out("rev-parse", "--is-shallow-repository") == "true"
+        except GitError:
+            return False
+
+    def has_remote(self, name: str = "origin") -> bool:
+        try:
+            return name in self.out("remote").split()
+        except GitError:
+            return False
+
+    def remote_url(self, name: str = "origin") -> str:
+        try:
+            return self.out("remote", "get-url", name)
+        except GitError:
+            return ""
+
+    def branch(self) -> Optional[str]:
+        """The current branch, or None on a detached HEAD."""
+        name = self.out("rev-parse", "--abbrev-ref", "HEAD")
+        return None if name == "HEAD" else name
+
+    def upstream(self) -> Optional[str]:
+        """The tracking branch, e.g. `origin/main`. None when there is none."""
+        try:
+            return self.out("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+        except GitError:
+            return None
+
+    # --- reading -------------------------------------------------------------
+
+    def head(self) -> str:
+        return self.out("rev-parse", "HEAD")
+
+    def resolve(self, rev: str) -> Optional[str]:
+        try:
+            return self.out("rev-parse", "--verify", f"{rev}^{{commit}}")
+        except GitError:
+            return None
+
+    def modified_tracked(self, *paths: str) -> List[str]:
+        """Tracked files that differ from HEAD, staged or not. Untracked are not ours."""
+        args = ["diff", "--name-only", "HEAD", "--"]
+        result = self.run(*args, *paths)
+        return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+
+    def changed_between(self, base: str, head: str, *paths: str) -> List[str]:
+        result = self.run("diff", "--name-only", f"{base}..{head}", "--", *paths)
+        return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+
+    def tracked_under(self, prefix: str) -> List[str]:
+        result = self.run("ls-files", "--", prefix)
+        return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+
+    def file_at(self, rev: str, path: str) -> Optional[str]:
+        """The contents of one file at one revision, or None if it was not there.
+
+        Also None when the blob is not valid UTF-8: a prompt that is not text is
+        a prompt we refuse to merge rather than mangle.
+        """
+        blob = self.raw("show", f"{rev}:{path}")
+        if blob is None:
+            return None
+        try:
+            return blob.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.warning(f"{path} at {rev[:8]} is not valid UTF-8; it will not be merged")
+            return None
+
+    def count_between(self, base: str, head: str) -> int:
+        try:
+            return int(self.out("rev-list", "--count", f"{base}..{head}"))
+        except (GitError, ValueError):
+            return 0
+
+    def commits_between(self, base: str, head: str, limit: int = 50) -> List[Commit]:
+        """Newest first. An empty list means nothing new, or a history too shallow to say."""
+        try:
+            result = self.run(
+                "log", f"--max-count={limit}", "--no-merges",
+                "--pretty=format:%H%x1f%s%x1f%an%x1f%cs", f"{base}..{head}",
+            )
+        except GitError:
+            return []
+        commits = []
+        for line in result.stdout.splitlines():
+            parts = line.split("\x1f")
+            if len(parts) == 4:
+                commits.append(Commit(sha=parts[0], subject=parts[1], author=parts[2], date=parts[3]))
+        return commits
+
+    def is_ancestor(self, maybe_ancestor: str, head: str) -> bool:
+        result = self.run("merge-base", "--is-ancestor", maybe_ancestor, head, check=False)
+        return result.returncode == 0
+
+    # --- writing -------------------------------------------------------------
+
+    def fetch(self, remote: str = "origin") -> None:
+        self.run("fetch", "--quiet", remote, timeout=NETWORK_TIMEOUT)
+
+    def unshallow(self, remote: str = "origin") -> None:
+        """Gives a `--depth 1` install enough history to diff and to log.
+
+        Falls back to a bounded deepen: on a big repository over a slow link,
+        some history beats failing the whole update over a changelog.
+        """
+        try:
+            self.run("fetch", "--unshallow", "--quiet", remote, timeout=NETWORK_TIMEOUT)
+        except GitError as e:
+            logger.warning(f"Could not unshallow, deepening instead: {e}")
+            self.run("fetch", "--depth=100", "--quiet", remote, timeout=NETWORK_TIMEOUT)
+
+    def checkout_paths(self, paths: Sequence[str]) -> None:
+        """Throws away local changes to these paths. Only ever called on a backup."""
+        if paths:
+            self.run("checkout", "HEAD", "--", *paths)
+
+    def merge_ff_only(self, rev: str) -> None:
+        self.run("merge", "--ff-only", rev)
+
+    def merge_file(self, ours: Path, base: Path, theirs: Path) -> Optional[str]:
+        """A three-way merge of one file. None when the two sides collide.
+
+        `git merge-file` returns the number of conflict regions, so anything
+        between 1 and 127 is a collision and 255 is git itself failing.
+        """
+        result = self.run(
+            "merge-file", "-p", "--quiet",
+            "-L", "your version", "-L", "the version you started from", "-L", "the new version",
+            str(ours), str(base), str(theirs),
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout
+        if result.returncode >= 128 or result.returncode < 0:
+            raise GitError("git merge-file failed", result.stderr)
+        return None

--- a/src/core/update/lock.py
+++ b/src/core/update/lock.py
@@ -1,0 +1,80 @@
+"""One update at a time, across processes.
+
+Two updates running together would interleave a `git checkout` of the prompts
+with another run's snapshot, and the second one would back up files the first
+had already reset. So: an exclusive file, created with O_EXCL, which is atomic
+on every filesystem we care about.
+
+A lock nobody released — the machine lost power mid-update — has to expire, or
+the feature is broken until someone finds the file. Expiry is by age alone:
+asking whether the recorded pid is still alive is the obvious refinement, and
+on Windows `os.kill(pid, 0)` does not ask, it terminates. So the lock records
+who holds it for the error message, and time decides when it is stale.
+"""
+
+import json
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.update.lock")
+
+LOCK_FILE = Path("data/.update.lock")
+
+# comfortably longer than the slowest plausible run — a cold `uv sync` plus an
+# `npm install` on a laptop — and short enough that a dead lock clears itself
+# within one coffee break
+STALE_AFTER = 45 * 60
+
+
+class UpdateBusy(Exception):
+    """Someone else is already updating."""
+
+
+def holder(root: Path) -> Optional[dict]:
+    """Who holds the lock right now, or None when it is free or stale."""
+    path = Path(root) / LOCK_FILE
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    started = payload.get("started_at", 0)
+    if not isinstance(started, (int, float)) or time.time() - started > STALE_AFTER:
+        return None
+    return payload
+
+
+@contextmanager
+def held(root: Path, source: str) -> Iterator[None]:
+    """Holds the update lock for the duration of the block."""
+    path = Path(root) / LOCK_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        handle = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        current = holder(root)
+        if current is not None:
+            age = int(time.time() - current.get("started_at", time.time()))
+            raise UpdateBusy(
+                f"An update started {age}s ago from {current.get('source', 'somewhere')} "
+                f"(pid {current.get('pid', '?')}) is still running."
+            ) from None
+        # stale: whoever wrote it is long gone
+        logger.warning("Clearing a stale update lock")
+        path.unlink(missing_ok=True)
+        try:
+            handle = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            raise UpdateBusy("Another update took the lock first.") from None
+
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as f:
+            json.dump({"pid": os.getpid(), "source": source, "started_at": time.time()}, f)
+        yield
+    finally:
+        path.unlink(missing_ok=True)

--- a/src/core/update/reconcile.py
+++ b/src/core/update/reconcile.py
@@ -1,0 +1,204 @@
+"""Putting a user's edited prompt back on top of a new version of the same file.
+
+The prompts ship with the engine and are meant to be edited. `soul.md` is prose
+the user writes; `operating.md` is machinery — the speak tool, the moods, how
+perception is described — that keeps improving upstream. Both are versioned, so
+an update can change a file the user has also changed, and the naive answers
+are both wrong: taking theirs throws away the character someone wrote, keeping
+ours freezes the engine's own instructions at whatever they were the day it was
+first touched.
+
+So every file gets a three-way merge — their version, the version they started
+from, the new version — which is what git would do for a merge commit, run here
+one file at a time so we decide what happens when it fails.
+
+And when it fails there is exactly one rule, because a prompt is not source
+code: **never write conflict markers into a file that goes into a system
+prompt.** `<<<<<<<` in `soul.md` is not a merge to resolve later, it is a
+character quietly going insane on stream. The user's file is left exactly as it
+was and the new version is dropped beside it as `<name>.new` for them to read.
+"""
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from src.core.update.gitrepo import GitError, Repo
+from src.utils.files import atomic_write_text
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.update.reconcile")
+
+# where the editable prompts live. Everything outside it is engine source: if
+# the user has edited that, the update refuses to run rather than merge code.
+PROMPTS = "data/prompts"
+
+NEW_SUFFIX = ".new"
+
+UNTOUCHED = "untouched"
+KEPT = "kept"
+MERGED = "merged"
+CONFLICT = "conflict"
+REMOVED = "removed"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """What happened to one file, in terms a person can act on."""
+
+    path: str
+    state: str
+    detail: str
+    # the revision this file's contents are now built on, to be recorded. On a
+    # conflict it is the base we merged *from*, unchanged — "does not advance"
+    # has to be written down, because an absent record would later be read as
+    # "based on whatever HEAD is now", which is the misreading this whole
+    # module exists to avoid.
+    base: Optional[str] = None
+
+    @property
+    def needs_review(self) -> bool:
+        return self.state == CONFLICT
+
+    def describe(self) -> dict:
+        return {
+            "path": self.path,
+            "name": Path(self.path).name,
+            "state": self.state,
+            "detail": self.detail,
+            "needs_review": self.needs_review,
+        }
+
+
+def new_file_for(root: Path, path: str) -> Path:
+    return Path(root) / (path + NEW_SUFFIX)
+
+
+def pending_reviews(root: Path, repo: Repo) -> list:
+    """Files sitting on an unresolved conflict, i.e. carrying a `.new` beside them."""
+    found = []
+    for path in repo.tracked_under(PROMPTS):
+        if new_file_for(root, path).is_file():
+            found.append(path)
+    return sorted(found)
+
+
+def reconcile(root: Path, repo: Repo, path: str, ours: str, base_sha: Optional[str], target: str) -> Outcome:
+    """Restores the user's version of one file, merged with the new one where it can be.
+
+    Called after the fast-forward, so the working copy holds the new version and
+    `ours` is what was snapshotted before it was reset.
+    """
+    root = Path(root)
+    theirs = repo.file_at(target, path)
+
+    if theirs is None:
+        # the new version does not have this file at all — deleted upstream, or
+        # a blob we refuse to decode. Either way the user's copy is the only
+        # one anybody asked for.
+        _write(root / path, ours)
+        # the base stays where it was: if the file comes back upstream, their
+        # edits still have something to be merged against
+        return Outcome(path, REMOVED, "the new version no longer ships this file; yours was kept",
+                       base=base_sha)
+
+    if ours == theirs:
+        _clear_new(root, path)
+        return Outcome(path, UNTOUCHED, "already identical to the new version", base=target)
+
+    base = repo.file_at(base_sha, path) if base_sha else None
+
+    if base is None:
+        # no usable base: either we never recorded one, or the revision is gone
+        # from a shallow history. A two-way guess is exactly the silent data
+        # loss this module exists to prevent, so hand both versions over.
+        _write(root / path, ours)
+        _write(new_file_for(root, path), theirs)
+        return Outcome(
+            path, CONFLICT,
+            "there is no record of which version yours was based on, so it was left untouched",
+            base=None,
+        )
+
+    if base == theirs:
+        _write(root / path, ours)
+        _clear_new(root, path)
+        return Outcome(path, KEPT, "the new version does not change this file", base=target)
+
+    merged = _merge(repo, ours=ours, base=base, theirs=theirs)
+    if merged is None:
+        _write(root / path, ours)
+        _write(new_file_for(root, path), theirs)
+        return Outcome(
+            path, CONFLICT,
+            "your edits and the new version touch the same lines",
+            base=base_sha,
+        )
+
+    _write(root / path, merged)
+    _clear_new(root, path)
+    return Outcome(path, MERGED, "your edits were carried over onto the new version", base=target)
+
+
+def resolve(root: Path, repo: Repo, path: str, choice: str, target: str) -> Outcome:
+    """The human ending to a conflict, and the only other place a base advances.
+
+    Without it, an update that conflicted stays conflicted forever: someone who
+    reconciles by hand leaves no trace of having done so, and the next update
+    would try to replay the same changes onto a file that already has them.
+    """
+    root = Path(root)
+    if choice not in ("mine", "theirs"):
+        raise ValueError(f"Unknown resolution: {choice}")
+
+    incoming = new_file_for(root, path)
+    if choice == "theirs":
+        text = _read(incoming)
+        if text is None:
+            raise FileNotFoundError(f"There is no new version of {path} to take")
+        _write(root / path, text)
+
+    _clear_new(root, path)
+    detail = ("the new version was taken" if choice == "theirs" else "your version was kept")
+    return Outcome(path, KEPT if choice == "mine" else MERGED, detail, base=target)
+
+
+# --- the merge itself --------------------------------------------------------
+
+
+def _merge(repo: Repo, ours: str, base: str, theirs: str) -> Optional[str]:
+    """`git merge-file` on three temporary files. None when the sides collide."""
+    with tempfile.TemporaryDirectory(prefix="bea-merge-") as workspace:
+        directory = Path(workspace)
+        sides = {}
+        for name, text in (("ours", ours), ("base", base), ("theirs", theirs)):
+            # newline="" keeps CRLF intact: rewriting every line ending of a file
+            # the user edited on Windows would turn a clean merge into a conflict
+            sides[name] = directory / name
+            sides[name].write_text(text, encoding="utf-8", newline="")
+        try:
+            return repo.merge_file(sides["ours"], sides["base"], sides["theirs"])
+        except GitError as e:
+            logger.error(f"merge-file failed, treating as a conflict: {e}")
+            return None
+
+
+def _write(path: Path, text: str) -> None:
+    atomic_write_text(path, text)
+
+
+def _read(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _clear_new(root: Path, path: str) -> None:
+    """A resolved conflict must not leave its leftovers on disk.
+
+    A stale `.new` is a file somebody opens six months later wondering whether
+    they were supposed to do something with it.
+    """
+    new_file_for(root, path).unlink(missing_ok=True)

--- a/src/core/update/runner.py
+++ b/src/core/update/runner.py
@@ -184,6 +184,15 @@ def _unsupported(repo: Repo) -> str:
     return ""
 
 
+def supported(root: Path = ROOT) -> str:
+    """Why this install cannot update itself, or an empty string when it can.
+
+    Public because the diagnostic asks the same question, and reaching into a
+    private helper to answer it is how the two end up disagreeing.
+    """
+    return _unsupported(Repo(root))
+
+
 def _target_ref(repo: Repo) -> str:
     """What we are updating towards: the tracking branch, or origin's main."""
     return repo.upstream() or "origin/main"

--- a/src/core/update/runner.py
+++ b/src/core/update/runner.py
@@ -1,0 +1,514 @@
+"""The update itself: what it checks, in what order, and what it refuses to do.
+
+Two commitments shape everything below.
+
+**Nothing the user wrote is ever lost.** Their prompts are read, backed up and
+put back through a three-way merge; anything else of theirs that git tracks and
+they have modified stops the run instead of being merged behind their back. The
+update is fast-forward only, so a diverged checkout is reported rather than
+rewritten. Every run is journalled, so one that dies halfway is undone by the
+next one.
+
+**Nothing happens halfway without saying so.** The git half and the rebuild half
+can fail independently — a fetch can die on the network, `npm` can be missing
+entirely — and rolling a successful fast-forward back because the dashboard did
+not rebuild would trade a small problem for a large one. So each step reports
+itself, and the report says plainly which ones ran.
+
+The steps are a fixed sequence, named once here, because the terminal and the
+dashboard both draw their progress from it.
+"""
+
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from src.core.update import backup, lock, state
+from src.core.update.gitrepo import GitError, Repo
+from src.core.update.reconcile import (
+    CONFLICT,
+    PROMPTS,
+    Outcome,
+    new_file_for,
+    pending_reviews,
+    reconcile,
+)
+from src.core.update.version import current_version
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.update")
+
+ROOT = Path(__file__).resolve().parents[3]
+
+# how long a check is trusted before the remote is asked again. The dashboard
+# polls; without this a tab left open all day is a fetch every few minutes.
+CHECK_TTL = 30 * 60
+
+# generous on purpose: a cold `uv sync` pulls a few hundred MB, and a first
+# `npm install` on a slow link is measured in minutes, not seconds
+DEPENDENCY_TIMEOUT = 30 * 60
+
+STEPS: List[tuple] = [
+    ("preflight", "Checking your install"),
+    ("download", "Downloading the new version"),
+    ("backup", "Backing up your files"),
+    ("apply", "Applying the update"),
+    ("reconcile", "Putting your edits back"),
+    ("dependencies", "Updating dependencies"),
+    ("dashboard", "Rebuilding the dashboard"),
+]
+
+RUNNING, DONE, SKIPPED, FAILED = "running", "done", "skipped", "failed"
+
+# what the run as a whole came to
+UPDATED, CURRENT, BLOCKED, FAILED_RUN = "updated", "up-to-date", "blocked", "failed"
+
+
+@dataclass
+class Step:
+    id: str
+    label: str
+    status: str
+    detail: str = ""
+
+    def describe(self) -> dict:
+        return {"id": self.id, "label": self.label, "status": self.status, "detail": self.detail}
+
+
+@dataclass
+class Report:
+    status: str
+    headline: str
+    detail: str = ""
+    steps: List[Step] = field(default_factory=list)
+    prompts: List[Outcome] = field(default_factory=list)
+    commits: List[dict] = field(default_factory=list)
+    blocked_paths: List[str] = field(default_factory=list)
+    from_sha: str = ""
+    to_sha: str = ""
+    backup: str = ""
+    restart_required: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.status in (UPDATED, CURRENT)
+
+    @property
+    def reviews(self) -> List[Outcome]:
+        return [p for p in self.prompts if p.needs_review]
+
+    def describe(self) -> dict:
+        return {
+            "status": self.status,
+            "ok": self.ok,
+            "headline": self.headline,
+            "detail": self.detail,
+            "steps": [s.describe() for s in self.steps],
+            "prompts": [p.describe() for p in self.prompts],
+            "commits": self.commits,
+            "blocked_paths": self.blocked_paths,
+            "from": self.from_sha[:8],
+            "to": self.to_sha[:8],
+            "backup": self.backup,
+            "restart_required": self.restart_required,
+            "needs_review": len(self.reviews),
+        }
+
+
+@dataclass
+class Availability:
+    """What a check found, without changing anything."""
+
+    supported: bool
+    reason: str = ""
+    behind: int = 0
+    current: str = ""
+    latest: str = ""
+    version: str = ""
+    commits: List[dict] = field(default_factory=list)
+    reviews: List[str] = field(default_factory=list)
+    busy: bool = False
+    checked_at: float = 0.0
+
+    @property
+    def available(self) -> bool:
+        return self.supported and self.behind > 0
+
+    def describe(self) -> dict:
+        return {
+            "supported": self.supported,
+            "available": self.available,
+            "reason": self.reason,
+            "behind": self.behind,
+            "current": self.current[:8],
+            "latest": self.latest[:8],
+            "version": self.version,
+            "commits": self.commits,
+            "reviews": self.reviews,
+            "busy": self.busy,
+            "checked_at": self.checked_at,
+        }
+
+
+Progress = Callable[[Step], None]
+
+
+def _noop(step: Step) -> None:
+    pass
+
+
+# --- is this install even updatable ------------------------------------------
+
+
+def in_docker() -> bool:
+    """Inside a container the source tree is the image, so pulling it is theatre."""
+    return Path("/.dockerenv").exists() or os.getenv("BEA_IN_DOCKER") == "1"
+
+
+def _unsupported(repo: Repo) -> str:
+    """The reason this checkout cannot be updated in place, or an empty string."""
+    if in_docker():
+        return "She is running in Docker, where the update is a rebuild of the image."
+    if not repo.available():
+        return "git is not installed, so there is nothing to pull with."
+    if not repo.is_repo():
+        return "This is not a git checkout — it was most likely downloaded as a zip."
+    if not repo.has_remote():
+        return "This checkout has no `origin` remote to pull from."
+    if repo.branch() is None:
+        return "This checkout is on a detached HEAD. Check out a branch first."
+    return ""
+
+
+def _target_ref(repo: Repo) -> str:
+    """What we are updating towards: the tracking branch, or origin's main."""
+    return repo.upstream() or "origin/main"
+
+
+# --- checking ----------------------------------------------------------------
+
+_cached: Optional[Availability] = None
+
+
+def check(root: Path = ROOT, force: bool = False, fetch: bool = True) -> Availability:
+    """Asks the remote whether there is anything new. Cached, because tabs stay open."""
+    global _cached
+
+    if _cached and not force and time.time() - _cached.checked_at < CHECK_TTL:
+        return _cached
+
+    repo = Repo(root)
+    reason = _unsupported(repo)
+    if reason:
+        _cached = Availability(supported=False, reason=reason, version=current_version(),
+                               checked_at=time.time())
+        return _cached
+
+    busy = lock.holder(root) is not None
+    result = Availability(supported=True, version=current_version(), busy=busy, checked_at=time.time())
+
+    try:
+        # an update running right now is rewriting the very refs we would read
+        if fetch and not busy:
+            if repo.is_shallow():
+                repo.unshallow()
+            repo.fetch()
+
+        result.current = repo.head()
+        target = repo.resolve(_target_ref(repo))
+        if not target:
+            result.supported = False
+            result.reason = f"Could not find `{_target_ref(repo)}` — is the remote reachable?"
+            _cached = result
+            return result
+
+        result.latest = target
+        result.behind = repo.count_between(result.current, target)
+        result.commits = [c.describe() for c in repo.commits_between(result.current, target)]
+        result.reviews = pending_reviews(root, repo)
+    except GitError as e:
+        result.supported = False
+        result.reason = str(e)
+
+    _cached = result
+    return result
+
+
+def invalidate() -> None:
+    """Forgets the cached check. Called whenever we ourselves moved the repo."""
+    global _cached
+    _cached = None
+
+
+# --- updating ----------------------------------------------------------------
+
+
+def apply(root: Path = ROOT, source: str = "cli", progress: Progress = _noop,
+          rebuild: bool = True) -> Report:
+    """Runs the whole update. Never raises for an expected failure — it reports it."""
+    root = Path(root)
+    repo = Repo(root)
+    steps: List[Step] = []
+
+    def step(step_id: str, status: str, detail: str = "") -> Step:
+        label = dict(STEPS)[step_id]
+        entry = Step(step_id, label, status, detail)
+        # a step reported twice is the same step changing state, not a new one
+        for index, existing in enumerate(steps):
+            if existing.id == step_id:
+                steps[index] = entry
+                break
+        else:
+            steps.append(entry)
+        progress(entry)
+        return entry
+
+    try:
+        with lock.held(root, source):
+            return _run(root, repo, step, steps, rebuild)
+    except lock.UpdateBusy as e:
+        return Report(status=BLOCKED, headline="An update is already running", detail=str(e), steps=steps)
+    except GitError as e:
+        logger.error(f"Update failed: {e}")
+        return Report(status=FAILED_RUN, headline="The update could not finish", detail=str(e), steps=steps)
+    except Exception as e:  # noqa: BLE001 - the last line before a 500
+        logger.exception("Unexpected failure during update")
+        return Report(status=FAILED_RUN, headline="The update could not finish",
+                      detail=f"{type(e).__name__}: {e}", steps=steps)
+
+
+def _run(root: Path, repo: Repo, step, steps: List[Step], rebuild: bool) -> Report:
+    # --- 1. preflight --------------------------------------------------------
+    step("preflight", RUNNING)
+
+    recovered = backup.recover(root)
+    if recovered:
+        step("preflight", RUNNING, f"Recovered {len(recovered)} file(s) from an interrupted update")
+
+    reason = _unsupported(repo)
+    if reason:
+        step("preflight", FAILED, reason)
+        return Report(status=BLOCKED, headline="This install cannot update itself",
+                      detail=reason, steps=steps)
+
+    # anything of theirs outside the prompts is code, and code is not ours to merge
+    blocked = [p for p in repo.modified_tracked() if not p.startswith(f"{PROMPTS}/")]
+    if blocked:
+        detail = ("These tracked files have local changes. Commit, stash or revert them and "
+                  "run the update again.")
+        step("preflight", FAILED, detail)
+        return Report(status=BLOCKED, headline="You have local changes to the engine itself",
+                      detail=detail, steps=steps, blocked_paths=blocked)
+
+    base_sha = repo.head()
+    edited = repo.modified_tracked(PROMPTS)
+    ours = _read_all(root, edited)
+    step("preflight", DONE,
+         f"{len(edited)} edited prompt(s) to preserve" if edited else "no local edits to preserve")
+
+    # --- 2. download ---------------------------------------------------------
+    step("download", RUNNING)
+    if repo.is_shallow():
+        repo.unshallow()
+    repo.fetch()
+    target = repo.resolve(_target_ref(repo))
+    if not target:
+        detail = f"Could not resolve `{_target_ref(repo)}` after fetching."
+        step("download", FAILED, detail)
+        return Report(status=FAILED_RUN, headline="The new version could not be found",
+                      detail=detail, steps=steps)
+
+    if target == base_sha:
+        step("download", DONE, "already on the latest version")
+        for pending in ("backup", "apply", "reconcile", "dependencies", "dashboard"):
+            step(pending, SKIPPED, "nothing to update")
+        return Report(status=CURRENT, headline="She is already up to date",
+                      steps=steps, from_sha=base_sha, to_sha=target)
+
+    if not repo.is_ancestor(base_sha, target):
+        detail = ("Your checkout has commits that are not upstream, so this cannot be a "
+                  "fast-forward. Merge or reset it by hand.")
+        step("download", FAILED, detail)
+        return Report(status=BLOCKED, headline="Your checkout has diverged",
+                      detail=detail, steps=steps, from_sha=base_sha, to_sha=target)
+
+    commits = [c.describe() for c in repo.commits_between(base_sha, target)]
+    step("download", DONE, f"{repo.count_between(base_sha, target)} new commit(s)")
+
+    # --- 3. backup -----------------------------------------------------------
+    step("backup", RUNNING)
+    snapshot = backup.take(root, edited, base_sha)
+    backup.open_journal(root, "reset", snapshot, base_sha, edited)
+    step("backup", DONE, f"saved to {backup.BACKUP_ROOT}/{snapshot.name}")
+
+    # --- 4. apply ------------------------------------------------------------
+    step("apply", RUNNING)
+    # last look before anything is destroyed: if a prompt changed underneath us
+    # between the read and now, the snapshot is already out of date
+    drifted = [p for p, text in ours.items() if _read(root / p) != text]
+    if drifted:
+        backup.close_journal(root)
+        detail = f"{', '.join(drifted)} changed while the update was preparing. Nothing was touched."
+        step("apply", FAILED, detail)
+        return Report(status=BLOCKED, headline="Something edited a prompt mid-update",
+                      detail=detail, steps=steps, blocked_paths=drifted,
+                      backup=snapshot.name)
+
+    repo.checkout_paths(edited)
+    backup.mark_phase(root, "merge")
+    repo.merge_ff_only(target)
+    invalidate()
+    step("apply", DONE, f"now on {target[:8]}")
+
+    # --- 5. reconcile --------------------------------------------------------
+    step("reconcile", RUNNING)
+    backup.mark_phase(root, "reconcile")
+    outcomes = _reconcile_all(root, repo, ours, base_sha, target)
+    backup.close_journal(root)
+
+    conflicts = [o for o in outcomes if o.state == CONFLICT]
+    if conflicts:
+        step("reconcile", DONE, f"{len(conflicts)} file(s) need your eyes")
+    else:
+        step("reconcile", DONE,
+             f"{len(outcomes)} edited prompt(s) preserved" if outcomes else "no local edits to restore")
+
+    # --- 6 & 7. dependencies and the dashboard -------------------------------
+    changed = repo.changed_between(base_sha, target)
+    if rebuild:
+        _sync_dependencies(root, changed, step)
+        _rebuild_dashboard(root, changed, step)
+    else:
+        step("dependencies", SKIPPED, "asked to skip")
+        step("dashboard", SKIPPED, "asked to skip")
+
+    headline = "Updated" if not conflicts else "Updated — some prompts need a look"
+    return Report(
+        status=UPDATED,
+        headline=headline,
+        detail=f"{len(commits)} commit(s) applied.",
+        steps=steps,
+        prompts=outcomes,
+        commits=commits,
+        from_sha=base_sha,
+        to_sha=target,
+        backup=snapshot.name,
+        restart_required=True,
+    )
+
+
+def _base_for(root: Path, path: str, bases: state.BaseMap, head: str) -> Optional[str]:
+    """Which revision this file's contents are built on.
+
+    Recorded, when we have a record — which is not HEAD whenever an earlier
+    conflict was left unresolved. Otherwise it depends on why there is no
+    record, and an unresolved conflict leaves a `.new` on disk that says so
+    independently of the state file. Without one, the file was checked out at
+    the revision they are on and edited from there, which is every install that
+    has never updated before; with one, we know their file predates something
+    and not what, so the merge is refused rather than guessed.
+    """
+    recorded = bases.get(path)
+    if recorded:
+        return recorded
+    return None if new_file_for(root, path).exists() else head
+
+
+def _reconcile_all(root: Path, repo: Repo, ours: Dict[str, str], base_sha: str, target: str) -> List[Outcome]:
+    bases = state.load(root)
+    outcomes: List[Outcome] = []
+
+    for path, text in ours.items():
+        outcome = reconcile(root, repo, path, text, _base_for(root, path, bases, base_sha), target)
+        outcomes.append(outcome)
+        if outcome.base:
+            bases.set(path, outcome.base)
+        logger.info(f"{path}: {outcome.state} — {outcome.detail}")
+
+    # files nobody edited are simply on the new version now
+    for path in repo.tracked_under(PROMPTS):
+        if path not in ours:
+            bases.set(path, target)
+
+    state.save(root, bases)
+    return outcomes
+
+
+# --- the rebuild half --------------------------------------------------------
+
+
+def _sync_dependencies(root: Path, changed: List[str], step) -> None:
+    if not any(p in ("uv.lock", "pyproject.toml") for p in changed):
+        step("dependencies", SKIPPED, "no dependency changes in this update")
+        return
+    if not shutil.which("uv"):
+        step("dependencies", FAILED, "uv is not on PATH — run `uv sync` yourself before starting her")
+        return
+
+    step("dependencies", RUNNING)
+    ok, detail = _command(root, ["uv", "sync"])
+    step("dependencies", DONE if ok else FAILED, detail if not ok else "python dependencies are current")
+
+
+def _rebuild_dashboard(root: Path, changed: List[str], step) -> None:
+    frontend = root / "src/web/frontend"
+    if not any(p.startswith("src/web/frontend/") for p in changed):
+        step("dashboard", SKIPPED, "the dashboard did not change in this update")
+        return
+    if not shutil.which("npm"):
+        # the built dashboard is gitignored, so without this the user updates
+        # and sees the old screens with no clue why
+        step("dashboard", FAILED,
+             "npm is not on PATH — run `make frontend` yourself, or the dashboard stays on the old build")
+        return
+
+    step("dashboard", RUNNING, "installing")
+    ok, detail = _command(frontend, ["npm", "install", "--no-audit", "--no-fund"])
+    if not ok:
+        step("dashboard", FAILED, detail)
+        return
+
+    step("dashboard", RUNNING, "building")
+    ok, detail = _command(frontend, ["npm", "run", "build"])
+    step("dashboard", DONE if ok else FAILED, detail if not ok else "the dashboard was rebuilt")
+
+
+def _command(cwd: Path, args: List[str]) -> tuple:
+    """Runs one build command. Returns (ok, the last thing it said when it failed)."""
+    try:
+        result = subprocess.run(
+            args, cwd=str(cwd), capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=DEPENDENCY_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return False, f"{args[0]} is not installed"
+    except subprocess.TimeoutExpired:
+        return False, f"`{' '.join(args)}` did not finish within {DEPENDENCY_TIMEOUT // 60} minutes"
+
+    if result.returncode == 0:
+        return True, ""
+    tail = (result.stderr or result.stdout or "").strip().splitlines()
+    return False, f"`{' '.join(args)}` failed: " + (tail[-1] if tail else f"exit code {result.returncode}")
+
+
+# --- small file helpers ------------------------------------------------------
+
+
+def _read(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _read_all(root: Path, paths: List[str]) -> Dict[str, str]:
+    contents = {}
+    for relative in paths:
+        text = _read(Path(root) / relative)
+        if text is not None:
+            contents[relative] = text
+    return contents

--- a/src/core/update/state.py
+++ b/src/core/update/state.py
@@ -1,0 +1,84 @@
+"""Which revision each editable file was last reconciled against.
+
+A three-way merge needs a base, and the base is *not* the commit you are on. If
+an update ends in a conflict the user never resolves, their file is still built
+on the revision from before that update — so the next update has to merge from
+there, or the changes they never took would look like deletions they made and
+get thrown away a second time, silently.
+
+Git cannot tell us this: as far as it is concerned the file is simply modified.
+So we keep it ourselves, one line per file, in a small untracked JSON.
+
+The rules are short:
+
+* the base advances when a file is untouched, or when a merge lands cleanly
+* the base does **not** advance on a conflict — nothing was reconciled
+* the base advances on an explicit resolution, which is the only place a human
+  decides instead of the merge
+
+Anything unreadable here degrades to "no base", and no base means we refuse to
+merge and hand the user both versions instead. Losing this file costs a round
+of manual reconciliation; trusting a wrong base would cost their edits.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+from src.utils.files import atomic_write_text
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.update.state")
+
+STATE_FILE = Path("data/.prompt_base.json")
+FORMAT = 1
+
+
+@dataclass
+class BaseMap:
+    """Repo-relative path -> the sha its current contents were reconciled against."""
+
+    bases: Dict[str, str] = field(default_factory=dict)
+
+    def get(self, path: str) -> Optional[str]:
+        sha = self.bases.get(path)
+        return sha if isinstance(sha, str) and len(sha) >= 7 else None
+
+    def set(self, path: str, sha: str) -> None:
+        self.bases[path] = sha
+
+    def forget(self, path: str) -> None:
+        self.bases.pop(path, None)
+
+
+def load(root: Path) -> BaseMap:
+    path = Path(root) / STATE_FILE
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return BaseMap()
+    except (OSError, json.JSONDecodeError) as e:
+        # a corrupt map is treated as an absent one: every file falls back to
+        # "hand both versions over", which is the safe half of the design
+        logger.warning(f"Could not read {STATE_FILE}, starting from scratch: {e}")
+        return BaseMap()
+
+    if not isinstance(payload, dict) or payload.get("format") != FORMAT:
+        logger.warning(f"{STATE_FILE} is in an unknown format, starting from scratch")
+        return BaseMap()
+
+    bases = payload.get("bases")
+    if not isinstance(bases, dict):
+        return BaseMap()
+    return BaseMap({str(k): str(v) for k, v in bases.items() if isinstance(v, str)})
+
+
+def save(root: Path, state: BaseMap) -> None:
+    path = Path(root) / STATE_FILE
+    body = json.dumps({"format": FORMAT, "bases": state.bases}, indent=2, sort_keys=True)
+    try:
+        atomic_write_text(path, body + "\n")
+    except OSError as e:
+        # not fatal: the next update falls back to handing over both versions
+        logger.error(f"Could not write {STATE_FILE}: {e}")

--- a/src/core/update/version.py
+++ b/src/core/update/version.py
@@ -1,0 +1,36 @@
+"""One version number, read from one place.
+
+There used to be two: `pyproject.toml` said one thing and the dashboard's
+sidebar had another hardcoded in a constant. That is harmless right up until
+something has to answer "what are you running, and is it older than what is on
+GitHub" — at which point two answers is the same as none.
+
+The installed metadata is the source; the file is the fallback for a checkout
+that was never `uv sync`'d, which is exactly the state a broken install is in.
+"""
+
+import re
+from functools import lru_cache
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
+
+UNKNOWN = "unknown"
+
+
+@lru_cache(maxsize=1)
+def current_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("projectbea")
+    except Exception:  # noqa: BLE001 - metadata missing or unreadable, fall through
+        pass
+
+    try:
+        # deliberately not tomllib: this has to work on 3.10, and one regex is
+        # cheaper than a conditional import for a single well-known line
+        match = re.search(r'^version\s*=\s*"([^"]+)"', PYPROJECT.read_text(encoding="utf-8"), re.MULTILINE)
+        return match.group(1) if match else UNKNOWN
+    except OSError:
+        return UNKNOWN

--- a/src/setup/doctor.py
+++ b/src/setup/doctor.py
@@ -451,6 +451,39 @@ async def check_dashboard(config: BrainConfig) -> Finding:
     return passed(f"built, and port {DEFAULT_PORT} is free")
 
 
+async def check_updates(config: BrainConfig) -> Finding:
+    """Whether `make update` will work here, which is not the same as whether she will.
+
+    Nothing in the engine shells out to git — she runs perfectly without it —
+    so this can never block. It exists because the failure is otherwise
+    invisible: the update button is simply absent, and a missing button
+    explains nothing.
+    """
+    from src.core.update import supported
+
+    reason = supported()
+    if not reason:
+        return passed("`make update` will work here")
+
+    if "Docker" in reason:
+        return passed("in Docker — updating means rebuilding the image")
+
+    if "git is not installed" in reason:
+        return warned(reason, "Install git, then `make update` keeps your prompts, "
+                              "config and memory across a new version:\n" + _git_install_hint())
+
+    return warned(reason, "She runs fine. `make update` will not work — reinstall with "
+                          "`git clone` if you want in-place updates.")
+
+
+def _git_install_hint() -> str:
+    if sys.platform == "darwin":
+        return "  brew install git   (or: xcode-select --install)"
+    if sys.platform == "win32":
+        return "  winget install --id Git.Git -e"
+    return "  sudo apt install git   (or your distribution's package manager)"
+
+
 CHECKS: List[Tuple[str, Callable]] = [
     ("Python and uv", check_python),
     ("Config and secrets", check_config),
@@ -465,6 +498,7 @@ CHECKS: List[Tuple[str, Callable]] = [
     ("OBS", check_obs),
     ("Discord", check_discord),
     ("The dashboard", check_dashboard),
+    ("Updates", check_updates),
 ]
 
 

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -1,0 +1,33 @@
+"""Writing a file without ever leaving half of one behind.
+
+Two things read the prompt files: the engine, on every turn, and the updater,
+while it is deciding what to merge. Both can be reading at the moment the
+dashboard saves an edit — and `Path.write_text` truncates first and writes
+after, so a reader landing in that window gets a file that is empty or cut in
+half, and a soul cut in half goes straight into a system prompt.
+
+`os.replace` is atomic on POSIX and on Windows, so a reader sees either the old
+file or the new one and never the seam between them.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, text: str, encoding: str = "utf-8") -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # the temp file has to share a filesystem with the target or os.replace
+    # degrades into a copy, which is exactly the window we are closing
+    handle, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(handle, "w", encoding=encoding, newline="") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -40,6 +40,7 @@ from src.core.settings_schema import section as _section
 from src.core.stage import clips_dir, public_config
 from src.core.update.version import current_version
 from src.utils.logger import get_logger
+from src.web.health import router as doctor_router
 from src.web.updates import router as update_router
 
 logger = get_logger("bea.web")
@@ -116,6 +117,7 @@ def _merge_skills(current: Dict[str, Any], incoming: Dict[str, Any]) -> None:
 
 # before the SPA catch-all below, which answers every GET registered after it
 app.include_router(update_router)
+app.include_router(doctor_router)
 
 
 @app.get("/config")

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -38,7 +38,9 @@ from src.core.settings_schema import ValidationError, apply_section, describe
 from src.core.settings_schema import restart_needed as _restart_needed
 from src.core.settings_schema import section as _section
 from src.core.stage import clips_dir, public_config
+from src.core.update.version import current_version
 from src.utils.logger import get_logger
+from src.web.updates import router as update_router
 
 logger = get_logger("bea.web")
 
@@ -111,6 +113,10 @@ def _merge_skills(current: Dict[str, Any], incoming: Dict[str, Any]) -> None:
             continue
         clean = {k: v for k, v in block.items() if v != MASK}
         current.setdefault(skill_key, {}).update(clean)
+
+# before the SPA catch-all below, which answers every GET registered after it
+app.include_router(update_router)
+
 
 @app.get("/config")
 def get_config():
@@ -342,6 +348,7 @@ def get_status():
         "active_skills": active_skills,
         "session_id": brain.history_manager.session_id,
         "uptime": time.time() - STARTED_AT,
+        "version": current_version(),
     }
 
 @app.post("/dream/run")

--- a/src/web/frontend/src/App.jsx
+++ b/src/web/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import ActivityPage from './pages/ActivityPage';
 import MemoryPage from './pages/MemoryPage';
 import SkillsPage from './pages/SkillsPage';
 import SettingsPage from './pages/SettingsPage';
+import MaintenancePage from './pages/MaintenancePage';
 import OnboardingPage from './pages/OnboardingPage';
 
 export default function App() {
@@ -22,6 +23,7 @@ export default function App() {
                 <Route path="activity" element={<ActivityPage />} />
                 <Route path="memory" element={<MemoryPage />} />
                 <Route path="skills" element={<SkillsPage />} />
+                <Route path="maintenance" element={<MaintenancePage />} />
                 <Route path="onboarding" element={<OnboardingPage />} />
                 <Route path="settings" element={<Navigate to="/dashboard/settings/mind" replace />} />
                 <Route path="settings/:section" element={<SettingsPage />} />

--- a/src/web/frontend/src/api.js
+++ b/src/web/frontend/src/api.js
@@ -115,6 +115,19 @@ export const api = {
     testVts: () => request('/test/vts', { method: 'POST' }),
     audioDevices: () => request('/audio/devices'),
 
+    // staying current: what is new, applying it, and settling a prompt the
+    // merge could not decide on its own
+    updateStatus: (force = false) => request(`/update${force ? '?force=true' : ''}`),
+    startUpdate: () => request('/update/apply', { method: 'POST' }),
+    updateRun: () => request('/update/run'),
+    review: (name) => request(`/update/reviews/${encodeURIComponent(name)}`),
+    resolveReview: (name, choice) =>
+        request(`/update/reviews/${encodeURIComponent(name)}`, { method: 'POST', body: { choice } }),
+
+    // the same checks `bea --doctor` runs
+    doctor: () => request('/doctor'),
+    runDoctor: () => request('/doctor/run', { method: 'POST' }),
+
     // the stage: what she is drawn with
     stageClips: () => request('/stage/clips'),
     vtsModel: () => request('/vts/model'),

--- a/src/web/frontend/src/components/Sidebar.jsx
+++ b/src/web/frontend/src/components/Sidebar.jsx
@@ -6,7 +6,7 @@ import {
 } from 'lucide-react';
 import { api } from '../api';
 import { cn } from '../lib/cn';
-import { NAV, VERSION } from '../lib/nav';
+import { NAV } from '../lib/nav';
 import { relativeTime } from '../lib/format';
 import { DESKTOP, useMediaQuery } from '../hooks/useMediaQuery';
 import { useToast } from '../state/ToastProvider';
@@ -309,7 +309,7 @@ export function Sidebar({ mobileOpen, onCloseMobile }) {
                     </NavLink>
                     {!rail && (
                         <p className="truncate px-2.5 pt-2 font-mono text-[10px] tracking-wider text-faint">
-                            {name} Control Room · {VERSION}
+                            {name} Control Room{status?.version ? ` · v${status.version}` : ''}
                         </p>
                     )}
                 </div>

--- a/src/web/frontend/src/components/StarNudge.jsx
+++ b/src/web/frontend/src/components/StarNudge.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Star } from 'lucide-react';
+import { Glass } from './glass/Glass';
+import { Button } from './ui/controls';
+
+const REPO = 'https://github.com/emqnuele/projectBEA';
+
+const KEY = {
+    visits: 'bea.star.visits',
+    lastShown: 'bea.star.shown',
+    never: 'bea.star.never',
+};
+
+// asking somebody to vouch for software they have used twice is asking a
+// stranger for a reference
+const AFTER_VISITS = 6;
+
+// if the answer was "not now", it stays "not now" for a fortnight
+const QUIET_FOR = 14 * 24 * 60 * 60 * 1000;
+
+function read(key, fallback = 0) {
+    try {
+        return Number(localStorage.getItem(key)) || fallback;
+    } catch {
+        return fallback;
+    }
+}
+
+function store(key, value) {
+    try {
+        localStorage.setItem(key, String(value));
+    } catch { /* private windows are allowed to have opinions */ }
+}
+
+/**
+ * An occasional, dismissible ask for a GitHub star.
+ *
+ * The only way this feature fails is by being annoying, so all of the logic is
+ * about not appearing: not before somebody has actually used her, not twice in
+ * a fortnight, and never again once they have said so. It is also the only
+ * thing on this screen that has nothing to do with running her, which is why it
+ * sits at the bottom of the page rather than in the chrome.
+ */
+export function StarNudge() {
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+        if (read(KEY.never)) return;
+
+        const visits = read(KEY.visits) + 1;
+        store(KEY.visits, visits);
+        if (visits < AFTER_VISITS) return;
+
+        const lastShown = read(KEY.lastShown);
+        if (lastShown && Date.now() - lastShown < QUIET_FOR) return;
+
+        store(KEY.lastShown, Date.now());
+        setShow(true);
+    }, []);
+
+    if (!show) return null;
+
+    const close = (forever) => () => {
+        if (forever) store(KEY.never, 1);
+        setShow(false);
+    };
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.6, type: 'spring', stiffness: 380, damping: 34 }}
+        >
+            <Glass quiet className="mt-2.5 flex flex-wrap items-center justify-between gap-3 rounded-b3 p-4">
+                <div className="flex min-w-0 items-center gap-3">
+                    <span
+                        className="grid h-9 w-9 shrink-0 place-items-center rounded-b2"
+                        style={{ background: 'var(--vital-soft)', color: 'var(--vital)' }}
+                    >
+                        <Star size={16} />
+                    </span>
+                    <div className="min-w-0">
+                        <h2 className="font-display text-[13px] font-semibold text-text">
+                            Enjoying her? Star the repo
+                        </h2>
+                        <p className="mt-0.5 text-[11px] leading-snug text-faint">
+                            It is free, it takes a second, and it is how other people find this.
+                        </p>
+                    </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                    <Button variant="ghost" size="sm" onClick={close(true)}>Don&apos;t ask again</Button>
+                    {/* an anchor, not a button: the star happens on GitHub, and
+                        this is the one control on the dashboard that leaves it */}
+                    <a
+                        href={REPO}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        onClick={close(true)}
+                        className="inline-flex h-8 select-none items-center gap-1.5 rounded-b1 border border-transparent
+                                   bg-text px-3 text-xs font-semibold text-bg transition-all duration-150
+                                   hover:opacity-90 active:scale-[0.98]"
+                    >
+                        <Star size={13} /> Star on GitHub
+                    </a>
+                </div>
+            </Glass>
+        </motion.div>
+    );
+}

--- a/src/web/frontend/src/components/TopBar.jsx
+++ b/src/web/frontend/src/components/TopBar.jsx
@@ -9,6 +9,7 @@ import { useToast } from '../state/ToastProvider';
 import { Glass } from './glass/Glass';
 import { Button, IconButton } from './ui/controls';
 import { AnimatedIcon, CountUp } from './motion/effects';
+import { UpdatePill } from './maintenance/UpdatePill';
 
 /** Sleeping · Speaking · Thinking · Listening — derived once, shown everywhere. */
 export function usePresence() {
@@ -80,6 +81,8 @@ export function TopBar({ onOpenMenu, onOpenPalette }) {
             </div>
 
             <div className="ml-auto flex items-center gap-1.5 sm:gap-2">
+                <UpdatePill />
+
                 {sessionTokens !== null && (
                     <span className="hidden items-center gap-1.5 rounded-full border border-line px-2.5 py-1 font-mono text-[10px] text-dim md:inline-flex">
                         <CountUp value={sessionTokens} format={compact} />

--- a/src/web/frontend/src/components/maintenance/DoctorPanel.jsx
+++ b/src/web/frontend/src/components/maintenance/DoctorPanel.jsx
@@ -1,0 +1,175 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertTriangle, Check, Stethoscope, X } from 'lucide-react';
+import { api } from '../../api';
+import { cn } from '../../lib/cn';
+import { useToast } from '../../state/ToastProvider';
+import { Glass } from '../glass/Glass';
+import { Button } from '../ui/controls';
+import { Spinner } from '../ui/feedback';
+
+const VERDICT = {
+    ok: { colour: 'var(--flux-act)', icon: Check },
+    warning: { colour: 'var(--flux-think)', icon: AlertTriangle },
+    blocked: { colour: 'var(--flux-err)', icon: X },
+};
+
+const POLL_EVERY = 700;
+
+/**
+ * The same checks `bea --doctor` runs, for the people who never open a terminal.
+ *
+ * They are the ones who need it: the failure it diagnoses looks, from the
+ * dashboard, like nothing at all — she is simply quiet. Findings are rendered
+ * as they land rather than at the end, because the run takes the better part of
+ * a minute and a screen that sits still for a minute reads as broken.
+ */
+export function DoctorPanel() {
+    const [run, setRun] = useState(null);
+    const toast = useToast();
+    const polling = useRef(null);
+
+    const running = run?.state === 'running';
+
+    const load = useCallback(async () => {
+        try {
+            return setRun(await api.doctor());
+        } catch {
+            return undefined;
+        }
+    }, []);
+
+    useEffect(() => { load(); }, [load]);
+
+    useEffect(() => {
+        if (!running) return undefined;
+        polling.current = setInterval(load, POLL_EVERY);
+        return () => clearInterval(polling.current);
+    }, [running, load]);
+
+    const start = async () => {
+        try {
+            setRun(await api.runDoctor());
+        } catch (e) {
+            toast.error('The checks could not start', e.message);
+        }
+    };
+
+    const findings = run?.findings || [];
+    const verdict = run?.verdict;
+
+    return (
+        <Glass quiet className="rounded-b3 p-5">
+            <header className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <p className="font-mono text-[10px] uppercase tracking-widest text-faint">Diagnosis</p>
+                    <h2 className="font-display text-[17px] font-bold leading-tight text-text">
+                        Is everything working?
+                    </h2>
+                    <p className="mt-1 max-w-md text-[12px] leading-relaxed text-dim">
+                        Keys, the mind, her voice, her ears, her memory, her body, OBS and the
+                        dashboard — checked in the order they depend on each other, stopping at the
+                        first thing that would stop her.
+                    </p>
+                </div>
+                <Button variant={findings.length ? 'outline' : 'primary'} size="sm"
+                        onClick={start} loading={running}>
+                    <Stethoscope size={13} /> {findings.length ? 'Run again' : 'Run the checks'}
+                </Button>
+            </header>
+
+            {verdict && !running && <Verdict verdict={verdict} />}
+
+            <ol className="mt-4 space-y-1">
+                <AnimatePresence initial={false}>
+                    {findings.map((finding) => (
+                        <motion.li
+                            key={finding.title}
+                            layout
+                            initial={{ opacity: 0, x: -6 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            transition={{ type: 'spring', stiffness: 480, damping: 34 }}
+                        >
+                            <Finding finding={finding} />
+                        </motion.li>
+                    ))}
+                </AnimatePresence>
+
+                {running && (
+                    <li className="flex items-center gap-2.5 px-1 py-1.5 text-[12px] text-faint">
+                        <Spinner size={12} />
+                        {findings.length
+                            ? `${findings.length} of ${run.total} checked…`
+                            : 'Starting…'}
+                        <span className="text-faint/70">
+                            some of these call your providers, so give it a moment
+                        </span>
+                    </li>
+                )}
+            </ol>
+
+            {!findings.length && !running && (
+                <p className="mt-4 text-[12px] leading-relaxed text-faint">
+                    Nothing has been checked yet. The run builds her voice, transcribes a line and
+                    asks the mind a question, so it costs a few requests at your provider.
+                </p>
+            )}
+        </Glass>
+    );
+}
+
+function Verdict({ verdict }) {
+    const tone = VERDICT[verdict.level] || VERDICT.warning;
+    const Icon = tone.icon;
+
+    return (
+        <div
+            className="mt-4 flex items-start gap-3 rounded-b2 border px-3.5 py-3"
+            style={{
+                borderColor: `color-mix(in srgb, ${tone.colour} 32%, transparent)`,
+                background: `color-mix(in srgb, ${tone.colour} 9%, transparent)`,
+            }}
+        >
+            <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full"
+                  style={{ background: `color-mix(in srgb, ${tone.colour} 18%, transparent)`, color: tone.colour }}>
+                <Icon size={12} strokeWidth={2.8} />
+            </span>
+            <div className="min-w-0">
+                <p className="text-[13px] font-semibold text-text">{verdict.headline}</p>
+                <p className="mt-0.5 text-[12px] leading-relaxed text-dim">{verdict.detail}</p>
+            </div>
+        </div>
+    );
+}
+
+function Finding({ finding }) {
+    const colour = finding.ok
+        ? 'var(--flux-act)'
+        : finding.blocking ? 'var(--flux-err)' : 'var(--flux-think)';
+    const Icon = finding.ok ? Check : finding.blocking ? X : AlertTriangle;
+
+    return (
+        <div className="rounded-b2 px-1 py-1.5 transition-colors hover:bg-fill">
+            <div className="flex items-start gap-2.5">
+                <span className="mt-[2px] shrink-0" style={{ color: colour }}>
+                    <Icon size={13} strokeWidth={2.6} />
+                </span>
+                <div className="min-w-0 flex-1">
+                    <p className="text-[12.5px] leading-snug">
+                        <span className={cn('font-semibold', finding.ok ? 'text-text' : 'text-text')}>
+                            {finding.title}
+                        </span>
+                        {finding.detail && <span className="ml-2 text-faint">{finding.detail}</span>}
+                    </p>
+                    {/* the fix is the whole point of a failed check, so it is never folded away */}
+                    {!finding.ok && finding.fix && (
+                        <pre className="mt-1.5 whitespace-pre-wrap rounded-b1 border border-line bg-fill px-2.5 py-2
+                                        font-mono text-[11px] leading-relaxed text-dim">
+                            {finding.fix}
+                        </pre>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/web/frontend/src/components/maintenance/PromptReview.jsx
+++ b/src/web/frontend/src/components/maintenance/PromptReview.jsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FileWarning } from 'lucide-react';
+import { api } from '../../api';
+import { cn } from '../../lib/cn';
+import { alignLines, countChanges } from '../../lib/diff';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/controls';
+import { Spinner } from '../ui/feedback';
+
+const TONE = {
+    same: '',
+    changed: 'var(--flux-think)',
+    added: 'var(--flux-act)',
+    removed: 'var(--flux-err)',
+};
+
+/**
+ * The two versions of a prompt the merge could not settle, side by side.
+ *
+ * The decision is deliberately not phrased as "resolve a conflict": the person
+ * reading this wrote a character, they did not open a pull request. What they
+ * are being asked is which of two paragraphs she should be reading from
+ * tonight, and the left column is the one she is using right now.
+ */
+export function PromptReview({ name, open, onClose, onResolve }) {
+    const [review, setReview] = useState(null);
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        if (!open || !name) return undefined;
+        let alive = true;
+        setReview(null);
+        api.review(name)
+            .then((data) => { if (alive) setReview(data); })
+            .catch(() => { if (alive) setReview({ mine: '', theirs: '', failed: true }); });
+        return () => { alive = false; };
+    }, [open, name]);
+
+    const diff = useMemo(
+        () => (review ? alignLines(review.mine, review.theirs) : null),
+        [review],
+    );
+
+    const settle = (choice) => async () => {
+        setBusy(true);
+        try {
+            await onResolve(name, choice);
+            onClose();
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const changes = diff ? countChanges(diff.rows) : 0;
+
+    return (
+        <Modal
+            open={open}
+            onClose={onClose}
+            size="xl"
+            title={name}
+            description={
+                diff
+                    ? `${changes} line${changes === 1 ? '' : 's'} differ · she is running the version on the left`
+                    : 'Loading both versions…'
+            }
+            footer={
+                <>
+                    <Button variant="ghost" onClick={onClose} disabled={busy}>Decide later</Button>
+                    <Button variant="outline" onClick={settle('theirs')} loading={busy}>
+                        Use the new version
+                    </Button>
+                    <Button variant="primary" onClick={settle('mine')} loading={busy}>
+                        Keep mine
+                    </Button>
+                </>
+            }
+        >
+            {!diff ? (
+                <div className="grid h-64 place-items-center"><Spinner size={20} /></div>
+            ) : (
+                <div className="-mx-1">
+                    <div className="sticky top-0 z-10 grid grid-cols-2 gap-px bg-line text-[10px] font-mono uppercase tracking-widest">
+                        <span className="bg-bg-raised px-3 py-1.5 text-dim">Yours · in use</span>
+                        <span className="bg-bg-raised px-3 py-1.5 text-dim">The new version</span>
+                    </div>
+                    <div className="max-h-[56vh] overflow-auto rounded-b-b2 border border-line border-t-0">
+                        <table className="w-full border-collapse font-mono text-[11.5px] leading-[1.55]">
+                            <tbody>
+                                {diff.rows.map((row, index) => (
+                                    <Row key={index} row={row} />
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                    {diff.truncated && (
+                        <p className="mt-2 text-[11px] text-faint">
+                            These files are too long to line up properly, so they are shown
+                            side by side instead.
+                        </p>
+                    )}
+                </div>
+            )}
+        </Modal>
+    );
+}
+
+function Row({ row }) {
+    const colour = TONE[row.state];
+    const tint = colour
+        ? { background: `color-mix(in srgb, ${colour} 9%, transparent)` }
+        : undefined;
+
+    return (
+        <tr style={tint}>
+            <Cell number={row.leftNumber} text={row.left} muted={row.state === 'added'} colour={colour} />
+            <Cell number={row.rightNumber} text={row.right} muted={row.state === 'removed'} colour={colour}
+                className="border-l border-line" />
+        </tr>
+    );
+}
+
+function Cell({ number, text, muted, colour, className }) {
+    return (
+        <td className={cn('w-1/2 align-top', className)}>
+            <div className="flex gap-2.5 px-2 py-[1px]">
+                <span className="w-7 shrink-0 select-none text-right text-faint/70">{number ?? ''}</span>
+                <span
+                    className={cn('min-w-0 flex-1 whitespace-pre-wrap break-words', muted && 'opacity-25')}
+                    style={colour && !muted ? { color: colour } : undefined}
+                >
+                    {/* a blank line still has to occupy one, or the two sides stop lining up */}
+                    {text === '' ? ' ' : text}
+                </span>
+            </div>
+        </td>
+    );
+}
+
+/** The list that sends people into the diff above. */
+export function ReviewList({ reviews, onOpen }) {
+    if (!reviews.length) return null;
+
+    return (
+        <div className="mt-4 space-y-1.5">
+            {reviews.map((review) => (
+                <button
+                    key={review.name}
+                    onClick={() => onOpen(review.name)}
+                    className="group flex w-full items-center gap-3 rounded-b2 border px-3 py-2.5 text-left transition-colors"
+                    style={{
+                        borderColor: 'color-mix(in srgb, var(--flux-think) 30%, transparent)',
+                        background: 'color-mix(in srgb, var(--flux-think) 8%, transparent)',
+                    }}
+                >
+                    <FileWarning size={15} className="shrink-0" style={{ color: 'var(--flux-think)' }} />
+                    <span className="min-w-0 flex-1">
+                        <span className="block truncate font-mono text-xs font-semibold text-text">
+                            {review.name}
+                        </span>
+                        <span className="block truncate text-[11px] text-faint">
+                            Your version is in use. Compare it with the new one.
+                        </span>
+                    </span>
+                    <span className="shrink-0 text-[11px] font-semibold text-dim group-hover:text-text">
+                        Compare
+                    </span>
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/web/frontend/src/components/maintenance/UpdatePanel.jsx
+++ b/src/web/frontend/src/components/maintenance/UpdatePanel.jsx
@@ -1,0 +1,316 @@
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import {
+    AlertTriangle, ArrowDownToLine, Check, CheckCircle2, Minus, RefreshCw, RotateCw, X,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useUpdate } from '../../state/UpdateProvider';
+import { useToast } from '../../state/ToastProvider';
+import { Glass } from '../glass/Glass';
+import { Button } from '../ui/controls';
+import { Badge, Spinner } from '../ui/feedback';
+import { PromptReview, ReviewList } from './PromptReview';
+
+const STEP_ICON = {
+    pending: { icon: Minus, colour: 'var(--text-faint)' },
+    running: { icon: null, colour: 'var(--flux-think)' },
+    done: { icon: Check, colour: 'var(--flux-act)' },
+    skipped: { icon: Minus, colour: 'var(--text-faint)' },
+    failed: { icon: X, colour: 'var(--flux-err)' },
+};
+
+const PROMPT_TONE = {
+    merged: 'var(--flux-act)',
+    kept: 'var(--flux-act)',
+    untouched: 'var(--text-faint)',
+    conflict: 'var(--flux-think)',
+    removed: 'var(--flux-think)',
+};
+
+/**
+ * The one screen that answers "am I behind, and what happens if I click".
+ *
+ * It is a small state machine — current, available, running, finished — and the
+ * reason each state gets its own body rather than a shared one with flags is
+ * that they are answering different questions. A changelog is useless while the
+ * thing is installing, and a progress bar is noise once it is done.
+ */
+export function UpdatePanel() {
+    const { status, run, report, available, running, checking, reviews, refresh, start, resolve }
+        = useUpdate();
+    const toast = useToast();
+    const [reviewing, setReviewing] = useState(null);
+
+    const finished = run?.state === 'done' && report;
+
+    const install = async () => {
+        try {
+            await start();
+        } catch (e) {
+            toast.error('The update could not start', e.message);
+        }
+    };
+
+    return (
+        <Glass quiet className="rounded-b3 p-5">
+            <header className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <p className="font-mono text-[10px] uppercase tracking-widest text-faint">Version</p>
+                    <h2 className="font-display text-2xl font-bold leading-tight text-text">
+                        {status?.version || '—'}
+                    </h2>
+                    <p className="mt-1 font-mono text-[11px] text-faint">
+                        {status?.current ? `commit ${status.current}` : 'not a git checkout'}
+                    </p>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-2">
+                    {status?.supported && !running && (
+                        <Button variant="ghost" size="sm" onClick={() => refresh(true)} loading={checking}>
+                            <RefreshCw size={13} /> Check again
+                        </Button>
+                    )}
+                    {available && !running && !finished && (
+                        <Button variant="primary" size="sm" onClick={install}>
+                            <ArrowDownToLine size={13} /> Install update
+                        </Button>
+                    )}
+                </div>
+            </header>
+
+            <div className="mt-5">
+                <AnimatePresence mode="wait">
+                    {running || finished ? (
+                        <Fade key="run"><RunBody run={run} report={report} /></Fade>
+                    ) : !status?.supported ? (
+                        <Fade key="unsupported"><Unsupported reason={status?.reason} /></Fade>
+                    ) : available ? (
+                        <Fade key="available"><WhatIsNew status={status} /></Fade>
+                    ) : (
+                        <Fade key="current"><UpToDate checkedAt={status?.checked_at} /></Fade>
+                    )}
+                </AnimatePresence>
+            </div>
+
+            {reviews.length > 0 && (
+                <section className="mt-6 border-t border-line pt-5">
+                    <h3 className="font-display text-[13px] font-semibold text-text">
+                        {reviews.length} prompt{reviews.length === 1 ? '' : 's'} kept your version
+                    </h3>
+                    <p className="mt-1 text-[12px] leading-relaxed text-dim">
+                        An update changed the same lines you had edited, so nothing was touched — she
+                        is running exactly what you wrote. The new version is waiting beside it.
+                    </p>
+                    <ReviewList reviews={reviews} onOpen={setReviewing} />
+                </section>
+            )}
+
+            <PromptReview
+                name={reviewing}
+                open={Boolean(reviewing)}
+                onClose={() => setReviewing(null)}
+                onResolve={async (name, choice) => {
+                    await resolve(name, choice);
+                    toast.success(
+                        choice === 'mine' ? 'Your version stays' : 'The new version is in place',
+                        name,
+                    );
+                }}
+            />
+        </Glass>
+    );
+}
+
+function Fade({ children }) {
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+        >
+            {children}
+        </motion.div>
+    );
+}
+
+function UpToDate({ checkedAt }) {
+    return (
+        <div className="flex items-center gap-3">
+            <span
+                className="grid h-9 w-9 shrink-0 place-items-center rounded-b2"
+                style={{ background: 'color-mix(in srgb, var(--flux-act) 14%, transparent)', color: 'var(--flux-act)' }}
+            >
+                <CheckCircle2 size={17} />
+            </span>
+            <div className="min-w-0">
+                <p className="text-[13px] font-semibold text-text">She is up to date</p>
+                <p className="text-[11px] text-faint">
+                    {checkedAt ? `Checked ${new Date(checkedAt * 1000).toLocaleTimeString()}` : 'Never checked'}
+                </p>
+            </div>
+        </div>
+    );
+}
+
+function Unsupported({ reason }) {
+    return (
+        <div className="flex items-start gap-3">
+            <span
+                className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-b2"
+                style={{ background: 'var(--fill-2)', color: 'var(--text-faint)' }}
+            >
+                <AlertTriangle size={16} />
+            </span>
+            <div className="min-w-0">
+                <p className="text-[13px] font-semibold text-text">This install cannot update itself</p>
+                <p className="mt-0.5 text-[12px] leading-relaxed text-dim">
+                    {reason || 'Updating from here is not available.'}
+                </p>
+            </div>
+        </div>
+    );
+}
+
+function WhatIsNew({ status }) {
+    return (
+        <div>
+            <div className="flex items-center gap-2.5">
+                <Badge color="var(--vital)" dot>
+                    {status.behind} new commit{status.behind === 1 ? '' : 's'}
+                </Badge>
+                <span className="font-mono text-[11px] text-faint">→ {status.latest}</span>
+            </div>
+
+            <p className="mt-3 text-[12px] leading-relaxed text-dim">
+                Your config, your memory and the prompts you have edited are backed up first and put
+                back afterwards. Nothing you wrote is overwritten.
+            </p>
+
+            <ul className="mt-4 max-h-56 space-y-1 overflow-y-auto pr-1">
+                {status.commits.map((commit) => (
+                    <li key={commit.sha} className="flex gap-2.5 text-[12px] leading-relaxed">
+                        <span className="shrink-0 font-mono text-[11px] text-faint">{commit.sha}</span>
+                        <span className="min-w-0 flex-1 text-dim">{commit.subject}</span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function RunBody({ run, report }) {
+    const steps = run?.steps || [];
+    const settled = steps.filter((s) => ['done', 'skipped', 'failed'].includes(s.status)).length;
+    const progress = steps.length ? settled / steps.length : 0;
+    const failedSteps = steps.filter((s) => s.status === 'failed');
+
+    return (
+        <div>
+            <div className="h-[3px] overflow-hidden rounded-full bg-fill-2">
+                <motion.div
+                    className="h-full rounded-full"
+                    style={{ background: 'var(--vital)' }}
+                    animate={{ width: `${Math.round(progress * 100)}%` }}
+                    transition={{ type: 'spring', stiffness: 180, damping: 30 }}
+                />
+            </div>
+
+            <ol className="mt-4 space-y-2">
+                {steps.map((step) => <StepRow key={step.id} step={step} />)}
+            </ol>
+
+            {report && (
+                <div className="mt-5 border-t border-line pt-4">
+                    <p className={cn('text-[13px] font-semibold',
+                        report.ok ? 'text-text' : 'text-[color:var(--flux-err)]')}>
+                        {report.headline}
+                    </p>
+                    {report.detail && (
+                        <p className="mt-1 text-[12px] leading-relaxed text-dim">{report.detail}</p>
+                    )}
+
+                    {report.blocked_paths?.length > 0 && (
+                        <ul className="mt-2 space-y-0.5">
+                            {report.blocked_paths.map((path) => (
+                                <li key={path} className="font-mono text-[11px] text-faint">{path}</li>
+                            ))}
+                        </ul>
+                    )}
+
+                    {report.prompts?.length > 0 && (
+                        <ul className="mt-3 space-y-1.5">
+                            {report.prompts.map((prompt) => (
+                                <li key={prompt.path} className="flex items-baseline gap-2 text-[12px]">
+                                    <span
+                                        className="h-1.5 w-1.5 shrink-0 translate-y-[-1px] rounded-full"
+                                        style={{ background: PROMPT_TONE[prompt.state] || 'var(--text-faint)' }}
+                                    />
+                                    <span className="font-mono text-[11px] font-semibold text-text">{prompt.name}</span>
+                                    <span className="min-w-0 flex-1 text-faint">{prompt.detail}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+
+                    {failedSteps.length > 0 && (
+                        <p className="mt-3 text-[12px] leading-relaxed"
+                           style={{ color: 'var(--flux-think)' }}>
+                            She is on the new version, but part of the rebuild did not run.
+                            {' '}{failedSteps.map((s) => s.detail).join(' ')}
+                        </p>
+                    )}
+
+                    {report.backup && (
+                        <p className="mt-3 font-mono text-[11px] text-faint">
+                            backup · data/.backups/{report.backup}
+                        </p>
+                    )}
+
+                    {report.restart_required && <RestartNotice />}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function StepRow({ step }) {
+    const tone = STEP_ICON[step.status] || STEP_ICON.pending;
+    const Icon = tone.icon;
+
+    return (
+        <li className="flex items-start gap-2.5">
+            <span className="mt-[1px] grid h-4 w-4 shrink-0 place-items-center" style={{ color: tone.colour }}>
+                {step.status === 'running' ? <Spinner size={12} /> : Icon && <Icon size={13} strokeWidth={2.6} />}
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className={cn('text-[12.5px] font-medium',
+                    step.status === 'pending' ? 'text-faint' : 'text-text')}>
+                    {step.label}
+                </span>
+                {step.detail && (
+                    <span className="ml-2 text-[11px] text-faint">{step.detail}</span>
+                )}
+            </span>
+        </li>
+    );
+}
+
+/** She keeps running the code she was started with until somebody restarts her. */
+function RestartNotice() {
+    return (
+        <div
+            className="mt-4 flex items-start gap-2.5 rounded-b2 border px-3 py-2.5"
+            style={{
+                borderColor: 'color-mix(in srgb, var(--vital) 34%, transparent)',
+                background: 'var(--vital-soft)',
+            }}
+        >
+            <RotateCw size={14} className="mt-0.5 shrink-0" style={{ color: 'var(--vital)' }} />
+            <p className="text-[12px] leading-relaxed text-dim">
+                The new version is on disk. She is still running the old one until you restart her:
+                {' '}<code className="font-mono text-text">uv run bea --web</code>
+            </p>
+        </div>
+    );
+}

--- a/src/web/frontend/src/components/maintenance/UpdatePill.jsx
+++ b/src/web/frontend/src/components/maintenance/UpdatePill.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowDownToLine, RotateCw, X } from 'lucide-react';
+import { useUpdate } from '../../state/UpdateProvider';
+
+/**
+ * The one piece of update chrome that follows you around.
+ *
+ * It has two things to say and they are not the same thing: there is a new
+ * version, or there is a new version already on disk and she is still running
+ * the old one. The second matters more — somebody has already clicked, and
+ * without this they would sit looking at the old dashboard wondering whether
+ * the update did anything.
+ */
+export function UpdatePill() {
+    const { available, running, restartRequired, status, dismiss } = useUpdate();
+    const navigate = useNavigate();
+
+    const mode = restartRequired ? 'restart' : running ? 'running' : available ? 'available' : null;
+    if (!mode) return null;
+
+    const copy = {
+        available: { icon: ArrowDownToLine, label: `Update · ${status?.behind}`, colour: 'var(--vital)' },
+        running: { icon: ArrowDownToLine, label: 'Updating…', colour: 'var(--flux-think)' },
+        restart: { icon: RotateCw, label: 'Restart to finish', colour: 'var(--vital)' },
+    }[mode];
+    const Icon = copy.icon;
+
+    return (
+        <AnimatePresence>
+            <motion.div
+                initial={{ opacity: 0, scale: 0.94 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.94 }}
+                transition={{ type: 'spring', stiffness: 520, damping: 34 }}
+                className="flex items-center"
+            >
+                <button
+                    onClick={() => navigate('/dashboard/maintenance')}
+                    title="Open maintenance"
+                    className="inline-flex h-8 items-center gap-1.5 rounded-full border px-2.5 text-[11px] font-semibold transition-all hover:brightness-110"
+                    style={{
+                        color: copy.colour,
+                        borderColor: `color-mix(in srgb, ${copy.colour} 34%, transparent)`,
+                        background: `color-mix(in srgb, ${copy.colour} 12%, transparent)`,
+                    }}
+                >
+                    <motion.span
+                        animate={mode === 'running' ? { y: [0, 2, 0] } : {}}
+                        transition={{ repeat: Infinity, duration: 1.4, ease: 'easeInOut' }}
+                        className="grid place-items-center"
+                    >
+                        <Icon size={12} strokeWidth={2.6} />
+                    </motion.span>
+                    <span className="hidden sm:inline">{copy.label}</span>
+                </button>
+
+                {mode === 'available' && (
+                    <button
+                        onClick={() => dismiss(status?.latest)}
+                        aria-label="Not now"
+                        title="Not now"
+                        className="-ml-1 grid h-8 w-6 place-items-center rounded-full text-faint transition-colors hover:text-text"
+                    >
+                        <X size={11} />
+                    </button>
+                )}
+            </motion.div>
+        </AnimatePresence>
+    );
+}

--- a/src/web/frontend/src/lib/diff.js
+++ b/src/web/frontend/src/lib/diff.js
@@ -1,0 +1,113 @@
+/**
+ * A line diff, so a prompt conflict can be read instead of squinted at.
+ *
+ * Longest common subsequence, which is what every diff tool uses and what makes
+ * "these forty lines are the same, these three are not" fall out of the data
+ * rather than out of guesswork. Prompts are hundreds of lines, so the quadratic
+ * table is nothing; the cap below is only there so a pathological paste cannot
+ * lock the tab up.
+ */
+
+const MAX_LINES = 4000;
+
+/**
+ * Pairs the two versions line by line.
+ * Each row is { left, right, leftNumber, rightNumber, state } where state is
+ * 'same' | 'changed' | 'added' | 'removed'.
+ */
+export function alignLines(mine = '', theirs = '') {
+    const a = mine.split('\n');
+    const b = theirs.split('\n');
+
+    if (a.length > MAX_LINES || b.length > MAX_LINES) {
+        return { rows: pairBluntly(a, b), truncated: true };
+    }
+
+    const table = lcsTable(a, b);
+    const rows = [];
+    let i = 0;
+    let j = 0;
+
+    while (i < a.length && j < b.length) {
+        if (a[i] === b[j]) {
+            rows.push({ left: a[i], right: b[j], leftNumber: i + 1, rightNumber: j + 1, state: 'same' });
+            i += 1;
+            j += 1;
+        } else if (table[i + 1][j] >= table[i][j + 1]) {
+            rows.push({ left: a[i], right: null, leftNumber: i + 1, rightNumber: null, state: 'removed' });
+            i += 1;
+        } else {
+            rows.push({ left: null, right: b[j], leftNumber: null, rightNumber: j + 1, state: 'added' });
+            j += 1;
+        }
+    }
+    while (i < a.length) {
+        rows.push({ left: a[i], right: null, leftNumber: i + 1, rightNumber: null, state: 'removed' });
+        i += 1;
+    }
+    while (j < b.length) {
+        rows.push({ left: null, right: b[j], leftNumber: null, rightNumber: j + 1, state: 'added' });
+        j += 1;
+    }
+
+    return { rows: pairAdjacent(rows), truncated: false };
+}
+
+/** How many lines differ at all — the number worth putting on a summary line. */
+export function countChanges(rows) {
+    return rows.filter((row) => row.state !== 'same').length;
+}
+
+/**
+ * Collapses a removal immediately followed by an addition into one row.
+ * An edited line is one thing that happened, and reading it as a deletion above
+ * an insertion makes every rewording look twice as large as it is.
+ */
+function pairAdjacent(rows) {
+    const paired = [];
+    for (let index = 0; index < rows.length; index += 1) {
+        const row = rows[index];
+        const next = rows[index + 1];
+        if (row.state === 'removed' && next?.state === 'added') {
+            paired.push({
+                left: row.left,
+                right: next.right,
+                leftNumber: row.leftNumber,
+                rightNumber: next.rightNumber,
+                state: 'changed',
+            });
+            index += 1;
+        } else {
+            paired.push(row);
+        }
+    }
+    return paired;
+}
+
+function pairBluntly(a, b) {
+    const rows = [];
+    for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+        const left = index < a.length ? a[index] : null;
+        const right = index < b.length ? b[index] : null;
+        rows.push({
+            left,
+            right,
+            leftNumber: left === null ? null : index + 1,
+            rightNumber: right === null ? null : index + 1,
+            state: left === right ? 'same' : 'changed',
+        });
+    }
+    return rows;
+}
+
+function lcsTable(a, b) {
+    const table = Array.from({ length: a.length + 1 }, () => new Uint32Array(b.length + 1));
+    for (let i = a.length - 1; i >= 0; i -= 1) {
+        for (let j = b.length - 1; j >= 0; j -= 1) {
+            table[i][j] = a[i] === b[j]
+                ? table[i + 1][j + 1] + 1
+                : Math.max(table[i + 1][j], table[i][j + 1]);
+        }
+    }
+    return table;
+}

--- a/src/web/frontend/src/lib/nav.js
+++ b/src/web/frontend/src/lib/nav.js
@@ -1,5 +1,5 @@
 import {
-    Activity, Blocks, BrainCircuit, Gauge, ListChecks, MessageSquare, Users,
+    Activity, Blocks, BrainCircuit, Gauge, ListChecks, MessageSquare, Users, Wrench,
 } from 'lucide-react';
 
 export const NAV = [
@@ -9,6 +9,7 @@ export const NAV = [
     { to: '/dashboard/activity', label: 'Activity', icon: Activity, hint: 'What she is perceiving and doing' },
     { to: '/dashboard/memory', label: 'Memory', icon: Users, hint: 'Who she knows and what she remembers' },
     { to: '/dashboard/skills', label: 'Abilities', icon: Blocks, hint: 'What she is able to do' },
+    { to: '/dashboard/maintenance', label: 'Maintenance', icon: Wrench, hint: 'Updates, and whether anything is broken' },
 ];
 
 export const SETTINGS_SECTIONS = [
@@ -30,4 +31,3 @@ export const SETTINGS_SECTIONS = [
 ];
 
 export const BRAND_ICON = BrainCircuit;
-export const VERSION = 'v2.0';

--- a/src/web/frontend/src/main.jsx
+++ b/src/web/frontend/src/main.jsx
@@ -6,6 +6,7 @@ import { AppearanceProvider } from './state/AppearanceProvider';
 import { BrainProvider } from './state/BrainProvider';
 import { ToastProvider } from './state/ToastProvider';
 import { DialogProvider } from './state/DialogProvider';
+import { UpdateProvider } from './state/UpdateProvider';
 import { GlassFilters } from './components/glass/GlassFilters';
 import { DitherField } from './components/atmosphere/DitherField';
 import './index.css';
@@ -16,11 +17,13 @@ createRoot(document.getElementById('root')).render(
             <ToastProvider>
                 <DialogProvider>
                     <BrainProvider>
-                        <GlassFilters />
-                        <DitherField />
-                        <BrowserRouter>
-                            <App />
-                        </BrowserRouter>
+                        <UpdateProvider>
+                            <GlassFilters />
+                            <DitherField />
+                            <BrowserRouter>
+                                <App />
+                            </BrowserRouter>
+                        </UpdateProvider>
                     </BrainProvider>
                 </DialogProvider>
             </ToastProvider>

--- a/src/web/frontend/src/pages/BootPage.jsx
+++ b/src/web/frontend/src/pages/BootPage.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { ArrowRight, Check, Loader2, X } from 'lucide-react';
 import { api } from '../api';
-import { VERSION } from '../lib/nav';
 import { cn } from '../lib/cn';
 import { Glass } from '../components/glass/Glass';
 import { Button } from '../components/ui/controls';
@@ -27,6 +26,9 @@ const CHECKS = [
 export default function BootPage() {
     const navigate = useNavigate();
     const [state, setState] = useState({ phase: 'checking', overview: null, error: null });
+    // the version is whatever is actually installed, asked for rather than
+    // hardcoded — two numbers that can disagree is the same as having none
+    const [version, setVersion] = useState('');
     const [probing, setProbing] = useState(true);
     const entered = useRef(false);
 
@@ -37,6 +39,7 @@ export default function BootPage() {
         try {
             await api.health();
             const overview = await api.overview();
+            api.status().then((s) => setVersion(s.version || '')).catch(() => { /* chrome */ });
             setState({ phase: 'ready', overview, error: null });
         } catch (e) {
             setState({ phase: 'down', overview: null, error: e.message });
@@ -93,7 +96,7 @@ export default function BootPage() {
                     initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.15 }}
                     className="font-mono text-[10px] uppercase tracking-[0.28em] text-faint"
                 >
-                    Control room {VERSION}
+                    Control room{version ? ` v${version}` : ''}
                 </motion.p>
 
                 <h1 className="mt-3 font-display text-5xl font-extrabold leading-none tracking-tight text-text">

--- a/src/web/frontend/src/pages/HomePage.jsx
+++ b/src/web/frontend/src/pages/HomePage.jsx
@@ -12,6 +12,7 @@ import { useBrain } from '../state/BrainProvider';
 import { useToast } from '../state/ToastProvider';
 import { usePresence } from '../components/TopBar';
 import { AttentionFlux } from '../components/AttentionFlux';
+import { StarNudge } from '../components/StarNudge';
 import { Glass } from '../components/glass/Glass';
 import { Button } from '../components/ui/controls';
 import { Badge, EmptyState, Skeleton } from '../components/ui/feedback';
@@ -293,6 +294,7 @@ export default function HomePage() {
                     </div>
                 </Tile>
             </div>
+            <StarNudge />
         </div>
     );
 }

--- a/src/web/frontend/src/pages/MaintenancePage.jsx
+++ b/src/web/frontend/src/pages/MaintenancePage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { UpdatePanel } from '../components/maintenance/UpdatePanel';
+import { DoctorPanel } from '../components/maintenance/DoctorPanel';
+
+/**
+ * The two things you do to an install rather than to her: update it, and find
+ * out why it is not working.
+ *
+ * Both existed already — one as `make update`, one as `bea --doctor` — and both
+ * were invisible to everyone who runs her from this screen and never opens a
+ * terminal, which is most people.
+ */
+export default function MaintenancePage() {
+    return (
+        <div className="h-full overflow-y-auto pb-2 pr-0.5">
+            <div className="mx-auto flex max-w-3xl flex-col gap-2.5">
+                <UpdatePanel />
+                <DoctorPanel />
+            </div>
+        </div>
+    );
+}

--- a/src/web/frontend/src/state/UpdateProvider.jsx
+++ b/src/web/frontend/src/state/UpdateProvider.jsx
@@ -1,0 +1,107 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '../api';
+
+const UpdateContext = createContext(null);
+
+export function useUpdate() {
+    const value = useContext(UpdateContext);
+    if (!value) throw new Error('useUpdate must be used inside <UpdateProvider>');
+    return value;
+}
+
+// the backend caches the answer for half an hour, so asking more often than
+// this only costs a request that returns the same thing
+const CHECK_EVERY = 30 * 60 * 1000;
+
+// while a run is going the steps are the only thing moving on screen
+const PROGRESS_EVERY = 900;
+
+/**
+ * Whether there is a new version, and the run that installs it.
+ *
+ * One place, because three things ask: the pill in the top bar, the panel on
+ * the health screen, and the banner that appears once an update has landed and
+ * she is still running the old code.
+ */
+export function UpdateProvider({ children }) {
+    const [status, setStatus] = useState(null);
+    const [run, setRun] = useState(null);
+    const [checking, setChecking] = useState(false);
+    // survives a page change, not a reload: the point is to stop the pill
+    // reappearing on every navigation, not to hide an update forever
+    const dismissed = useRef(new Set());
+    const [, forceRender] = useState(0);
+
+    const refresh = useCallback(async (force = false) => {
+        setChecking(true);
+        try {
+            const next = await api.updateStatus(force);
+            setStatus(next);
+            if (next.run) setRun(next.run);
+            return next;
+        } catch {
+            // the connection banner already says the brain is gone; an update
+            // check failing on top of that is not news
+            return null;
+        } finally {
+            setChecking(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        refresh();
+        const timer = setInterval(() => refresh(), CHECK_EVERY);
+        return () => clearInterval(timer);
+    }, [refresh]);
+
+    // --- the run in flight ---
+    useEffect(() => {
+        if (run?.state !== 'running') return undefined;
+        const timer = setInterval(async () => {
+            try {
+                const next = await api.updateRun();
+                setRun(next);
+                if (next?.state === 'done') refresh(true);
+            } catch { /* the next tick will try again */ }
+        }, PROGRESS_EVERY);
+        return () => clearInterval(timer);
+    }, [run?.state, refresh]);
+
+    const start = useCallback(async () => {
+        const started = await api.startUpdate();
+        setRun(started);
+        return started;
+    }, []);
+
+    const resolve = useCallback(async (name, choice) => {
+        const result = await api.resolveReview(name, choice);
+        setStatus((prev) => (prev ? { ...prev, reviews: result.reviews } : prev));
+        return result;
+    }, []);
+
+    const dismiss = useCallback((sha) => {
+        dismissed.current.add(sha);
+        forceRender((n) => n + 1);
+    }, []);
+
+    const value = useMemo(() => {
+        const report = run?.report || null;
+        return {
+            status,
+            run,
+            report,
+            checking,
+            available: Boolean(status?.available) && !dismissed.current.has(status?.latest),
+            running: run?.state === 'running',
+            // she is on the new code on disk, not in memory, until she restarts
+            restartRequired: Boolean(report?.restart_required && report.status === 'updated'),
+            reviews: status?.reviews || [],
+            refresh,
+            start,
+            resolve,
+            dismiss,
+        };
+    }, [status, run, checking, refresh, start, resolve, dismiss]);
+
+    return <UpdateContext.Provider value={value}>{children}</UpdateContext.Provider>;
+}

--- a/src/web/health.py
+++ b/src/web/health.py
@@ -1,0 +1,129 @@
+"""`bea --doctor`, run from the dashboard.
+
+The checks were written for a terminal, and that is where people who already
+know they have a problem go. The people who need them most are the ones who do
+not know yet — she is quiet, or she will not hear them, and nothing on screen
+says which of the nine things between a microphone and a reply gave up. So the
+same sequence is exposed here, findings streamed as they land.
+
+It is never run on its own: the checks build a voice, transcribe a line and
+call the mind, which costs real money at somebody's provider. It runs when a
+person asks for it, and at no other time.
+"""
+
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.web.health")
+
+router = APIRouter(prefix="/doctor", tags=["doctor"])
+
+_run: Optional[Dict[str, Any]] = None
+_task: Optional[asyncio.Task] = None
+
+
+def _brain():
+    from src.web.app import brain_instance
+
+    return brain_instance
+
+
+@router.get("")
+def doctor_status() -> Dict[str, Any]:
+    """The last run, or nothing. Polled while the checks are landing."""
+    return _run or {"state": "idle", "findings": [], "verdict": None}
+
+
+@router.post("/run", status_code=202)
+async def run_doctor() -> Dict[str, Any]:
+    global _run, _task
+
+    if _run is not None and _run["state"] == "running":
+        raise HTTPException(status_code=409, detail="The checks are already running.")
+
+    brain = _brain()
+    if brain is None:
+        raise HTTPException(status_code=503, detail="Brain not initialized")
+
+    from src.setup.doctor import CHECKS
+
+    _run = {
+        "state": "running",
+        "started_at": time.time(),
+        "total": len(CHECKS),
+        "findings": [],
+        "verdict": None,
+    }
+    _task = asyncio.create_task(_work(brain.config))
+    return _run
+
+
+async def _work(config) -> None:
+    global _run
+
+    from src.setup.doctor import diagnose
+
+    def landed(title, finding) -> None:
+        if _run is None:
+            return
+        _run["findings"].append({
+            "title": title,
+            "ok": finding.ok,
+            "detail": finding.detail,
+            "fix": finding.fix,
+            "blocking": finding.blocking,
+            "stops": finding.stops,
+        })
+
+    try:
+        await diagnose(config, report=landed)
+    except Exception as e:  # noqa: BLE001 - the run is the product; report the failure as one
+        logger.exception("The checks could not run")
+        if _run is not None:
+            _run["findings"].append({
+                "title": "The checks themselves",
+                "ok": False, "detail": f"{type(e).__name__}: {e}",
+                "fix": "", "blocking": True, "stops": True,
+            })
+
+    if _run is not None:
+        _run["state"] = "done"
+        _run["finished_at"] = time.time()
+        _run["verdict"] = _verdict(_run["findings"], _run["total"])
+
+
+def _verdict(findings: List[Dict[str, Any]], total: int) -> Dict[str, Any]:
+    """The same reading the terminal gives: one blocker beats any number of warnings."""
+    blocking = [f["title"] for f in findings if f["stops"]]
+    warnings = [f["title"] for f in findings if not f["ok"] and not f["blocking"]]
+
+    if blocking:
+        return {
+            "level": "blocked",
+            "headline": f"{blocking[0]} is in the way",
+            # the sequence stops at the first blocker, so the rest never ran and
+            # their silence must not read as a pass
+            "detail": f"{total - len(findings)} check(s) below it never ran.",
+            "blocking": blocking,
+            "warnings": warnings,
+        }
+    if warnings:
+        return {
+            "level": "warning",
+            "headline": "She will run",
+            "detail": f"{len(warnings)} thing(s) will not work as well as they could.",
+            "blocking": [],
+            "warnings": warnings,
+        }
+    return {
+        "level": "ok",
+        "headline": "Everything checks out",
+        "detail": f"All {len(findings)} checks passed.",
+        "blocking": [],
+        "warnings": [],
+    }

--- a/src/web/updates.py
+++ b/src/web/updates.py
@@ -121,11 +121,11 @@ def start_update() -> Dict[str, Any]:
         }
 
     threading.Thread(target=_work, name="bea-update", daemon=True).start()
-    return _snapshot_run()
+    return _snapshot_run() or {}
 
 
 @router.get("/run")
-def run_progress() -> Dict[str, Any]:
+def run_progress() -> Optional[Dict[str, Any]]:
     """Polled while the bar is on screen. Returns the last run once it is over."""
     return _snapshot_run()
 

--- a/src/web/updates.py
+++ b/src/web/updates.py
@@ -1,0 +1,236 @@
+"""The dashboard's side of the updater: check, apply, and settle a conflict.
+
+`POST /update/apply` runs `git pull` and a build, which is to say it executes
+code, so it is the most powerful endpoint in the app. Three things keep it
+honest: the API binds to loopback and its CORS list is closed, the update
+itself refuses to touch anything the user modified outside `data/prompts`, and
+`updates.allow_web_apply` in config turns this door off entirely for anyone who
+would rather update from a terminal.
+
+The run happens on a worker thread. It shells out to git, uv and npm for
+minutes at a time, and doing that on the event loop would freeze every other
+screen — including the one drawing the progress bar for this very run.
+"""
+
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from src.core.update import runner
+from src.core.update import state as base_state
+from src.core.update.gitrepo import Repo
+from src.core.update.reconcile import new_file_for, pending_reviews, resolve
+from src.core.update.runner import ROOT
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.web.update")
+
+router = APIRouter(prefix="/update", tags=["update"])
+
+# the run in flight, or the last one that finished. One at a time — the file
+# lock enforces that across processes, this guards the two threads in ours.
+_run: Optional[Dict[str, Any]] = None
+_guard = threading.Lock()
+
+
+class Resolution(BaseModel):
+    choice: str = Field(..., pattern="^(mine|theirs)$")
+
+
+def _brain():
+    """Imported here rather than at module load: app.py imports this module."""
+    from src.web.app import brain_instance
+
+    return brain_instance
+
+
+def _config_flag(name: str, default: bool = True) -> bool:
+    brain = _brain()
+    block = getattr(brain.config, "updates", None) if brain else None
+    if not isinstance(block, dict):
+        return default
+    return bool(block.get(name, default))
+
+
+def _reload() -> None:
+    """Re-reads the prompts from disk, so a merge is live without a restart."""
+    brain = _brain()
+    if brain is None:
+        return
+    try:
+        brain.reload_configuration()
+    except Exception as e:  # noqa: BLE001 - a stale prompt is not worth a 500
+        logger.warning(f"Could not reload after the update: {e}")
+
+
+# --- what is out there -------------------------------------------------------
+
+
+@router.get("")
+def update_status(force: bool = False) -> Dict[str, Any]:
+    """Everything the update screens need: what is new, what is running, what needs a look."""
+    if not _config_flag("check"):
+        return {
+            "supported": False,
+            "available": False,
+            "reason": "Update checks are switched off in your settings.",
+            "can_apply": False,
+            "reviews": _reviews(),
+            "run": _snapshot_run(),
+        }
+
+    status = runner.check(root=ROOT, force=force)
+    return {
+        **status.describe(),
+        "can_apply": status.supported and _config_flag("allow_web_apply"),
+        "reviews": _reviews(),
+        "run": _snapshot_run(),
+    }
+
+
+@router.post("/check")
+def force_check() -> Dict[str, Any]:
+    return update_status(force=True)
+
+
+# --- doing it ----------------------------------------------------------------
+
+
+@router.post("/apply", status_code=202)
+def start_update() -> Dict[str, Any]:
+    if not _config_flag("allow_web_apply"):
+        raise HTTPException(
+            status_code=403,
+            detail="Updating from the dashboard is switched off. Run `make update` in a terminal.",
+        )
+
+    global _run
+    with _guard:
+        if _run is not None and _run["state"] == "running":
+            raise HTTPException(status_code=409, detail="An update is already running.")
+        _run = {
+            "state": "running",
+            "started_at": time.time(),
+            "steps": [{"id": step_id, "label": label, "status": "pending", "detail": ""}
+                      for step_id, label in runner.STEPS],
+            "report": None,
+        }
+
+    threading.Thread(target=_work, name="bea-update", daemon=True).start()
+    return _snapshot_run()
+
+
+@router.get("/run")
+def run_progress() -> Dict[str, Any]:
+    """Polled while the bar is on screen. Returns the last run once it is over."""
+    return _snapshot_run()
+
+
+def _work() -> None:
+    global _run
+
+    def progress(step: runner.Step) -> None:
+        with _guard:
+            if _run is None:
+                return
+            for entry in _run["steps"]:
+                if entry["id"] == step.id:
+                    entry["status"] = step.status
+                    entry["detail"] = step.detail
+                    break
+
+    report = runner.apply(root=ROOT, source="dashboard", progress=progress)
+
+    with _guard:
+        if _run is not None:
+            # steps that never ran would otherwise pulse forever on a failure
+            for entry in _run["steps"]:
+                if entry["status"] in ("pending", "running"):
+                    entry["status"] = "skipped" if report.ok else "pending"
+            _run["state"] = "done"
+            _run["finished_at"] = time.time()
+            _run["report"] = report.describe()
+
+    if report.status == runner.UPDATED:
+        _reload()
+
+
+def _snapshot_run() -> Optional[Dict[str, Any]]:
+    with _guard:
+        return dict(_run) if _run is not None else None
+
+
+# --- the conflicts the merge could not settle --------------------------------
+
+
+@router.get("/reviews")
+def list_reviews() -> Dict[str, Any]:
+    return {"reviews": _reviews()}
+
+
+@router.get("/reviews/{name}")
+def read_review(name: str) -> Dict[str, Any]:
+    path = _review_path(name)
+    return {
+        "name": name,
+        "path": path,
+        "mine": _text(ROOT / path),
+        "theirs": _text(new_file_for(ROOT, path)),
+    }
+
+
+@router.post("/reviews/{name}")
+def settle_review(name: str, body: Resolution) -> Dict[str, Any]:
+    path = _review_path(name)
+    repo = Repo(ROOT)
+
+    try:
+        outcome = resolve(ROOT, repo, path, body.choice, repo.head())
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    # the only place outside a clean merge where a file's base is allowed to
+    # move: a human has just said which version is the one to build on
+    bases = base_state.load(ROOT)
+    if outcome.base:
+        bases.set(path, outcome.base)
+    base_state.save(ROOT, bases)
+
+    _reload()
+    return {"resolved": outcome.describe(), "reviews": _reviews()}
+
+
+def _reviews() -> List[Dict[str, str]]:
+    try:
+        repo = Repo(ROOT)
+        if not repo.is_repo():
+            return []
+        return [{"name": Path(p).name, "path": p} for p in pending_reviews(ROOT, repo)]
+    except Exception as e:  # noqa: BLE001 - a missing list is not worth a 500
+        logger.warning(f"Could not list the prompts awaiting review: {e}")
+        return []
+
+
+def _review_path(name: str) -> str:
+    """Turns a file name from the browser into a path, or refuses.
+
+    Only names the updater itself has flagged are accepted, so nothing the
+    caller sends is ever joined onto a path we then write to.
+    """
+    for review in _reviews():
+        if review["name"] == name:
+            return review["path"]
+    raise HTTPException(status_code=404, detail=f"{name} is not waiting for a decision.")
+
+
+def _text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -20,6 +20,7 @@ from src.setup.doctor import (
     check_manual,
     check_python,
     check_stage,
+    check_updates,
     diagnose,
     failed,
     passed,
@@ -306,6 +307,52 @@ async def test_an_unbuilt_dashboard_is_only_a_warning_otherwise(monkeypatch, tmp
     found = await check_dashboard(config(stage={"avatar_backend": "png",
                                                 "caption_backend": "obs"}))
     assert not found.ok and not found.stops
+
+
+# --- can this install update itself ------------------------------------------
+#
+# Nothing in the engine shells out to git, so none of this may ever block. It is
+# here because without it the failure is invisible: the update button is simply
+# absent, and an absent button explains nothing.
+
+
+async def test_a_working_checkout_says_updates_will_work(monkeypatch):
+    monkeypatch.setattr("src.core.update.supported", lambda: "")
+    found = await check_updates(config())
+    assert found.ok
+
+
+async def test_missing_git_is_a_warning_carrying_the_install_command(monkeypatch):
+    monkeypatch.setattr("src.core.update.supported",
+                        lambda: "git is not installed, so there is nothing to pull with.")
+    found = await check_updates(config())
+
+    assert not found.ok
+    assert not found.stops, "she runs without git; this must never stop the run"
+    assert "git" in found.fix
+
+
+async def test_a_zip_download_is_told_it_cannot_update_in_place(monkeypatch):
+    monkeypatch.setattr("src.core.update.supported",
+                        lambda: "This is not a git checkout — it was most likely downloaded as a zip.")
+    found = await check_updates(config())
+
+    assert not found.ok and not found.stops
+    assert "git clone" in found.fix
+
+
+async def test_docker_is_not_a_problem_to_report(monkeypatch):
+    """There the update is a rebuild of the image, which is not a fault."""
+    monkeypatch.setattr("src.core.update.supported",
+                        lambda: "She is running in Docker, where the update is a rebuild of the image.")
+    found = await check_updates(config())
+
+    assert found.ok
+
+
+async def test_the_update_check_is_the_last_thing_asked():
+    """It is about the install, not about her: everything that stops her comes first."""
+    assert CHECKS[-1][0] == "Updates"
 
 
 # --- the exit code a script would read ---------------------------------------

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -237,3 +237,61 @@ def test_the_default_persona_leaves_the_shipped_experience_alone(tmp_path, monke
     p = persona_of(config)
     assert p.name == "Bea"
     assert set(p.trigger_words) >= {"bea"}
+
+
+# --- is she still the one we ship --------------------------------------------
+#
+# This used to read `data/prompts/soul.md` and compare it to
+# `data/prompts/soul.md`. In a normal install those are the same file, so the
+# answer could only ever be "unchanged": the banner asking people to set her up
+# never went away, not even for someone looking at the character they wrote.
+# The tests passed because their fixture ran from a temp directory, which put
+# the two paths on different files and hid the whole thing.
+
+
+def test_the_shipped_soul_hash_matches_the_file_we_ship():
+    """The guard on the constant. Changing soul.md without updating
+    SHIPPED_SOUL_SHA256 makes `customised` lie, and nothing else would notice."""
+    from pathlib import Path
+
+    from src.core.persona import SHIPPED_SOUL_SHA256
+    from src.core.persona_store import soul_digest
+
+    shipped = Path(__file__).parents[1] / "data/prompts/soul.md"
+    assert soul_digest(shipped.read_text(encoding="utf-8")) == SHIPPED_SOUL_SHA256, (
+        "data/prompts/soul.md changed. Update SHIPPED_SOUL_SHA256 in "
+        "src/core/persona.py to the value this test computed."
+    )
+
+
+def test_the_soul_we_ship_does_not_count_as_customised():
+    from pathlib import Path
+
+    from src.core.persona_store import is_customised
+
+    shipped = (Path(__file__).parents[1] / "data/prompts/soul.md").read_text(encoding="utf-8")
+    assert is_customised(shipped) is False
+
+
+def test_a_soul_somebody_wrote_counts_as_customised():
+    from src.core.persona_store import is_customised
+
+    assert is_customised("# SOUL\n\nShe is a gremlin who hates everyone.\n") is True
+
+
+def test_whitespace_alone_is_not_writing_a_character():
+    """Re-saving from the dashboard can add a newline. That is not authorship."""
+    from pathlib import Path
+
+    from src.core.persona_store import is_customised
+
+    shipped = (Path(__file__).parents[1] / "data/prompts/soul.md").read_text(encoding="utf-8")
+    assert is_customised(f"\n\n{shipped.strip()}  \n") is False
+
+
+def test_an_empty_soul_is_not_customised_either():
+    """An emptied file is a broken install, not a character."""
+    from src.core.persona_store import is_customised
+
+    assert is_customised("") is False
+    assert is_customised("   \n  ") is False

--- a/tests/test_update_api.py
+++ b/tests/test_update_api.py
@@ -54,7 +54,23 @@ def test_a_plain_directory_reports_why_it_cannot_update(client):
 
     assert body["supported"] is False
     assert body["can_apply"] is False
-    assert "not a git checkout" in body["reason"]
+    # which refusal it is depends on the machine running the suite — a box
+    # without git answers before the checkout is ever looked at
+    assert body["reason"]
+
+
+def test_a_machine_without_git_says_so_rather_than_failing(client, monkeypatch):
+    """Nothing in the engine needs git, so a box without it loses the updater
+    and nothing else. The screen has to explain that instead of going blank."""
+    from src.core.update.gitrepo import Repo
+
+    monkeypatch.setattr(Repo, "available", lambda self: False)
+    body = client.get("/update?force=true").json()
+
+    assert body["supported"] is False
+    assert body["can_apply"] is False
+    assert "git is not installed" in body["reason"]
+    assert body["reviews"] == []
 
 
 def test_the_check_can_be_switched_off(client):

--- a/tests/test_update_api.py
+++ b/tests/test_update_api.py
@@ -1,0 +1,126 @@
+"""The dashboard's door to the updater.
+
+`POST /update/apply` executes code — a pull, a `uv sync`, an `npm install` that
+runs whatever scripts the new version declares. That is legitimate and it is
+what the button is for, but it means the interesting tests here are not the
+happy path: they are the refusals, and the fact that a file name arriving from
+a browser never becomes a path we write to.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.core.config import BrainConfig
+from src.core.update import runner
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    from src.web import app as web
+    from src.web import updates
+
+    prompts = tmp_path / "data" / "prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "soul.md").write_text("mine", encoding="utf-8")
+
+    class BrainStub:
+        def __init__(self):
+            self.config = BrainConfig()
+            self.reloads = 0
+            self.skill_registry = None
+            self.history_manager = SimpleNamespace(session_id="test")
+            self.is_speaking = False
+            self.is_sleeping = False
+
+        def reload_configuration(self):
+            self.reloads += 1
+
+    brain = BrainStub()
+    monkeypatch.setattr(web, "brain_instance", brain)
+    monkeypatch.setattr(updates, "ROOT", tmp_path)
+    monkeypatch.setattr(updates, "_run", None)
+    monkeypatch.setattr(runner, "_cached", None)
+
+    with TestClient(web.app) as test_client:
+        test_client.brain = brain
+        test_client.root = tmp_path
+        yield test_client
+
+
+def test_a_plain_directory_reports_why_it_cannot_update(client):
+    body = client.get("/update").json()
+
+    assert body["supported"] is False
+    assert body["can_apply"] is False
+    assert "not a git checkout" in body["reason"]
+
+
+def test_the_check_can_be_switched_off(client):
+    client.brain.config.updates = {"check": False, "allow_web_apply": True}
+
+    body = client.get("/update").json()
+
+    assert body["supported"] is False
+    assert "switched off" in body["reason"]
+
+
+def test_applying_from_the_dashboard_can_be_revoked(client):
+    client.brain.config.updates = {"check": True, "allow_web_apply": False}
+
+    response = client.post("/update/apply")
+
+    assert response.status_code == 403
+    assert "make update" in response.json()["detail"]
+
+
+def test_a_config_without_the_block_still_works(client):
+    """A config.json written before this feature existed must not 500 the screen."""
+    delattr(client.brain.config, "updates")
+
+    assert client.get("/update").status_code == 200
+
+
+def test_a_second_apply_while_one_runs_is_refused(client, monkeypatch):
+    from src.web import updates
+
+    monkeypatch.setattr(updates, "_run", {"state": "running", "steps": [], "report": None})
+
+    assert client.post("/update/apply").status_code == 409
+
+
+def test_there_is_nothing_to_review_on_a_clean_install(client):
+    assert client.get("/update/reviews").json() == {"reviews": []}
+
+
+def test_an_unknown_review_is_not_found(client):
+    assert client.get("/update/reviews/soul.md").status_code == 404
+
+
+@pytest.mark.parametrize("name", ["../../../etc/passwd", "..%2fconfig.json", "soul.md", "operating.md"])
+def test_a_name_from_the_browser_never_becomes_a_path(client, name):
+    """Only names the updater itself flagged are accepted, so nothing is ever joined.
+
+    Asserted against the resolver rather than the route, because a traversal in
+    a URL is normalised away long before it reaches a handler — the property
+    worth pinning is that an unflagged name has no path at all, whatever it
+    looks like.
+    """
+    from fastapi import HTTPException
+
+    from src.web.updates import _review_path
+
+    with pytest.raises(HTTPException) as refused:
+        _review_path(name)
+    assert refused.value.status_code == 404
+
+
+def test_a_nonsense_resolution_is_rejected(client):
+    assert client.post("/update/reviews/soul.md", json={"choice": "burn it"}).status_code == 422
+
+
+def test_the_status_endpoint_carries_the_version(client):
+    body = client.get("/status").json()
+
+    assert body["version"] and body["version"] != "unknown"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -19,6 +19,7 @@ the result and updates again.
 """
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -28,6 +29,15 @@ from src.core.update import backup, lock, runner, state
 from src.core.update.gitrepo import Repo
 from src.core.update.reconcile import CONFLICT, KEPT, MERGED, REMOVED, UNTOUCHED, new_file_for
 from src.core.update.runner import BLOCKED, CURRENT, UPDATED
+
+# these build real repositories to test against, so they are the one part of
+# the suite that cannot run without git. The engine can: nothing outside
+# `src/core/update` ever shells out to it, which is why the updater degrades
+# into a message instead of a failure.
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git is not installed; the updater is unavailable, the engine is not",
+)
 
 SOUL = "data/prompts/soul.md"
 OPERATING = "data/prompts/operating.md"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,699 @@
+"""What the updater must never do to somebody's install.
+
+Every test here runs against real git repositories built in a temp directory —
+a bare "origin" and a clone of it — because the whole feature is an argument
+about what git does when two people change the same file, and a mocked git
+would only ever confirm what we already believe.
+
+The shape of the suite follows the shape of the problem. A file being updated
+is in one of four states, and three of them are trivial:
+
+    |                  | upstream unchanged | upstream changed |
+    | user untouched   | nothing to do      | git updates it   |
+    | user edited      | keep theirs        | ← the real work  |
+
+The last cell is where a naive updater silently destroys either the character
+someone wrote or the engine improvements they were owed, so most of what
+follows is about that one cell, and about what happens when the user ignores
+the result and updates again.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.core.update import backup, lock, runner, state
+from src.core.update.gitrepo import Repo
+from src.core.update.reconcile import CONFLICT, KEPT, MERGED, REMOVED, UNTOUCHED, new_file_for
+from src.core.update.runner import BLOCKED, CURRENT, UPDATED
+
+SOUL = "data/prompts/soul.md"
+OPERATING = "data/prompts/operating.md"
+
+# three paragraphs far enough apart that a change to one never lands in the
+# same merge hunk as a change to another — that is what makes the "both sides
+# edited, cleanly" case deterministic rather than a coin toss on diff context
+ORIGINAL = "\n".join([
+    "# Operating manual",
+    "",
+    "## Identity",
+    "She is curious.",
+    "",
+    "filler a",
+    "filler b",
+    "filler c",
+    "filler d",
+    "filler e",
+    "filler f",
+    "filler g",
+    "filler h",
+    "",
+    "## Speaking",
+    "Use the speak tool.",
+    "",
+])
+
+
+def git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True,
+        env={"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+             "HOME": str(cwd), "PATH": "/usr/bin:/bin:/usr/local/bin"},
+    )
+    assert result.returncode == 0, f"git {' '.join(args)} failed: {result.stderr}"
+    return result.stdout.strip()
+
+
+def commit(cwd: Path, message: str) -> str:
+    git(cwd, "add", "-A")
+    git(cwd, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", message)
+    return git(cwd, "rev-parse", "HEAD")
+
+
+def write(root: Path, relative: str, text: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def read(root: Path, relative: str) -> str:
+    return (root / relative).read_text(encoding="utf-8")
+
+
+def replace(root: Path, relative: str, old: str, new: str) -> None:
+    text = read(root, relative)
+    assert old in text, f"{old!r} is not in {relative}; the fixture drifted"
+    write(root, relative, text.replace(old, new))
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch):
+    """An upstream repository and somebody's clone of it."""
+    monkeypatch.setattr(runner, "_cached", None)
+
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    git(upstream, "init", "-q")
+    # git's default branch name has changed over the years; pin it either way
+    git(upstream, "symbolic-ref", "HEAD", "refs/heads/main")
+    write(upstream, SOUL, "# Soul\n\nShe is the one we ship.\n")
+    write(upstream, OPERATING, ORIGINAL)
+    write(upstream, "src/core/brain.py", "print('engine')\n")
+    write(upstream, "uv.lock", "lock = 1\n")
+    commit(upstream, "initial")
+
+    clone = tmp_path / "clone"
+    git(tmp_path, "clone", "-q", str(upstream), str(clone))
+    return upstream, clone
+
+
+def update(clone: Path, **kwargs) -> runner.Report:
+    runner.invalidate()
+    return runner.apply(root=clone, source="test", **kwargs)
+
+
+def bases(clone: Path) -> dict:
+    return state.load(clone).bases
+
+
+# --- the three easy quadrants -------------------------------------------------
+
+
+def test_a_file_nobody_edited_just_becomes_the_new_one(world):
+    upstream, clone = world
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, always.")
+    head = commit(upstream, "clarify speaking")
+
+    report = update(clone)
+
+    assert report.status == UPDATED
+    assert "Use the speak tool, always." in read(clone, OPERATING)
+    assert report.prompts == [], "a file the user never touched is not worth reporting"
+    assert bases(clone)[OPERATING] == head
+
+
+def test_an_edited_file_untouched_upstream_is_kept(world):
+    upstream, clone = world
+    write(clone, SOUL, "# Soul\n\nShe is mine.\n")
+    replace(upstream, OPERATING, "She is curious.", "She is curious and blunt.")
+    head = commit(upstream, "tune identity")
+
+    report = update(clone)
+
+    assert report.status == UPDATED
+    assert read(clone, SOUL) == "# Soul\n\nShe is mine.\n"
+    assert [o.state for o in report.prompts] == [KEPT]
+    assert bases(clone)[SOUL] == head
+
+
+def test_an_edit_identical_to_the_new_version_is_a_no_op(world):
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is curious and blunt.")
+    replace(upstream, OPERATING, "She is curious.", "She is curious and blunt.")
+    head = commit(upstream, "same change")
+
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [UNTOUCHED]
+    assert bases(clone)[OPERATING] == head
+
+
+# --- the quadrant the whole thing exists for ----------------------------------
+
+
+def test_edits_on_both_sides_are_combined(world):
+    """The case that rules out both naive answers.
+
+    The user rewrote the identity paragraph; upstream improved the speaking
+    instructions. Taking theirs loses her character, keeping ours freezes the
+    engine's own manual. Both have to survive.
+    """
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic and tired.")
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, never narrate.")
+    head = commit(upstream, "improve the manual")
+
+    report = update(clone)
+
+    merged = read(clone, OPERATING)
+    assert "She is sarcastic and tired." in merged, "the user's character was dropped"
+    assert "Use the speak tool, never narrate." in merged, "the engine improvement was dropped"
+    assert [o.state for o in report.prompts] == [MERGED]
+    assert bases(clone)[OPERATING] == head
+    assert not new_file_for(clone, OPERATING).exists()
+
+
+def test_a_collision_leaves_the_users_file_exactly_as_it_was(world):
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "different identity")
+    mine = read(clone, OPERATING)
+
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [CONFLICT]
+    assert read(clone, OPERATING) == mine
+    assert "She is warm." in new_file_for(clone, OPERATING).read_text(encoding="utf-8")
+
+
+def test_a_collision_never_writes_conflict_markers(world):
+    """The one rule. `<<<<<<<` in a prompt is a system prompt that has gone mad."""
+    upstream, clone = world
+    replace(clone, SOUL, "She is the one we ship.", "She is mine.")
+    replace(upstream, SOUL, "She is the one we ship.", "She is ours.")
+    commit(upstream, "reword the shipped soul")
+
+    update(clone)
+
+    for marker in ("<<<<<<<", "=======", ">>>>>>>"):
+        assert marker not in read(clone, SOUL)
+
+
+def test_a_collision_does_not_move_the_base(world):
+    """Nothing was reconciled, so the file is still built on the old revision."""
+    upstream, clone = world
+    start = Repo(clone).head()
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "different identity")
+
+    update(clone)
+
+    assert bases(clone).get(OPERATING) in (None, start)
+
+
+# --- updating again on top of a conflict nobody resolved ----------------------
+
+
+def test_a_second_update_still_offers_the_changes_the_first_one_could_not_apply(world):
+    """The reason the base is tracked per file instead of being taken as HEAD.
+
+    The user ignored the first conflict. If the second update merged from the
+    new HEAD instead of from where their file actually branched, the changes
+    they never took would read as deletions they made — and would be dropped
+    for good, silently.
+    """
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "identity, colliding")
+    update(clone)
+    assert new_file_for(clone, OPERATING).exists()
+
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, never narrate.")
+    commit(upstream, "speaking, not colliding")
+    report = update(clone)
+
+    offered = new_file_for(clone, OPERATING).read_text(encoding="utf-8")
+    assert "Use the speak tool, never narrate." in offered, "the newest change was not carried into .new"
+    assert "She is warm." in offered, "the change from the first update was lost"
+    assert [o.state for o in report.prompts] == [CONFLICT]
+    assert read(clone, OPERATING).count("She is sarcastic.") == 1
+
+
+def test_the_stale_new_file_is_replaced_not_accumulated(world):
+    upstream, clone = world
+    replace(clone, SOUL, "She is the one we ship.", "She is mine.")
+
+    replace(upstream, SOUL, "She is the one we ship.", "Draft one.")
+    commit(upstream, "first")
+    update(clone)
+
+    replace(upstream, SOUL, "Draft one.", "Draft two.")
+    commit(upstream, "second")
+    update(clone)
+
+    offered = new_file_for(clone, SOUL).read_text(encoding="utf-8")
+    assert "Draft two." in offered
+    assert "Draft one." not in offered
+    assert not (clone / (SOUL + ".new.new")).exists()
+
+
+def test_a_conflict_that_stops_colliding_clears_itself(world):
+    """Upstream moved its change elsewhere, so the merge now lands. No leftovers."""
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+    update(clone)
+    assert new_file_for(clone, OPERATING).exists()
+
+    replace(upstream, OPERATING, "She is warm.", "She is curious.")
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, briefly.")
+    head = commit(upstream, "reverted, and something else")
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [MERGED]
+    assert not new_file_for(clone, OPERATING).exists(), "a resolved conflict left its .new behind"
+    assert "She is sarcastic." in read(clone, OPERATING)
+    assert "Use the speak tool, briefly." in read(clone, OPERATING)
+    assert bases(clone)[OPERATING] == head
+
+
+# --- the human ending to a conflict -------------------------------------------
+
+
+def test_keeping_mine_clears_the_review_and_advances_the_base(world):
+    from src.core.update.reconcile import resolve
+
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+    update(clone)
+
+    repo = Repo(clone)
+    outcome = resolve(clone, repo, OPERATING, "mine", repo.head())
+
+    assert outcome.base == repo.head()
+    assert not new_file_for(clone, OPERATING).exists()
+    assert "She is sarcastic." in read(clone, OPERATING)
+
+
+def test_taking_theirs_replaces_the_file(world):
+    from src.core.update.reconcile import resolve
+
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+    update(clone)
+
+    repo = Repo(clone)
+    resolve(clone, repo, OPERATING, "theirs", repo.head())
+
+    assert "She is warm." in read(clone, OPERATING)
+    assert "She is sarcastic." not in read(clone, OPERATING)
+    assert not new_file_for(clone, OPERATING).exists()
+
+
+def test_after_resolving_the_next_update_does_not_replay_the_same_change(world):
+    """What the explicit resolution buys: the base moved, so the delta is not re-applied."""
+    from src.core.update.reconcile import resolve
+
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+    update(clone)
+
+    repo = Repo(clone)
+    outcome = resolve(clone, repo, OPERATING, "mine", repo.head())
+    bases_now = state.load(clone)
+    bases_now.set(OPERATING, outcome.base)
+    state.save(clone, bases_now)
+
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, briefly.")
+    commit(upstream, "unrelated")
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [MERGED]
+    assert "She is sarcastic." in read(clone, OPERATING)
+    assert "She is warm." not in read(clone, OPERATING), "the resolved change came back"
+
+
+def test_resolving_refuses_an_unknown_choice(world):
+    from src.core.update.reconcile import resolve
+
+    _, clone = world
+    with pytest.raises(ValueError):
+        resolve(clone, Repo(clone), OPERATING, "whatever", "HEAD")
+
+
+# --- what it refuses to do ----------------------------------------------------
+
+
+def test_local_changes_to_the_engine_stop_the_update(world):
+    upstream, clone = world
+    write(clone, "src/core/brain.py", "print('my own patch')\n")
+    replace(upstream, SOUL, "She is the one we ship.", "changed")
+    commit(upstream, "anything")
+    before = Repo(clone).head()
+
+    report = update(clone)
+
+    assert report.status == BLOCKED
+    assert report.blocked_paths == ["src/core/brain.py"]
+    assert Repo(clone).head() == before, "a blocked update still moved the repository"
+    assert read(clone, "src/core/brain.py") == "print('my own patch')\n"
+
+
+def test_a_diverged_checkout_is_reported_not_rewritten(world):
+    upstream, clone = world
+    write(clone, "data/prompts/mine.md", "a commit of my own\n")
+    commit(clone, "local work")
+    local_head = git(clone, "rev-parse", "HEAD")
+    replace(upstream, SOUL, "She is the one we ship.", "changed")
+    commit(upstream, "upstream work")
+
+    report = update(clone)
+
+    assert report.status == BLOCKED
+    assert "fast-forward" in report.detail
+    assert git(clone, "rev-parse", "HEAD") == local_head
+
+
+def test_nothing_new_is_not_an_update(world):
+    _, clone = world
+    report = update(clone)
+
+    assert report.status == CURRENT
+    assert [s.status for s in report.steps if s.id == "apply"] == ["skipped"]
+
+
+def test_a_directory_that_is_not_a_checkout_says_so(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "_cached", None)
+    report = runner.apply(root=tmp_path, source="test")
+
+    assert report.status == BLOCKED
+    assert "not a git checkout" in report.detail
+
+
+def test_a_prompt_edited_mid_update_stops_the_run(world, monkeypatch):
+    """The narrow window between reading the user's file and resetting it.
+
+    The dashboard can save a prompt at any moment, including the moment after
+    the updater has read it and before it hands the path to git. Losing that
+    save is not acceptable, so the run re-reads and bails out instead.
+    """
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, briefly.")
+    commit(upstream, "upstream work")
+    before = Repo(clone).head()
+
+    original_fetch = Repo.fetch
+
+    def fetch_then_meddle(self, remote="origin"):
+        original_fetch(self, remote)
+        write(clone, OPERATING, read(clone, OPERATING) + "\na late save from the dashboard\n")
+
+    monkeypatch.setattr(Repo, "fetch", fetch_then_meddle)
+    report = update(clone)
+
+    assert report.status == BLOCKED
+    assert report.blocked_paths == [OPERATING]
+    assert Repo(clone).head() == before
+    assert "a late save from the dashboard" in read(clone, OPERATING)
+
+
+def test_only_one_update_runs_at_a_time(world):
+    _, clone = world
+    with lock.held(clone, "somebody else"):
+        report = update(clone)
+
+    assert report.status == BLOCKED
+    assert "already running" in report.headline
+
+
+def test_a_stale_lock_does_not_wedge_the_feature_forever(world, monkeypatch):
+    _, clone = world
+    with lock.held(clone, "a process that died"):
+        monkeypatch.setattr(lock, "STALE_AFTER", -1)
+        report = update(clone)
+
+    assert report.status == CURRENT, "a lock older than the timeout should have been cleared"
+
+
+# --- when the file is gone upstream -------------------------------------------
+
+
+def test_a_prompt_deleted_upstream_keeps_the_users_copy(world):
+    upstream, clone = world
+    replace(clone, SOUL, "She is the one we ship.", "She is mine.")
+    (upstream / SOUL).unlink()
+    commit(upstream, "drop the shipped soul")
+
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [REMOVED]
+    assert read(clone, SOUL) == "# Soul\n\nShe is mine.\n"
+
+
+# --- degrading safely ----------------------------------------------------------
+
+
+def test_a_first_update_takes_the_revision_they_are_on_as_the_base(world):
+    """There is no state file before the first update, and none is needed.
+
+    A checkout nobody has updated yet holds files that came out of the commit
+    it is sitting on, so that commit is the base — by construction, not by
+    guesswork. Refusing to merge here would make the very first update of every
+    install a conflict.
+    """
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, briefly.")
+    commit(upstream, "an easy change")
+    assert not (clone / state.STATE_FILE).exists()
+
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [MERGED]
+    assert "She is sarcastic." in read(clone, OPERATING)
+    assert "Use the speak tool, briefly." in read(clone, OPERATING)
+
+
+def test_a_pending_conflict_outlives_a_lost_state_file(world):
+    """The rule that makes the complexity affordable: it fails into the simple thing.
+
+    Without the state file we do not know what their version was based on. The
+    `.new` sitting on disk still says a conflict is open, so the merge is
+    refused rather than guessed at from HEAD — which would read the changes
+    they never took as deletions they made.
+    """
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+    update(clone)
+    assert new_file_for(clone, OPERATING).exists()
+
+    (clone / state.STATE_FILE).write_text("{ not json", encoding="utf-8")
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, briefly.")
+    commit(upstream, "an easy change nobody gets")
+    report = update(clone)
+
+    assert [o.state for o in report.prompts] == [CONFLICT]
+    assert "no record of which version" in report.prompts[0].detail
+    assert "She is sarcastic." in read(clone, OPERATING)
+
+
+def test_an_unknown_state_format_is_ignored(tmp_path):
+    (tmp_path / "data").mkdir()
+    (tmp_path / state.STATE_FILE).write_text(json.dumps({"format": 99, "bases": {"a": "b"}}))
+
+    assert state.load(tmp_path).bases == {}
+
+
+def test_the_state_file_survives_a_round_trip(tmp_path):
+    written = state.BaseMap({SOUL: "a" * 40})
+    state.save(tmp_path, written)
+
+    assert state.load(tmp_path).get(SOUL) == "a" * 40
+
+
+def test_a_truncated_sha_is_not_a_base(tmp_path):
+    assert state.BaseMap({SOUL: "abc"}).get(SOUL) is None
+
+
+# --- backups and crashes -------------------------------------------------------
+
+
+def test_the_users_prompt_is_in_the_backup_before_anything_is_touched(world):
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+
+    report = update(clone)
+
+    saved = clone / backup.BACKUP_ROOT / report.backup / OPERATING
+    assert "She is sarcastic." in saved.read_text(encoding="utf-8")
+
+
+def test_an_update_that_died_mid_flight_is_undone_by_the_next_one(world):
+    upstream, clone = world
+    write(clone, OPERATING, "the version I wrote\n")
+    snapshot = backup.take(clone, [OPERATING], "deadbeef")
+    backup.open_journal(clone, "merge", snapshot, "deadbeef", [OPERATING])
+    # what a crash between the reset and the reconciliation leaves behind
+    write(clone, OPERATING, "a half-applied upstream version\n")
+
+    restored = backup.recover(clone)
+
+    assert restored == [OPERATING]
+    assert read(clone, OPERATING) == "the version I wrote\n"
+    assert not (clone / backup.JOURNAL_FILE).exists()
+
+
+def test_a_crash_before_anything_was_written_restores_nothing(world):
+    _, clone = world
+    snapshot = backup.take(clone, [OPERATING], "deadbeef")
+    backup.open_journal(clone, "preflight", snapshot, "deadbeef", [OPERATING])
+    write(clone, OPERATING, "untouched by the update\n")
+
+    assert backup.recover(clone) == []
+    assert read(clone, OPERATING) == "untouched by the update\n"
+    assert not (clone / backup.JOURNAL_FILE).exists()
+
+
+def test_old_backups_are_pruned(world, monkeypatch):
+    _, clone = world
+    monkeypatch.setattr(backup, "KEEP_BACKUPS", 2)
+    for index in range(4):
+        directory = clone / backup.BACKUP_ROOT / f"2024010{index}-000000"
+        directory.mkdir(parents=True)
+    backup.take(clone, [OPERATING], "deadbeef")
+
+    kept = sorted(d.name for d in (clone / backup.BACKUP_ROOT).iterdir())
+    assert len(kept) == 2
+
+
+# --- the rebuild half ----------------------------------------------------------
+
+
+def test_a_dependency_change_is_what_triggers_uv_sync(world):
+    upstream, clone = world
+    write(upstream, "uv.lock", "lock = 2\n")
+    commit(upstream, "bump a dependency")
+
+    calls = []
+    report = runner.apply(
+        root=clone, source="test",
+        progress=lambda step: calls.append((step.id, step.status)),
+    )
+
+    dependencies = [s for s in report.steps if s.id == "dependencies"][0]
+    assert dependencies.status != "skipped", "a lockfile change must not skip the sync"
+
+
+def test_an_update_that_touches_nothing_buildable_skips_the_rebuild(world):
+    upstream, clone = world
+    replace(upstream, SOUL, "She is the one we ship.", "changed")
+    commit(upstream, "prompt only")
+
+    report = update(clone)
+
+    statuses = {s.id: s.status for s in report.steps}
+    assert statuses["dependencies"] == "skipped"
+    assert statuses["dashboard"] == "skipped"
+    assert "no dependency changes" in [s.detail for s in report.steps if s.id == "dependencies"][0]
+
+
+def test_skipping_the_rebuild_is_reported_as_such(world):
+    upstream, clone = world
+    write(upstream, "uv.lock", "lock = 2\n")
+    commit(upstream, "bump")
+
+    report = update(clone, rebuild=False)
+
+    assert {s.id: s.status for s in report.steps}["dependencies"] == "skipped"
+
+
+# --- checking ------------------------------------------------------------------
+
+
+def test_a_check_sees_what_is_waiting(world):
+    upstream, clone = world
+    replace(upstream, SOUL, "She is the one we ship.", "changed")
+    commit(upstream, "something new")
+
+    runner.invalidate()
+    status = runner.check(root=clone, force=True)
+
+    assert status.supported and status.available
+    assert status.behind == 1
+    assert status.commits[0]["subject"] == "something new"
+
+
+def test_a_check_changes_nothing_in_the_working_copy(world):
+    upstream, clone = world
+    replace(clone, SOUL, "She is the one we ship.", "She is mine.")
+    replace(upstream, SOUL, "She is the one we ship.", "theirs")
+    commit(upstream, "upstream")
+    before = Repo(clone).head()
+
+    runner.invalidate()
+    runner.check(root=clone, force=True)
+
+    assert Repo(clone).head() == before
+    assert read(clone, SOUL) == "# Soul\n\nShe is mine.\n"
+
+
+def test_a_check_is_cached_between_calls(world, monkeypatch):
+    _, clone = world
+    runner.invalidate()
+    runner.check(root=clone, force=True)
+
+    def explode(self, remote="origin"):
+        raise AssertionError("the cached check went back to the network")
+
+    monkeypatch.setattr(Repo, "fetch", explode)
+    assert runner.check(root=clone).supported
+
+
+def test_a_check_reports_the_conflicts_waiting_for_a_decision(world):
+    upstream, clone = world
+    replace(clone, OPERATING, "She is curious.", "She is sarcastic.")
+    replace(upstream, OPERATING, "She is curious.", "She is warm.")
+    commit(upstream, "colliding")
+    update(clone)
+
+    runner.invalidate()
+    assert runner.check(root=clone, force=True).reviews == [OPERATING]
+
+
+def test_docker_is_told_to_rebuild_the_image(world, monkeypatch):
+    _, clone = world
+    monkeypatch.setattr(runner, "in_docker", lambda: True)
+    runner.invalidate()
+
+    status = runner.check(root=clone, force=True)
+    assert not status.supported
+    assert "Docker" in status.reason

--- a/uv.lock
+++ b/uv.lock
@@ -1389,7 +1389,7 @@ wheels = [
 
 [[package]]
 name = "projectbea"
-version = "0.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "edge-tts" },


### PR DESCRIPTION
## What this changes

`make update` (and a button on a new **Maintenance** screen) that pulls the new version without touching anything the user wrote.

The problem it solves: six files under `data/prompts/` are tracked by git *and* meant to be edited. A plain `git pull` either refuses to run or writes `<<<<<<<` conflict markers into `soul.md`, which `load_text` then reads verbatim into a system prompt. That failure is silent — she just starts behaving like someone else.

**The approach.** Each prompt gets a three-way merge (`git merge-file`) between the user's version, the version it was based on, and the new one. An edited `operating.md` keeps the user's changes *and* receives the engine's. Neither naive answer works: taking upstream discards the character someone wrote, keeping local freezes the engine's own operating manual forever.

The base is tracked per file in `data/.prompt_base.json`, because it is **not** `HEAD`: after an unresolved conflict the file is still built on the older revision, and merging from `HEAD` next time would read the changes the user never took as deletions they made, and drop them silently. The base advances on a clean merge or an explicit resolution, never on a conflict.

On a collision the user's file is left byte-for-byte and the new version lands beside it as `<name>.new`. Conflict markers are never written into a prompt.

Also here:
- **`/dashboard/maintenance`** — the update (changelog, live step progress, side-by-side line diff for anything needing a decision) and the `--doctor` checks, which were previously invisible to anyone who never opens a terminal.
- **One version number.** `pyproject.toml` said `0.1.0`, the sidebar hardcoded `v2.0`. Now `src/core/update/version.py` is the source, served on `GET /status`. Bumped to `2.0.0` to match what the UI has been showing.
- **`SoulFile.write` is now atomic** (`src/utils/files.py`) — the engine reads that file every turn and the updater reads it mid-run; truncate-then-write could hand either one half a persona.
- An occasional, dismissible GitHub star nudge on the overview.

## What breaks if it is wrong

Somebody loses the character they spent a week writing, or silently stops receiving improvements to `operating.md` while the engine moves on around it.

That is why the failure modes all land on the safe side:

- any tracked file modified **outside** `data/prompts/` aborts the run with the list — the updater merges prose, not source
- `--ff-only`; a diverged checkout is reported, never rewritten
- no usable base → hand over both versions rather than guess
- prompts, config, `.env` and the database are snapshotted before the first write (the DB via the SQLite backup API, since it is open in WAL mode)
- a journal records the phase; a run that dies between the reset and the reconciliation is undone by the next one
- an `O_EXCL` lock, age-expiring, so two runs cannot interleave
- the prompts are re-read immediately before the reset, so a dashboard save landing mid-run aborts instead of being lost

`POST /update/apply` executes code (`git pull`, `uv sync`, `npm install`). It is loopback-only like the rest of the API, refuses the same things the CLI refuses, and `updates.allow_web_apply` closes it without affecting `make update`. `updates.check` is the only outbound call, and only to the remote the copy was cloned from.

It deliberately does **not** restart her: a self-`exec` from inside the request that triggered it races the memory flush in `cli.main`'s `finally`. The UI says so instead.

## Checks

- [x] `make test` passes — 1696 tests (39 new for the updater, 13 for its API)
- [x] `make lint` passes, `uvx pyright` clean
- [x] New behaviour has a test named after the behaviour — the four quadrants, repeated updates on an unresolved conflict, both resolutions, every refusal, crash recovery, the lock. All against real temporary git repositories, no mocked git
- [x] `docs/` updated — new [`docs/updating.md`](docs/updating.md), plus setup, configuration, api, frontend and architecture

Verified end to end against a throwaway clone: merge, collision, review, resolve, and a later update that correctly does *not* replay the resolved change.

### Additional fixes

- **Fixed the check for a customised soul**: `persona_store` now uses a constant hash (`SHIPPED_SOUL_SHA256`) instead of reading the live file. The onboarding banner finally settles.
- **Graceful degradation without git**: The updater and doctor check now safely degrade when git is missing. The installer provides platform-specific commands to install git rather than halting completely.