### PR TITLE
Fix the bugs that made her go silent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,15 @@ permissions:
 
 jobs:
   test:
-    name: lint and tests
-    runs-on: ubuntu-latest
+    # she is installed on all three, so she is tested on all three. A date
+    # format that only windows rejects took her voice away on windows alone,
+    # and a green ubuntu run said nothing about it.
+    name: lint and tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +44,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
 
+      # lint and types read the code, not the machine: one platform is the
+      # whole answer, and three runs of it would be three of the same one
       - name: Lint
+        if: matrix.os == 'ubuntu-latest'
         run: uv run ruff check src tests
 
       # src only, and only because it is at zero: tests pass fakes and
@@ -45,6 +55,7 @@ jobs:
       # of the fakes. Added once it already passed — a gate that is red on the
       # day it lands is a gate people learn to ignore.
       - name: Types
+        if: matrix.os == 'ubuntu-latest'
         run: uvx pyright
 
       - name: Tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install setup update docker docker-up docker-down run web frontend lock clean test lint migrate model
+.PHONY: help install setup update docker docker-up docker-down run web node lock clean test lint migrate model doctor
 
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -39,11 +39,11 @@ migrate: ## one-shot: move the old json/chroma stores into data/bea.db
 run: ## start the engine in CLI mode
 	uv run bea
 
-web: frontend ## build the frontend and start the web dashboard
+web: node ## build the javascript and start the web dashboard
 	uv run bea --web
 
-frontend: ## install deps and build the react dashboard
-	cd src/web/frontend && npm install && npm run build
+node: ## install the dashboard and the discord bot (needs node 20+)
+	uv run bea --install-node
 
 test: ## run the test suite
 	uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -397,9 +397,13 @@ Settings*), and a virtual audio cable such as
 separate track.
 
 ```bash
-uv sync                # or: make install
-uv run bea --setup     # or: make setup  (writes config.json and .env for you)
+uv sync                    # or: make install
+uv run bea --install-node  # or: make node   (the dashboard and the discord bot)
+uv run bea --setup         # or: make setup  (writes config.json and .env for you)
 ```
+
+Both of those need Node 20+. The discord bot is a node program of its own, so
+turning the skill on without it leaves her looking enabled and never online.
 
 Or by hand, copy `.env.example` to `.env`:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ nothing else. No OBS, no Discord bot, no Minecraft server, no virtual audio
 cable. Those are three separate profiles you can pick later, or turn on one at
 a time from the Abilities screen.
 
-Already cloned the repo? `make setup` does the same thing.
+Already cloned the repo? `uv run bea --setup` does the same thing — `make setup`
+if you have Make. Every `make` target here is one `uv run` command underneath, so
+nothing needs Make: Windows in particular does not ship it.
 
 > [!NOTE]
 > She needs an API key from OpenRouter, OpenAI or Groq.
@@ -74,7 +76,7 @@ Already cloned the repo? `make setup` does the same thing.
 ## Updating without losing her
 
 ```bash
-make update
+uv run bea --update
 ```
 
 Not `git pull`. The files that hold who she is — her soul, her operating manual
@@ -82,7 +84,7 @@ Not `git pull`. The files that hold who she is — her soul, her operating manua
 to run or writes conflict markers straight into the text her personality is read
 from, and nobody finds out until she starts talking like someone else.
 
-`make update` backs up your prompts, your config and your memory first, then
+`--update` backs up your prompts, your config and your memory first, then
 merges the new version *into* your edits the way git merges a branch: you keep
 the character you wrote, and the engine still gets the improvements to its own
 instructions. If a change lands on the exact lines you rewrote, yours stays
@@ -385,7 +387,7 @@ The compose file publishes the dashboard to `127.0.0.1:8000`, never to
 
 ## Manual setup
 
-`make setup` covers all of this. Here it is by hand.
+`uv run bea --setup` covers all of this. Here it is by hand.
 
 **Prerequisites:** [uv](https://docs.astral.sh/uv/) (it installs Python for
 you), Node.js 18+ for the dashboard and the Discord bot, OBS Studio with the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -532,7 +532,7 @@ arrives with its tests in the same commit.**
 ```bash
 make install        # uv sync
 make run            # CLI
-make web            # build the frontend + dashboard on :8000
+make web            # build the javascript + dashboard on :8000
 make update         # fast-forward, preserving edited prompts (see updating.md)
 uv run bea --doctor # or: make doctor (diagnose and fix issues)
 make test           # pytest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -531,6 +531,7 @@ arrives with its tests in the same commit.**
 
 ```bash
 make install        # uv sync
+make node           # uv run bea --install-node (dashboard + discord bot)
 make run            # CLI
 make web            # build the javascript + dashboard on :8000
 make update         # fast-forward, preserving edited prompts (see updating.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -244,7 +244,7 @@ Type messages at the `You >` prompt. Type `exit` to quit.
 ### Web Dashboard mode
 
 ```bash
-uv run bea --web    # or: make web  (also builds the frontend)
+uv run bea --web    # or: make web  (also builds the javascript)
 ```
 
 Opens the FastAPI server at `http://localhost:8000`. The React frontend (built
@@ -361,6 +361,6 @@ costs a handful of provider requests and never runs on its own.
 | A model in `mind` "does not support tool calling" | Remove it from the pool. Bea speaks only through tools, so a model without them never says anything |
 | She never starts anything in Minecraft | Give her objectives on the dashboard's Stream Plan page — with an empty plan she only ever reacts |
 | OBS avatar source not updating after config migration | If your `config.json` still contains the old key `obs_image_source`, it is silently renamed to `obs_avatar_source` by `load_from_file()`. Delete the old key from your `config.json` and re-save to avoid ambiguity. |
-| `make update` says you have local changes to the engine | You have edited a tracked file outside `data/prompts/`. Commit, stash or revert it — the updater merges prompts, not source |
-| The dashboard looks unchanged after an update | The build is gitignored. Run `make frontend`, or check whether the `dashboard` step reported a missing `npm` |
+| The update says you have local changes to the engine | You have edited a tracked file outside `data/prompts/`. Commit, stash or revert it — the updater merges prompts, not source |
+| The dashboard looks unchanged after an update | The build is gitignored. Run `uv run bea --install-node`, or check whether the `dashboard` step reported a missing `npm` |
 | A prompt has a `.new` beside it | An update changed the same lines you had. Yours is in use; compare them in Maintenance, or with `diff data/prompts/operating.md data/prompts/operating.md.new` |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,6 +42,7 @@ If you have `make` available, the same is wrapped in convenient targets:
 
 ```bash
 make install        # uv sync
+make node           # uv run bea --install-node (dashboard + discord bot)
 make help           # list every target
 ```
 

--- a/docs/web/api.md
+++ b/docs/web/api.md
@@ -627,7 +627,7 @@ What the OBS browser source reads, and what the dashboard asks about the avatar.
 None of it is authenticated, so none of it ever carries a secret.
 
 #### `GET /stage`
-The page to point an OBS **Browser Source** at. `404` with "run `make frontend`"
+The page to point an OBS **Browser Source** at. `404` with "run `uv run bea --install-node`"
 when the frontend has not been built.
 
 #### `GET /stage/stream`

--- a/install.ps1
+++ b/install.ps1
@@ -67,18 +67,18 @@ Write-Host "  this downloads a few hundred MB the first time" -ForegroundColor D
 uv sync
 Ok "dependencies ready"
 
-# --- 4. the dashboard -------------------------------------------------------
+# --- 4. the javascript ------------------------------------------------------
+# the dashboard is not the only javascript she has: her discord voice is a node
+# program of its own, and installing only the dashboard left the skill switched
+# on in the UI and dead in the process
 
-Step "Building the dashboard"
+Step "Building the dashboard and the discord bot"
 if (Get-Command npm -ErrorAction SilentlyContinue) {
-    Push-Location src\web\frontend
-    npm install --silent
-    npm run build | Out-Null
-    Pop-Location
-    Ok "dashboard built"
+    uv run bea --install-node
+    Ok "dashboard and discord bot ready"
 } else {
-    Warn "Node.js not found - skipping the dashboard."
-    Warn "Install Node 18+ from https://nodejs.org, then run: make frontend"
+    Warn "Node.js not found - skipping the dashboard and the discord bot."
+    Warn "Install Node 20+ from https://nodejs.org, then run: uv run bea --install-node"
 }
 
 # --- 5. configuration -------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -74,13 +74,16 @@ ok "dependencies ready"
 
 # --- 4. the dashboard -------------------------------------------------------
 
-step "Building the dashboard"
+# the dashboard is not the only javascript she has: her discord voice is a node
+# program of its own, and installing only the dashboard left the skill switched
+# on in the UI and dead in the process
+step "Building the dashboard and the discord bot"
 if command -v npm >/dev/null 2>&1; then
-  (cd src/web/frontend && npm install --silent && npm run build >/dev/null)
-  ok "dashboard built"
+  uv run bea --install-node
+  ok "dashboard and discord bot ready"
 else
-  warn "Node.js not found — skipping the dashboard."
-  warn "Install Node 18+ from https://nodejs.org, then run: make frontend"
+  warn "Node.js not found — skipping the dashboard and the discord bot."
+  warn "Install Node 20+ from https://nodejs.org, then run: uv run bea --install-node"
 fi
 
 # --- 5. configuration -------------------------------------------------------

--- a/src/cli.py
+++ b/src/cli.py
@@ -34,6 +34,8 @@ def parse_args():
                         help="Pull the new version without overwriting your prompts or your config")
     parser.add_argument("--no-rebuild", action="store_true",
                         help="With --update: skip `uv sync` and the dashboard build")
+    parser.add_argument("--install-node", action="store_true",
+                        help="Install the dashboard and the discord bot (needs Node 20+)")
     parser.add_argument("--web", action="store_true", help="Start Web Interface (FastAPI + React)")
     parser.add_argument("--host", default="127.0.0.1",
                         help="Bind address for the web interface (default: loopback only)")
@@ -208,6 +210,11 @@ def run():
         config = BrainConfig()
         apply_cli_overrides(config, args)
         raise SystemExit(run_doctor(config=config))
+    # no engine needed to run npm, and this is what people without `make` reach
+    # for when the dashboard or the discord bot was never installed
+    if args.install_node:
+        from src.setup.node import install_all
+        raise SystemExit(install_all())
     # and again: an update exists to repair the tree everything below is
     # imported from, so it must not import any of it
     if args.update:

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -197,7 +197,7 @@ class AIVtuberBrain:
         if store.rag is not None and embedder is not None:
             # vectors from two models are not comparable: a change re-embeds
             try:
-                store.rag.ensure_model(embedder.model_name)
+                store.rag.ensure_model(embedder.identity)
             except Exception as e:
                 logger.error(f"Could not verify the embedding model: {e}")
         return store

--- a/src/core/brain.py
+++ b/src/core/brain.py
@@ -526,11 +526,15 @@ class AIVtuberBrain:
         """Transcribes audio, deposits a voice perception, waits for the reply."""
         transcript = self.stt.transcribe(audio_path) if self.stt else ""
         text = transcript or "[Audio Message]"
-        voice = self._surface("voice:discord")
-        if not voice or not self.consciousness:
+        # the dashboard's own microphone, not discord's: handing it to the
+        # discord surface made the owner arrive as a stranger in a call she was
+        # not in, which the attention gate was free to ignore — and did
+        chat = self._surface("chat:ui")
+        if not chat or not self.consciousness:
+            logger.warning("generate_audio_response called before initialize().")
             return DEFAULT_MOOD, "", transcript
         payload = await self._perceive_and_wait(
-            lambda cid: voice.perceive(text, "user", meta={"correlation_id": cid}),
+            lambda cid: chat.perceive_voice(text, meta={"correlation_id": cid}),
             route="local",
         )
         if not payload:

--- a/src/core/consciousness.py
+++ b/src/core/consciousness.py
@@ -26,6 +26,21 @@ from src.utils.sanitize import clean_model_output
 logger = get_logger("bea.consciousness")
 
 
+def _block(what: str, produce) -> str:
+    """One part of the briefing, or nothing when building it went wrong.
+
+    Her context is assembled from a dozen independent sources, and any one of
+    them raising used to cost the entire turn — she went silent, and the log
+    said only what the exception had said. Losing one block is a worse answer;
+    losing every turn is not an answer at all.
+    """
+    try:
+        return produce() or ""
+    except Exception as e:
+        logger.error(f"Leaving {what} out of the briefing: {e}", exc_info=True)
+        return ""
+
+
 class Consciousness:
     """The single, always-on mind.
 
@@ -476,12 +491,9 @@ class Consciousness:
         happens to feel — costs the whole prompt on every single turn. That is
         why the rest of it is a separate message further down: see `_briefing`.
         """
-        sections = [
-            s.context_section for s in self.surfaces.active()
-            # the monologue rules are only true on an idle turn, so they belong
-            # to the briefing rather than in here
-            if s.context_section and s.name != "idle"
-        ]
+        # the monologue rules are only true on an idle turn, so they belong to
+        # the briefing rather than in here
+        sections = self.surfaces.context_sections(exclude=("idle",))
         return {"role": "system",
                 "content": compose(self._get_soul(), self._get_operating(), *sections)}
 
@@ -503,18 +515,22 @@ class Consciousness:
             if idle is not None and idle.active and idle.context_section:
                 parts.append(idle.context_section)
 
-        parts.extend(x for x in (s.live_state() for s in self.surfaces.active()) if x)
+        parts.extend(self.surfaces.live_states())
 
         if dynamic is None:
             dynamic = self.surfaces.dynamic_context(batch) if batch else []
 
-        feeling = self.affect.render() if self.affect else ""
+        feeling = _block("how she feels", lambda: self.affect.render() if self.affect else "")
         if feeling:
             parts.append(feeling)
         parts.extend(dynamic)
-        for block in (self.recap.render(),
-                      self.attention.digest() if self.attention else "",
-                      self.conversations.recent_lines() if self.conversations else ""):
+        for what, produce in (
+            ("the session recap", self.recap.render),
+            ("what she missed", lambda: self.attention.digest() if self.attention else ""),
+            ("the other conversations",
+             lambda: self.conversations.recent_lines() if self.conversations else ""),
+        ):
+            block = _block(what, produce)
             if block:
                 parts.append(block)
 

--- a/src/core/consciousness.py
+++ b/src/core/consciousness.py
@@ -269,7 +269,9 @@ class Consciousness:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"Consciousness loop error: {e}")
+                # the message alone names neither the line nor the skill it came
+                # from, and this is the one place every turn fails through
+                logger.error(f"Consciousness loop error: {e}", exc_info=True)
                 await asyncio.sleep(1)
             finally:
                 # a turn that raised must not leave its caller hanging for the

--- a/src/core/memory/embedder.py
+++ b/src/core/memory/embedder.py
@@ -7,6 +7,8 @@ The default is multilingual: with an English-only model, non-English sentences
 collapse into the same region and retrieval becomes close to random.
 """
 
+import warnings
+from importlib import metadata
 from typing import Any, List, Optional, Sequence
 
 from src.utils.logger import get_logger
@@ -18,6 +20,20 @@ DEFAULT_CACHE_DIR = "data/embeddings_cache"
 
 # old config values meaning "the default": fastembed rejects them
 _LEGACY_NAMES = frozenset({"local", "default", "", "none"})
+
+
+def _fastembed_series() -> str:
+    """`major.minor` of the installed fastembed, or "?" when it cannot be read.
+
+    Patch releases are left out on purpose: the pooling of a model is the kind
+    of thing that moves in a minor, and re-embedding a whole store on a bugfix
+    would be a long startup for nothing.
+    """
+    try:
+        return ".".join(metadata.version("fastembed").split(".")[:2])
+    except Exception as e:
+        logger.warning(f"Could not read the fastembed version ({e}).")
+        return "?"
 
 
 def resolve_model(name: Optional[str]) -> str:
@@ -47,8 +63,27 @@ class FastEmbedEmbedder:
         from fastembed import TextEmbedding  # lazy: heavy import
 
         logger.info(f"Loading embedding model '{self.model_name}'…")
-        self._model = TextEmbedding(model_name=self.model_name, cache_dir=self.cache_dir)
+        with warnings.catch_warnings():
+            # fastembed warns that it pools this model differently than it used
+            # to. That is handled — `identity` carries the version, so the store
+            # re-embeds — and printing a raw traceback about it on every start
+            # reads like something is broken
+            warnings.filterwarnings("ignore", message=".*mean pooling.*")
+            self._model = TextEmbedding(model_name=self.model_name, cache_dir=self.cache_dir)
         return self._model
+
+    @property
+    def identity(self) -> str:
+        """What the stored vectors were made with, not merely which model.
+
+        The same model name does not mean the same vector space: fastembed 0.6
+        began mean-pooling the sentence-transformers models it used to read the
+        CLS token of, which left every memory written before it in a space the
+        new queries cannot be compared against. Nothing said so — recall simply
+        got worse. Carrying the version here makes that a re-embed, which is
+        what a changed model has always been.
+        """
+        return f"{self.model_name}@fastembed{_fastembed_series()}"
 
     def embed(self, texts: Sequence[str]) -> List[List[float]]:
         model = self._ensure()

--- a/src/core/skills/base.py
+++ b/src/core/skills/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, List, Optional, Protocol, Sequence, runtime_checkable
 
 from src.core.agent.tools import Tool
 from src.utils.logger import get_logger
@@ -165,15 +165,45 @@ class SkillRegistry:
     def active(self) -> List[Skill]:
         return [s for s in self._skills.values() if s.active]
 
-    def context_sections(self) -> List[str]:
-        return [s.context_section for s in self.active() if s.context_section]
+    def _contribution(self, skill: Skill, what: str, call) -> Optional[str]:
+        """One block of context, or nothing at all when producing it went wrong.
+
+        A skill that raises while describing itself used to take the whole turn
+        with it: the loop caught the error far away from here, so what reached
+        the log named neither the skill nor what it had been asked for, and she
+        said nothing at all rather than saying something without that block.
+        """
+        try:
+            return call()
+        except Exception as e:
+            logger.error(f"Skill '{skill.name}' could not contribute its {what}: {e}",
+                         exc_info=True)
+            return None
+
+    def context_sections(self, exclude: Sequence[str] = ()) -> List[str]:
+        out: List[str] = []
+        for s in self.active():
+            if s.name in exclude:
+                continue
+            text = self._contribution(s, "prompt section", lambda s=s: s.context_section)
+            if text:
+                out.append(text)
+        return out
+
+    def live_states(self) -> List[str]:
+        out: List[str] = []
+        for s in self.active():
+            text = self._contribution(s, "live state", lambda s=s: s.live_state())
+            if text:
+                out.append(text)
+        return out
 
     def dynamic_context(self, batch) -> List[str]:
         out: List[str] = []
         for s in self.active():
-            ctx = s.context_for(batch)
-            if ctx:
-                out.append(ctx)
+            text = self._contribution(s, "context for this batch", lambda s=s: s.context_for(batch))
+            if text:
+                out.append(text)
         return out
 
     def tools(self) -> List[Tool]:

--- a/src/core/skills/chat.py
+++ b/src/core/skills/chat.py
@@ -5,24 +5,49 @@ from src.core.skills.base import Skill
 
 
 class ChatSurface(Skill):
-    """Text chat from the web UI (and a template for twitch/telegram later).
+    """Chat from the web UI, typed or spoken (and a template for twitch/telegram).
 
-    Input only: pushes CHAT perceptions. Output is rendered locally by Expression
-    (VOICE), so there is no per-surface text sink here.
+    Input only: pushes CHAT and VOICE perceptions. Output is rendered locally by
+    Expression (VOICE), so there is no per-surface text sink here.
     """
 
     name = "chat:ui"
 
-    def perceive(self, text: str, user: str = "user", meta: Optional[Dict[str, Any]] = None) -> Perception:
+    def _author(self, user: str) -> Author:
         # the local UI is single-user: this is the owner talking
-        author = Author(platform="ui", native_id=user, display_name=user, is_owner=True)
+        return Author(platform="ui", native_id=user, display_name=user, is_owner=True)
+
+    def perceive(self, text: str, user: str = "user", meta: Optional[Dict[str, Any]] = None) -> Perception:
         p = Perception(
             kind=PerceptionKind.CHAT,
             surface=self.name,
             content=f"[{user}] {text}",
             salience=0.8,  # someone is talking to you directly
             meta={**(meta or {}), "user": user},
-            author=author,
+            author=self._author(user),
+        )
+        self.bus.put(p)
+        return p
+
+    def perceive_voice(self, transcript: str, user: str = "user",
+                       meta: Optional[Dict[str, Any]] = None) -> Perception:
+        """The dashboard microphone: the owner, out loud, in the same room.
+
+        This used to be handed to the discord surface, for no better reason than
+        that being where voice had been implemented first. It arrived as an
+        unknown person speaking in a call — so the attention gate was entitled
+        to let it go by, and did: the mic worked, the transcript came back, and
+        she said nothing at all.
+        """
+        p = Perception(
+            kind=PerceptionKind.VOICE,
+            surface=self.name,
+            content=f"[{user}] (spoken): {transcript}",
+            # she is being spoken to directly, with nobody else in the room
+            salience=0.9,
+            meta={**(meta or {}), "user": user, "listeners": 1,
+                  "alone_with_speaker": True},
+            author=self._author(user),
         )
         self.bus.put(p)
         return p

--- a/src/core/skills/voice/surface.py
+++ b/src/core/skills/voice/surface.py
@@ -36,6 +36,18 @@ class VoiceSurface(PlatformSkill):
     # how long to wait before bringing a crashed bot back up
     restart_backoff: float = 3.0
 
+    # a bot that never gets as far as logging in is not crashing, it is refusing
+    # to run: a bad token is the usual reason, and no number of restarts will
+    # change that. Restarting it forever buried the one line that said why under
+    # a stack trace every three seconds.
+    healthy_after: float = 20.0
+    max_failed_starts: int = 3
+
+    # how the supervisor tells "it crashed" apart from "it never ran". Class
+    # attributes, so a surface is supervisable before it has been initialized.
+    _started_at: float = 0.0
+    _failed_starts: int = 0
+
     def initialize(self) -> None:
         super().initialize()
         self.transport = DiscordTransport(self.config)
@@ -81,6 +93,8 @@ class VoiceSurface(PlatformSkill):
             return
         if self.transport.start():
             self.active = True
+            self._started_at = time.time()
+            self._failed_starts = 0
             self._monitor = asyncio.create_task(self._watch_transport())
             self._floor_task = asyncio.create_task(self._watch_floor())
             logger.info("VoiceSurface started.")
@@ -114,12 +128,36 @@ class VoiceSurface(PlatformSkill):
         """
         if self.transport.poll_exit() is None:
             return
-        logger.warning("Discord bot died; restarting it.")
+
+        # it ran long enough to have been working: whatever killed it now is not
+        # the reason it would not start, so the count starts again
+        if time.time() - self._started_at >= self.healthy_after:
+            self._failed_starts = 0
+        self._failed_starts += 1
+
+        if self._failed_starts > self.max_failed_starts:
+            self._give_up()
+            return
+
+        logger.warning(f"Discord bot died; restarting it "
+                       f"({self._failed_starts}/{self.max_failed_starts}).")
         await asyncio.sleep(self.restart_backoff)
         if self.transport.start():
+            self._started_at = time.time()
             logger.info("Discord bot is back up.")
             return
         logger.error("Discord bot could not be restarted; the capability is off.")
+        self.active = False
+
+    def _give_up(self) -> None:
+        """Says the thing the restart loop was drowning out, once, and stops."""
+        reason = ("The discord bot has quit immediately every time it was started. "
+                  "Its own output above says why — an invalid DISCORD_TOKEN is the "
+                  "usual answer. Discord is off until that is fixed.")
+        logger.error(reason)
+        events = getattr(self.context, "event_manager", None)
+        if events is not None:
+            events.publish(EventCategory.ERROR, "discord", reason)
         self.active = False
 
     # --- being left alone ---------------------------------------------------

--- a/src/core/skills/voice/transport.py
+++ b/src/core/skills/voice/transport.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 import aiohttp
 
 from src.core.config import BrainConfig
+from src.setup.node import executable
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.skills.voice.transport")
@@ -72,14 +73,21 @@ class DiscordTransport:
             return False
 
         if not (self.bot_dir / "node_modules").exists():
-            logger.error("node_modules not found. Run 'npm install' in the bot directory.")
+            logger.error("The discord bot's packages are not installed. "
+                         "Run `uv run bea --install-node`.")
+            return False
+
+        node = executable("node")
+        if node is None:
+            logger.error("The discord bot is a node program and node is not installed. "
+                         "Get node 20 or newer from https://nodejs.org.")
             return False
 
         self.api_url = f"http://{LOOPBACK}:{self._port()}"
 
         try:
             self.bot_process = subprocess.Popen(
-                ["node", "index.js"], cwd=str(self.bot_dir), env=self.subprocess_env(token),
+                [node, "index.js"], cwd=str(self.bot_dir), env=self.subprocess_env(token),
                 stdout=sys.stdout, stderr=sys.stderr, shell=False,
             )
             logger.info(f"Discord bot started with PID {self.bot_process.pid}.")

--- a/src/core/social/reach.py
+++ b/src/core/social/reach.py
@@ -76,9 +76,13 @@ class Reach:
 
     def channels(self, person_id: str) -> List[Channel]:
         """Every account of theirs, most recently seen first."""
+        # the tie-break is not decoration: the clock on windows moves in steps
+        # of about 15ms, so two sightings in the same moment carry the same
+        # timestamp and the order sqlite returns them in is its own business.
+        # Later row wins, which is the same answer the timestamps would give.
         rows = self.memory.db.query(
             "SELECT platform, native_id, display_name, last_seen FROM identities "
-            "WHERE person_id = ? ORDER BY last_seen DESC",
+            "WHERE person_id = ? ORDER BY last_seen DESC, rowid DESC",
             (person_id,),
         )
         return [

--- a/src/core/timeline.py
+++ b/src/core/timeline.py
@@ -82,7 +82,10 @@ def now_block(
     It goes into every turn, so it stays short: the day and the clock, how long
     she has been up, and when she last spoke where she is.
     """
-    stamp = now.strftime("%A %-d %B %Y, %H:%M")
+    # the day number is written out rather than asked of strftime: `%-d` is a
+    # unix extension, and on windows it raises instead of dropping the zero —
+    # which cost her every turn, since this line is in all of them
+    stamp = f"{now.strftime('%A')} {now.day} {now.strftime('%B %Y, %H:%M')}"
     if timezone:
         stamp += f" ({timezone})"
     lines = ["[RIGHT NOW]", stamp]

--- a/src/core/update/reconcile.py
+++ b/src/core/update/reconcile.py
@@ -71,6 +71,29 @@ class Outcome:
         }
 
 
+def _lf(text: str) -> str:
+    """Line endings out of the way, so a merge is about the words.
+
+    The three sides reach us having been read three different ways: the user's
+    file through python's text mode, which turns CRLF into LF, and the other two
+    straight out of git as bytes, which does not. On windows that made every
+    line of every prompt differ from itself — so a clean merge came back as a
+    conflict, and the engine's own improvements were dropped on the floor while
+    the report said the user's edits had collided with them.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _newline(text: str) -> str:
+    """What this file is written with, so a merge does not quietly convert it."""
+    crlf = text.count("\r\n")
+    return "\r\n" if crlf and crlf >= text.count("\n") - crlf else "\n"
+
+
+def _as_written(text: str, newline: str) -> str:
+    return text if newline == "\n" else text.replace("\n", newline)
+
+
 def new_file_for(root: Path, path: str) -> Path:
     return Path(root) / (path + NEW_SUFFIX)
 
@@ -93,11 +116,20 @@ def reconcile(root: Path, repo: Repo, path: str, ours: str, base_sha: Optional[s
     root = Path(root)
     theirs = repo.file_at(target, path)
 
+    # whatever the user's file is written with survives whatever we decide
+    style = _newline(ours)
+    ours = _lf(ours)
+    if theirs is not None:
+        theirs = _lf(theirs)
+
+    def write(destination: Path, text: str) -> None:
+        _write(destination, _as_written(text, style))
+
     if theirs is None:
         # the new version does not have this file at all — deleted upstream, or
         # a blob we refuse to decode. Either way the user's copy is the only
         # one anybody asked for.
-        _write(root / path, ours)
+        write(root / path, ours)
         # the base stays where it was: if the file comes back upstream, their
         # edits still have something to be merged against
         return Outcome(path, REMOVED, "the new version no longer ships this file; yours was kept",
@@ -108,13 +140,15 @@ def reconcile(root: Path, repo: Repo, path: str, ours: str, base_sha: Optional[s
         return Outcome(path, UNTOUCHED, "already identical to the new version", base=target)
 
     base = repo.file_at(base_sha, path) if base_sha else None
+    if base is not None:
+        base = _lf(base)
 
     if base is None:
         # no usable base: either we never recorded one, or the revision is gone
         # from a shallow history. A two-way guess is exactly the silent data
         # loss this module exists to prevent, so hand both versions over.
-        _write(root / path, ours)
-        _write(new_file_for(root, path), theirs)
+        write(root / path, ours)
+        write(new_file_for(root, path), theirs)
         return Outcome(
             path, CONFLICT,
             "there is no record of which version yours was based on, so it was left untouched",
@@ -122,21 +156,21 @@ def reconcile(root: Path, repo: Repo, path: str, ours: str, base_sha: Optional[s
         )
 
     if base == theirs:
-        _write(root / path, ours)
+        write(root / path, ours)
         _clear_new(root, path)
         return Outcome(path, KEPT, "the new version does not change this file", base=target)
 
     merged = _merge(repo, ours=ours, base=base, theirs=theirs)
     if merged is None:
-        _write(root / path, ours)
-        _write(new_file_for(root, path), theirs)
+        write(root / path, ours)
+        write(new_file_for(root, path), theirs)
         return Outcome(
             path, CONFLICT,
             "your edits and the new version touch the same lines",
             base=base_sha,
         )
 
-    _write(root / path, merged)
+    write(root / path, merged)
     _clear_new(root, path)
     return Outcome(path, MERGED, "your edits were carried over onto the new version", base=target)
 
@@ -173,8 +207,9 @@ def _merge(repo: Repo, ours: str, base: str, theirs: str) -> Optional[str]:
         directory = Path(workspace)
         sides = {}
         for name, text in (("ours", ours), ("base", base), ("theirs", theirs)):
-            # newline="" keeps CRLF intact: rewriting every line ending of a file
-            # the user edited on Windows would turn a clean merge into a conflict
+            # all three arrive normalised to LF, and newline="" writes them out
+            # unchanged: the merge compares words, and the caller puts the
+            # user's own line endings back on whatever comes out of it
             sides[name] = directory / name
             sides[name].write_text(text, encoding="utf-8", newline="")
         try:

--- a/src/core/update/runner.py
+++ b/src/core/update/runner.py
@@ -523,8 +523,11 @@ def _command(cwd: Path, args: List[str]) -> tuple:
 
 
 def _read(path: Path) -> Optional[str]:
+    # newline="" so the file arrives written the way the user wrote it: the
+    # reconciler needs to know, to hand it back in the same shape
     try:
-        return path.read_text(encoding="utf-8")
+        with path.open(encoding="utf-8", newline="") as handle:
+            return handle.read()
     except (OSError, UnicodeDecodeError):
         return None
 

--- a/src/core/update/runner.py
+++ b/src/core/update/runner.py
@@ -38,6 +38,7 @@ from src.core.update.reconcile import (
     reconcile,
 )
 from src.core.update.version import current_version
+from src.setup.node import PROJECTS as NODE_PROJECTS
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.update")
@@ -52,6 +53,8 @@ CHECK_TTL = 30 * 60
 # `npm install` on a slow link is measured in minutes, not seconds
 DEPENDENCY_TIMEOUT = 30 * 60
 
+# the node projects contribute a step each, so adding one is a line in
+# `setup/node.py` rather than four scattered through here
 STEPS: List[tuple] = [
     ("preflight", "Checking your install"),
     ("download", "Downloading the new version"),
@@ -59,8 +62,7 @@ STEPS: List[tuple] = [
     ("apply", "Applying the update"),
     ("reconcile", "Putting your edits back"),
     ("dependencies", "Updating dependencies"),
-    ("dashboard", "Rebuilding the dashboard"),
-]
+] + [(p.name, f"Updating the {p.name}") for p in NODE_PROJECTS]
 
 RUNNING, DONE, SKIPPED, FAILED = "running", "done", "skipped", "failed"
 
@@ -333,7 +335,8 @@ def _run(root: Path, repo: Repo, step, steps: List[Step], rebuild: bool) -> Repo
 
     if target == base_sha:
         step("download", DONE, "already on the latest version")
-        for pending in ("backup", "apply", "reconcile", "dependencies", "dashboard"):
+        for pending in ("backup", "apply", "reconcile", "dependencies",
+                        *(p.name for p in NODE_PROJECTS)):
             step(pending, SKIPPED, "nothing to update")
         return Report(status=CURRENT, headline="She is already up to date",
                       steps=steps, from_sha=base_sha, to_sha=target)
@@ -390,10 +393,11 @@ def _run(root: Path, repo: Repo, step, steps: List[Step], rebuild: bool) -> Repo
     changed = repo.changed_between(base_sha, target)
     if rebuild:
         _sync_dependencies(root, changed, step)
-        _rebuild_dashboard(root, changed, step)
+        _rebuild_node(root, changed, step)
     else:
         step("dependencies", SKIPPED, "asked to skip")
-        step("dashboard", SKIPPED, "asked to skip")
+        for project in NODE_PROJECTS:
+            step(project.name, SKIPPED, "asked to skip")
 
     headline = "Updated" if not conflicts else "Updated — some prompts need a look"
     return Report(
@@ -463,27 +467,32 @@ def _sync_dependencies(root: Path, changed: List[str], step) -> None:
     step("dependencies", DONE if ok else FAILED, detail if not ok else "python dependencies are current")
 
 
-def _rebuild_dashboard(root: Path, changed: List[str], step) -> None:
-    frontend = root / "src/web/frontend"
-    if not any(p.startswith("src/web/frontend/") for p in changed):
-        step("dashboard", SKIPPED, "the dashboard did not change in this update")
-        return
-    if not shutil.which("npm"):
-        # the built dashboard is gitignored, so without this the user updates
-        # and sees the old screens with no clue why
-        step("dashboard", FAILED,
-             "npm is not on PATH — run `make frontend` yourself, or the dashboard stays on the old build")
-        return
+def _rebuild_node(root: Path, changed: List[str], step) -> None:
+    """Every javascript part of her, not only the one you can see.
 
-    step("dashboard", RUNNING, "installing")
-    ok, detail = _command(frontend, ["npm", "install", "--no-audit", "--no-fund"])
-    if not ok:
-        step("dashboard", FAILED, detail)
-        return
+    The discord bot was left out of this for as long as it existed: an update
+    that changed its packages left the skill switched on in the UI and the bot
+    unable to start, saying so nowhere but its own stderr.
+    """
+    for project in NODE_PROJECTS:
+        if not any(p.startswith(project.path + "/") for p in changed):
+            step(project.name, SKIPPED, f"the {project.name} did not change in this update")
+            continue
+        if not shutil.which("npm"):
+            # what npm builds is gitignored, so without this the user updates
+            # and gets the old screens — or no voice — with no clue why
+            step(project.name, FAILED,
+                 f"npm is not on PATH — run `uv run bea --install-node` yourself, "
+                 f"or the {project.name} stays as it was")
+            continue
 
-    step("dashboard", RUNNING, "building")
-    ok, detail = _command(frontend, ["npm", "run", "build"])
-    step("dashboard", DONE if ok else FAILED, detail if not ok else "the dashboard was rebuilt")
+        step(project.name, RUNNING, "installing")
+        ok, detail = _command(project.directory(root), ["npm", "install", "--no-audit", "--no-fund"])
+        if ok and project.builds:
+            step(project.name, RUNNING, "building")
+            ok, detail = _command(project.directory(root), ["npm", "run", "build"])
+        step(project.name, DONE if ok else FAILED,
+             detail if not ok else f"the {project.name} is current")
 
 
 def _command(cwd: Path, args: List[str]) -> tuple:

--- a/src/core/update/runner.py
+++ b/src/core/update/runner.py
@@ -39,6 +39,7 @@ from src.core.update.reconcile import (
 )
 from src.core.update.version import current_version
 from src.setup.node import PROJECTS as NODE_PROJECTS
+from src.setup.node import executable
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.update")
@@ -497,9 +498,14 @@ def _rebuild_node(root: Path, changed: List[str], step) -> None:
 
 def _command(cwd: Path, args: List[str]) -> tuple:
     """Runs one build command. Returns (ok, the last thing it said when it failed)."""
+    # under the name this machine gave it: npm is `npm.cmd` on windows, which
+    # subprocess cannot find by its bare name
+    program = executable(args[0])
+    if program is None:
+        return False, f"{args[0]} is not installed"
     try:
         result = subprocess.run(
-            args, cwd=str(cwd), capture_output=True, text=True,
+            [program, *args[1:]], cwd=str(cwd), capture_output=True, text=True,
             encoding="utf-8", errors="replace", timeout=DEPENDENCY_TIMEOUT,
         )
     except FileNotFoundError:

--- a/src/setup/doctor.py
+++ b/src/setup/doctor.py
@@ -404,13 +404,13 @@ async def check_discord(config: BrainConfig) -> Finding:
 
     if shutil.which("node") is None:
         return failed("the bot is a node program and node is not installed",
-                      "Install node 20 or newer, then `npm ci` in "
-                      "src/core/skills/voice/bot.", blocking=False)
+                      "Install node 20 or newer from https://nodejs.org, then "
+                      "`uv run bea --install-node`.", blocking=False)
 
     bot = Path("src/core/skills/voice/bot")
     if not (bot / "node_modules" / "@discordjs" / "voice").is_dir():
         return failed("the bot's packages have never been installed",
-                      f"cd {bot} && npm ci", blocking=False)
+                      "uv run bea --install-node", blocking=False)
 
     return passed("node, the bot's packages and a token are all in place")
 
@@ -439,9 +439,9 @@ async def check_dashboard(config: BrainConfig) -> Finding:
     if not DASHBOARD.is_file():
         if needs_page:
             return failed("the dashboard has never been built, and her stage needs it",
-                          "make frontend")
+                          "uv run bea --install-node")
         return warned("the dashboard has never been built",
-                      "make frontend — the engine runs without it, the web "
+                      "uv run bea --install-node — the engine runs without it, the web "
                       "interface does not.")
 
     if _reachable("127.0.0.1", DEFAULT_PORT):

--- a/src/setup/node.py
+++ b/src/setup/node.py
@@ -46,11 +46,26 @@ PROJECTS: Tuple[NodeProject, ...] = (
 )
 
 
+def executable(name: str) -> Optional[str]:
+    """The program to actually run, under the name this machine gave it.
+
+    Windows ships npm as `npm.cmd`, and `CreateProcess` — which is what
+    subprocess uses without a shell — only ever looks for an `.exe` under a bare
+    name. It runs a `.cmd` quite happily once told the full name, which is what
+    `which` returns. Without this every npm step failed on windows saying npm
+    was not installed, on machines where it plainly was.
+    """
+    return shutil.which(name)
+
+
 def run(project: NodeProject, args: List[str], root: Optional[Path] = None) -> Tuple[bool, str]:
     """One npm command. Returns (ok, what it said when it did not work)."""
+    npm = executable("npm")
+    if npm is None:
+        return False, "npm is not installed"
     try:
         result = subprocess.run(
-            ["npm", *args], cwd=str(project.directory(root)), capture_output=True,
+            [npm, *args], cwd=str(project.directory(root)), capture_output=True,
             text=True, encoding="utf-8", errors="replace", timeout=TIMEOUT,
         )
     except FileNotFoundError:

--- a/src/setup/node.py
+++ b/src/setup/node.py
@@ -1,0 +1,90 @@
+"""The parts of her that are javascript, and how to get them installed.
+
+There are two, and for a long time only one of them was ever installed. The
+dashboard is the obvious one — you notice a missing dashboard immediately. Her
+discord voice is a node program too, and nothing said so: the installer built
+the dashboard, the updater rebuilt the dashboard, and the discord toggle in the
+UI turned on a bot whose packages had never been fetched. It went on looking
+enabled and simply never came online.
+
+Listed in one place so that anything which installs, updates or checks her
+covers all of it — and so adding a third is one line rather than three.
+"""
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.setup.node")
+
+# `npm install` on a slow link is measured in minutes
+TIMEOUT = 900
+
+
+@dataclass(frozen=True)
+class NodeProject:
+    """One npm project of hers: where it lives and what it needs."""
+
+    name: str
+    path: str
+    builds: bool  # whether `npm run build` follows the install
+
+    def directory(self, root: Optional[Path] = None) -> Path:
+        return (root or Path.cwd()) / self.path
+
+    def installed(self, root: Optional[Path] = None) -> bool:
+        return (self.directory(root) / "node_modules").is_dir()
+
+
+PROJECTS: Tuple[NodeProject, ...] = (
+    NodeProject("dashboard", "src/web/frontend", builds=True),
+    NodeProject("discord bot", "src/core/skills/voice/bot", builds=False),
+)
+
+
+def run(project: NodeProject, args: List[str], root: Optional[Path] = None) -> Tuple[bool, str]:
+    """One npm command. Returns (ok, what it said when it did not work)."""
+    try:
+        result = subprocess.run(
+            ["npm", *args], cwd=str(project.directory(root)), capture_output=True,
+            text=True, encoding="utf-8", errors="replace", timeout=TIMEOUT,
+        )
+    except FileNotFoundError:
+        return False, "npm is not installed"
+    except subprocess.TimeoutExpired:
+        return False, f"`npm {' '.join(args)}` did not finish within {TIMEOUT // 60} minutes"
+    if result.returncode == 0:
+        return True, ""
+    last = (result.stderr or result.stdout or "").strip().splitlines()
+    return False, last[-1] if last else f"npm exited with {result.returncode}"
+
+
+def install_all(root: Optional[Path] = None) -> int:
+    """Installs (and builds) every node project. Returns a process exit code.
+
+    Written for the people who have no `make`: every target in the Makefile is
+    a one-line command underneath, and this is the one that was not.
+    """
+    if shutil.which("npm") is None:
+        logger.error("Node.js is not installed. Get Node 20 or newer from https://nodejs.org, "
+                     "then run this again.")
+        return 1
+
+    failed = False
+    for project in PROJECTS:
+        logger.info(f"Installing the {project.name}…")
+        ok, detail = run(project, ["install", "--no-audit", "--no-fund"], root)
+        if ok and project.builds:
+            logger.info(f"Building the {project.name}…")
+            ok, detail = run(project, ["run", "build"], root)
+        if ok:
+            logger.info(f"The {project.name} is ready.")
+        else:
+            logger.error(f"The {project.name} could not be installed: {detail}")
+            failed = True
+
+    return 1 if failed else 0

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1173,7 +1173,7 @@ def stage_page():
     if not page.is_file():
         raise HTTPException(
             status_code=404,
-            detail="The stage page is not built. Run `make frontend`.",
+            detail="The stage page is not built. Run `uv run bea --install-node`.",
         )
     return FileResponse(page)
 

--- a/src/web/updates.py
+++ b/src/web/updates.py
@@ -105,7 +105,7 @@ def start_update() -> Dict[str, Any]:
     if not _config_flag("allow_web_apply"):
         raise HTTPException(
             status_code=403,
-            detail="Updating from the dashboard is switched off. Run `make update` in a terminal.",
+            detail="Updating from the dashboard is switched off. Run `uv run bea --update` in a terminal.",
         )
 
     global _run

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -30,10 +30,12 @@ class FakeLLMClient(LLMClient):
         return len(self.calls)
 
     async def complete(self, messages, tools=None, response_format=None) -> AssistantMessage:
-        if self.fail_with:
-            raise self.fail_with
+        # recorded before it fails: a call that raised is still a call that was
+        # made, and a test waiting for one would otherwise wait forever
         # deep enough to survive the caller mutating its context afterwards
         self.calls.append([dict(m) for m in messages])
+        if self.fail_with:
+            raise self.fail_with
         self.tools_seen.append([t["function"]["name"] for t in (tools or [])])
         if self.script:
             return self.script.pop(0)

--- a/tests/test_bot_security.py
+++ b/tests/test_bot_security.py
@@ -236,3 +236,79 @@ async def test_stopping_the_surface_releases_the_session():
     surface.active = True
     await surface.stop()
     assert closed == [True]
+
+
+# --- a bot that will not start is not a bot that keeps crashing ---------------
+
+
+class NeverLogsIn(FlakyTransport):
+    """Starts every time and quits immediately every time: a bad token."""
+
+    def __init__(self):
+        super().__init__(deaths=0)
+
+    def poll_exit(self):
+        return 1
+
+
+async def test_a_bot_that_never_comes_up_is_not_restarted_forever():
+    """An invalid token restarted it every three seconds, for as long as she
+    ran, burying the one line that said why under a stack trace each time."""
+    from src.core.skills.voice.surface import VoiceSurface
+
+    surface = VoiceSurface(Config(), bus=None, expression=None)
+    surface.transport = NeverLogsIn()
+    surface.active = True
+    surface.restart_backoff = 0.0
+
+    for _ in range(10):
+        await surface.supervise_once()
+
+    assert surface.active is False
+    assert surface.transport.starts <= surface.max_failed_starts
+
+
+async def test_giving_up_says_what_to_look_at():
+    from src.core.events import EventCategory
+    from src.core.skills.voice.surface import VoiceSurface
+
+    published = []
+
+    class Events:
+        def publish(self, category, source, message, metadata=None):
+            published.append((category, message))
+
+    class Ctx:
+        event_manager = Events()
+
+    surface = VoiceSurface(Config(), bus=None, expression=None, context=Ctx())
+    surface.transport = NeverLogsIn()
+    surface.active = True
+    surface.restart_backoff = 0.0
+
+    for _ in range(10):
+        await surface.supervise_once()
+
+    assert published
+    category, message = published[-1]
+    assert category == EventCategory.ERROR
+    assert "DISCORD_TOKEN" in message
+
+
+async def test_a_bot_that_ran_for_a_while_gets_its_restarts_back():
+    """Crashing after an hour is not the same failure as never starting."""
+    import time
+
+    from src.core.skills.voice.surface import VoiceSurface
+
+    surface = VoiceSurface(Config(), bus=None, expression=None)
+    surface.transport = FlakyTransport(deaths=10)
+    surface.active = True
+    surface.restart_backoff = 0.0
+
+    for _ in range(10):
+        surface._started_at = time.time() - surface.healthy_after - 1
+        await surface.supervise_once()
+
+    assert surface.active is True
+    assert surface.transport.starts == 10

--- a/tests/test_broken_context.py
+++ b/tests/test_broken_context.py
@@ -1,0 +1,121 @@
+"""A skill that breaks must cost its own block, not the whole turn.
+
+Her context is assembled from a dozen independent sources. One of them raising
+used to reach the loop's catch-all far away from where it happened: she went
+silent on every message, and the log said `Invalid format string` and nothing
+about which skill had said it or what it had been asked for.
+"""
+
+import pytest
+
+from src.core.attention.gate import Attention
+from src.core.consciousness import Consciousness
+from src.core.perception.bus import PerceptionBus
+from src.core.perception.types import Perception, PerceptionKind
+from src.core.skills.base import Skill, SkillRegistry
+from tests.fakes import FakeExpression, FakeHistory, FakeLLMClient, RecordingEvents
+
+
+class Config:
+    def __init__(self):
+        self.consciousness = {"enabled": True, "idle_after": 3600.0, "window": 0.0,
+                              "burst_steps": 3, "history_limit": 30,
+                              "correlation_timeout": 5.0}
+        self.attention = {}
+        self.skills = {}
+        self.persona = {}
+
+
+class Broken(Skill):
+    """Every hook raises the way the clock did on windows."""
+
+    name = "broken"
+
+    @property
+    def context_section(self):
+        raise ValueError("Invalid format string")
+
+    def live_state(self):
+        raise ValueError("Invalid format string")
+
+    def context_for(self, batch):
+        raise ValueError("Invalid format string")
+
+
+class Working(Skill):
+    name = "working"
+
+    @property
+    def context_section(self):
+        return "## RULES\nsomething she needs to know"
+
+    def live_state(self):
+        return "[RIGHT NOW]\nhalf past noon"
+
+    def context_for(self, batch):
+        return "[LONG TERM MEMORY]\n- she likes the sea"
+
+
+def _mind(*skills):
+    registry = SkillRegistry()
+    for skill in skills:
+        skill.active = True
+        registry.register(skill)
+    config = Config()
+    return Consciousness(
+        config=config, llm=FakeLLMClient(), bus=PerceptionBus(window=0.0),
+        expression=FakeExpression(), surfaces=registry, history_manager=FakeHistory(),
+        event_manager=RecordingEvents(), soul_getter=lambda: "she is called Bea",
+        operating_getter=lambda: "she speaks with `speak`", attention=Attention(config),
+    )
+
+
+def _skill(cls):
+    return cls(Config(), bus=None, expression=None, context=None)
+
+
+BATCH = [Perception(PerceptionKind.CHAT, "chat:ui", "[ema]: ciao")]
+
+
+def test_a_broken_skill_does_not_cost_the_system_prompt():
+    mind = _mind(_skill(Broken), _skill(Working))
+    content = mind._system_message()["content"]
+    assert "she is called Bea" in content
+    assert "something she needs to know" in content
+
+
+def test_a_broken_skill_does_not_cost_the_briefing():
+    mind = _mind(_skill(Broken), _skill(Working))
+    content = mind._briefing(BATCH)["content"]
+    assert "half past noon" in content
+    assert "she likes the sea" in content
+
+
+def test_the_whole_turn_is_not_lost_to_one_bad_block():
+    """What actually happened: she answered nothing, to anyone, for an hour."""
+    mind = _mind(_skill(Broken))
+    assert mind._system_message()["content"]
+    assert mind._briefing(BATCH) is not None
+
+
+def test_the_log_names_the_skill_and_what_it_was_asked_for(caplog):
+    mind = _mind(_skill(Broken))
+    with caplog.at_level("ERROR", logger="bea.skills"):
+        mind._briefing(BATCH)
+    logged = caplog.text
+    assert "broken" in logged
+    assert "live state" in logged
+
+
+@pytest.mark.parametrize("attribute", ["recap", "attention", "conversations"])
+def test_a_broken_block_outside_the_skills_is_left_out_too(attribute):
+    mind = _mind(_skill(Working))
+
+    class Raises:
+        def __getattr__(self, name):
+            def boom(*args, **kwargs):
+                raise ValueError("Invalid format string")
+            return boom
+
+    setattr(mind, attribute, Raises())
+    assert "half past noon" in mind._briefing(BATCH)["content"]

--- a/tests/test_dashboard_microphone.py
+++ b/tests/test_dashboard_microphone.py
@@ -1,0 +1,66 @@
+"""The microphone on the dashboard is the owner talking, in the same room.
+
+It was handed to the discord surface, for no better reason than that being
+where voice had been implemented first. So it arrived as an unknown person
+speaking in a call she was not in — which the attention gate is entitled to let
+go by, and did. The mic worked, the transcript came back, and she said nothing:
+from the outside, indistinguishable from voice being broken.
+"""
+
+from src.core.attention.gate import Attention
+from src.core.perception.bus import PerceptionBus
+from src.core.perception.types import PerceptionKind
+from src.core.skills.chat import ChatSurface
+
+
+class Config:
+    def __init__(self):
+        self.skills = {}
+        self.attention = {"enabled": True, "cooldown_seconds": 0, "interject_threshold": 0.45,
+                          "quiet_hours": [], "trigger_words": ["bea"], "hot_names": [],
+                          "self_ids": [], "digest_max_lines": 8}
+        self.persona = {}
+
+
+def _surface():
+    surface = ChatSurface(Config(), bus=PerceptionBus(window=0.0), expression=None)
+    surface.active = True
+    return surface
+
+
+def test_a_spoken_line_arrives_as_voice():
+    p = _surface().perceive_voice("ciao, come stai?")
+    assert p.kind is PerceptionKind.VOICE
+    assert "ciao, come stai?" in p.content
+
+
+def test_it_arrives_on_the_dashboard_not_on_discord():
+    p = _surface().perceive_voice("ciao")
+    assert p.surface == "chat:ui"
+    assert p.author.platform == "ui"
+
+
+def test_the_person_at_the_microphone_is_the_owner():
+    """Anyone else and the gate may decide she has better things to do."""
+    assert _surface().perceive_voice("ciao").author.is_owner
+
+
+def test_the_gate_lets_her_own_voice_through():
+    """The bug in one line: as a stranger on discord this was dropped here."""
+    p = _surface().perceive_voice("ciao")
+    kept, noted = Attention(Config()).judge([p])
+    assert kept == [p]
+    assert noted == []
+
+
+def test_she_knows_nobody_else_is_in_the_room():
+    """`listeners` is what stops the gate rolling dice over a single speaker."""
+    p = _surface().perceive_voice("ciao")
+    assert p.meta["listeners"] == 1
+    assert p.meta["alone_with_speaker"] is True
+
+
+def test_typing_still_arrives_as_chat():
+    p = _surface().perceive("ciao")
+    assert p.kind is PerceptionKind.CHAT
+    assert p.surface == "chat:ui"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -299,7 +299,7 @@ async def test_an_unbuilt_dashboard_is_fatal_when_her_stage_needs_it(monkeypatch
     monkeypatch.setattr(doctor, "DASHBOARD", tmp_path / "never-built.html")
     found = await check_dashboard(config(stage={"avatar_backend": "model",
                                                 "caption_backend": "obs"}))
-    assert found.stops and found.fix == "make frontend"
+    assert found.stops and found.fix == "uv run bea --install-node"
 
 
 async def test_an_unbuilt_dashboard_is_only_a_warning_otherwise(monkeypatch, tmp_path):
@@ -403,7 +403,7 @@ async def test_a_machine_without_node_is_told_so_and_told_what_to_install(monkey
 
     assert not found.ok
     assert "node" in found.detail
-    assert "npm ci" in found.fix
+    assert "--install-node" in found.fix
 
 
 async def test_packages_that_were_never_installed_are_named(monkeypatch, tmp_path):
@@ -413,4 +413,4 @@ async def test_packages_that_were_never_installed_are_named(monkeypatch, tmp_pat
     found = await check_discord(config(skills={"discord": {"enabled": True}}))
 
     assert not found.ok
-    assert "npm ci" in found.fix
+    assert "--install-node" in found.fix

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -430,3 +430,37 @@ def test_a_real_model_name_is_left_alone():
     from src.core.memory.embedder import resolve_model
 
     assert resolve_model("BAAI/bge-small-en-v1.5") == "BAAI/bge-small-en-v1.5"
+
+
+# --- what the stored vectors were made with ----------------------------------
+
+
+def test_the_identity_carries_more_than_the_model_name():
+    """fastembed 0.6 began mean-pooling the model 0.5 read the CLS token of.
+
+    Same name, different vector space: every memory written before it became
+    incomparable to the queries made after, and nothing reported it.
+    """
+    from src.core.memory.embedder import FastEmbedEmbedder
+
+    embedder = FastEmbedEmbedder("BAAI/bge-small-en-v1.5")
+    assert embedder.identity.startswith("BAAI/bge-small-en-v1.5@fastembed")
+    assert embedder.identity != embedder.model_name
+
+
+def test_a_new_fastembed_series_re_embeds_the_store(monkeypatch):
+    from src.core.memory import embedder as embedder_module
+
+    monkeypatch.setattr(embedder_module, "_fastembed_series", lambda: "0.5")
+    before = embedder_module.FastEmbedEmbedder("m").identity
+    monkeypatch.setattr(embedder_module, "_fastembed_series", lambda: "0.6")
+    assert embedder_module.FastEmbedEmbedder("m").identity != before
+
+
+def test_a_patch_release_is_not_worth_re_embedding_for(monkeypatch):
+    from src.core.memory import embedder as embedder_module
+
+    monkeypatch.setattr(embedder_module.metadata, "version", lambda _: "0.7.3")
+    first = embedder_module._fastembed_series()
+    monkeypatch.setattr(embedder_module.metadata, "version", lambda _: "0.7.9")
+    assert embedder_module._fastembed_series() == first

--- a/tests/test_node_install.py
+++ b/tests/test_node_install.py
@@ -1,0 +1,71 @@
+"""Every javascript part of her gets installed, not only the visible one.
+
+The dashboard is the obvious one — a missing dashboard announces itself. Her
+discord voice is a node program too, and nothing installed it: the toggle in the
+UI turned on a bot whose packages had never been fetched, and it went on looking
+enabled while never coming online.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.setup import node
+
+
+def test_the_discord_bot_is_one_of_the_projects():
+    assert "discord bot" in {p.name for p in node.PROJECTS}
+
+
+def test_every_project_points_at_a_real_package_json():
+    for project in node.PROJECTS:
+        assert (Path(project.path) / "package.json").is_file(), project.name
+
+
+def test_only_the_dashboard_needs_building():
+    """The bot is run from source; there is nothing to bundle."""
+    builds = {p.name for p in node.PROJECTS if p.builds}
+    assert builds == {"dashboard"}
+
+
+def test_all_of_them_are_installed(monkeypatch):
+    ran = []
+
+    def record(project, args, root=None):
+        ran.append((project.name, args))
+        return True, ""
+
+    monkeypatch.setattr(node.shutil, "which", lambda name: "/usr/bin/npm")
+    monkeypatch.setattr(node, "run", record)
+
+    assert node.install_all() == 0
+    assert ("discord bot", ["install", "--no-audit", "--no-fund"]) in ran
+    assert ("dashboard", ["run", "build"]) in ran
+
+
+def test_a_machine_without_node_is_told_rather_than_left_guessing(monkeypatch, caplog):
+    monkeypatch.setattr(node.shutil, "which", lambda name: None)
+    with caplog.at_level("ERROR", logger="bea.setup.node"):
+        assert node.install_all() == 1
+    assert "nodejs.org" in caplog.text
+
+
+def test_one_project_failing_does_not_hide_the_others(monkeypatch):
+    ran = []
+
+    def record(project, args, root=None):
+        ran.append(project.name)
+        return project.name != "dashboard", "npm exploded"
+
+    monkeypatch.setattr(node.shutil, "which", lambda name: "/usr/bin/npm")
+    monkeypatch.setattr(node, "run", record)
+
+    assert node.install_all() == 1
+    assert "discord bot" in ran
+
+
+@pytest.mark.parametrize("project", node.PROJECTS, ids=lambda p: p.name)
+def test_a_project_knows_whether_it_has_been_installed(project, tmp_path):
+    assert not project.installed(tmp_path)
+    (tmp_path / project.path / "node_modules").mkdir(parents=True)
+    assert project.installed(tmp_path)

--- a/tests/test_node_install.py
+++ b/tests/test_node_install.py
@@ -69,3 +69,30 @@ def test_a_project_knows_whether_it_has_been_installed(project, tmp_path):
     assert not project.installed(tmp_path)
     (tmp_path / project.path / "node_modules").mkdir(parents=True)
     assert project.installed(tmp_path)
+
+
+# --- windows calls npm something else ----------------------------------------
+
+
+def test_npm_is_run_under_the_name_this_machine_gave_it(monkeypatch):
+    """On windows npm is `npm.cmd`, and subprocess will not find it by the
+    bare name — every npm step failed saying npm was not installed."""
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["argv0"] = args[0]
+        raise RuntimeError("far enough: the name is what is being tested")
+
+    monkeypatch.setattr(node.shutil, "which", lambda name: r"C:\Program Files\nodejs\npm.cmd")
+    monkeypatch.setattr(node.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError):
+        node.run(node.PROJECTS[0], ["install"])
+    assert seen["argv0"].endswith("npm.cmd")
+
+
+def test_a_missing_npm_is_reported_rather_than_raised(monkeypatch):
+    monkeypatch.setattr(node.shutil, "which", lambda name: None)
+    ok, detail = node.run(node.PROJECTS[0], ["install"])
+    assert not ok
+    assert "npm is not installed" in detail

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -10,6 +10,7 @@ happens, which is exactly why it needs a test.
 
 import asyncio
 import random
+import time
 from datetime import datetime
 
 from src.core.attention.gate import Attention
@@ -85,17 +86,30 @@ def chat(text: str) -> Perception:
     )
 
 
+async def _until(condition, timeout: float = 5.0) -> None:
+    """Waits for the thing being waited for, rather than for a while.
+
+    A fixed sleep looked fine here and made the file flaky on windows, where
+    the timer moves in steps of about 15ms and a turn can take longer than the
+    20ms it was given — so the second turn never ran and the assertion blamed
+    the prompt.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.005)
+
+
 async def run_turns(mind, bus, lines) -> None:
     mind.alive = True
     task = asyncio.create_task(mind.run())
     try:
-        for line in lines:
+        for index, line in enumerate(lines, start=1):
             bus.put(chat(line))
-            for _ in range(40):
-                await asyncio.sleep(0.005)
-                if not bus._queue.qsize():
-                    break
-        await asyncio.sleep(0.02)
+            # one line, one turn: waiting for the call keeps the next line from
+            # joining this batch, which would make two messages into one turn
+            await _until(lambda n=index: mind.llm.call_count >= n)
     finally:
         mind.alive = False
         task.cancel()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -70,6 +70,28 @@ def test_it_says_the_weekday_the_date_and_the_time():
     assert "12:30" in block
 
 
+def test_a_single_digit_day_keeps_no_leading_zero():
+    assert "5 August 2026" in now_block(datetime(2026, 8, 5, 12, 30))
+
+
+def test_the_date_survives_a_clock_that_refuses_unix_only_directives():
+    """Windows raises `Invalid format string` on `%-d` rather than ignoring it.
+
+    This line goes into every turn, so it did not degrade anything — it took
+    the whole turn down, on every message, with an error naming neither.
+    """
+
+    class WindowsClock:
+        day = 5
+
+        def strftime(self, fmt: str) -> str:
+            if "%-" in fmt:
+                raise ValueError("Invalid format string")
+            return datetime(2026, 8, 5, 12, 30).strftime(fmt)
+
+    assert "5 August 2026" in now_block(WindowsClock())
+
+
 def test_it_is_labelled_so_she_can_find_it():
     assert now_block(NOON).startswith("[RIGHT NOW]")
 

--- a/tests/test_update_api.py
+++ b/tests/test_update_api.py
@@ -88,7 +88,7 @@ def test_applying_from_the_dashboard_can_be_revoked(client):
     response = client.post("/update/apply")
 
     assert response.status_code == 403
-    assert "make update" in response.json()["detail"]
+    assert "bea --update" in response.json()["detail"]
 
 
 def test_a_config_without_the_block_still_works(client):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -88,9 +88,12 @@ def commit(cwd: Path, message: str) -> str:
 
 
 def write(root: Path, relative: str, text: str) -> None:
+    # bytes, so the fixture is the same repository on every platform: text mode
+    # on windows writes CRLF, which quietly made these tests build a different
+    # repository there than the one they describe
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    path.write_bytes(text.encode("utf-8"))
 
 
 def read(root: Path, relative: str) -> str:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -19,6 +19,7 @@ the result and updates again.
 """
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -67,10 +68,14 @@ ORIGINAL = "\n".join([
 
 
 def git(cwd: Path, *args: str) -> str:
+    # the developer's own git config is kept out of these fixtures, but the
+    # PATH is inherited: git lives somewhere else entirely on windows, and a
+    # hardcoded posix one made the suite unrunnable there
+    env = {**os.environ,
+           "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+           "HOME": str(cwd), "USERPROFILE": str(cwd)}
     result = subprocess.run(
-        ["git", *args], cwd=str(cwd), capture_output=True, text=True,
-        env={"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
-             "HOME": str(cwd), "PATH": "/usr/bin:/bin:/usr/local/bin"},
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, env=env,
     )
     assert result.returncode == 0, f"git {' '.join(args)} failed: {result.stderr}"
     return result.stdout.strip()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -707,3 +707,55 @@ def test_docker_is_told_to_rebuild_the_image(world, monkeypatch):
     status = runner.check(root=clone, force=True)
     assert not status.supported
     assert "Docker" in status.reason
+
+
+# --- the javascript she has that is not the dashboard -------------------------
+
+
+def test_an_update_to_the_discord_bot_installs_it(world, monkeypatch):
+    """The bot was left out of the rebuild for as long as it existed.
+
+    An update that changed its packages left the discord toggle on in the UI
+    and the bot unable to start, saying so nowhere but its own stderr.
+    """
+    upstream, clone = world
+    write(upstream, "src/core/skills/voice/bot/package.json", '{"name": "bea-discord-bot"}\n')
+    commit(upstream, "bump the bot")
+
+    ran = []
+
+    def record(cwd, args):
+        ran.append((cwd, args))
+        return True, ""
+
+    monkeypatch.setattr(runner.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(runner, "_command", record)
+
+    report = update(clone)
+
+    statuses = {s.id: s.status for s in report.steps}
+    assert statuses["discord bot"] == "done"
+    assert any("bot" in str(cwd) and args[:1] == ["npm"] for cwd, args in ran)
+
+
+def test_the_bot_is_left_alone_when_it_did_not_change(world):
+    upstream, clone = world
+    replace(upstream, SOUL, "She is the one we ship.", "changed")
+    commit(upstream, "prompt only")
+
+    report = update(clone)
+
+    assert {s.id: s.status for s in report.steps}["discord bot"] == "skipped"
+
+
+def test_a_missing_npm_names_the_one_command_that_fixes_it(world, monkeypatch):
+    upstream, clone = world
+    write(upstream, "src/core/skills/voice/bot/package.json", '{"name": "bea-discord-bot"}\n')
+    commit(upstream, "bump the bot")
+    monkeypatch.setattr(runner.shutil, "which", lambda name: None if name == "npm" else "/usr/bin/x")
+
+    report = update(clone)
+
+    bot = [s for s in report.steps if s.id == "discord bot"][0]
+    assert bot.status == "failed"
+    assert "--install-node" in bot.detail

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -764,3 +764,67 @@ def test_a_missing_npm_names_the_one_command_that_fixes_it(world, monkeypatch):
     bot = [s for s in report.steps if s.id == "discord bot"][0]
     assert bot.status == "failed"
     assert "--install-node" in bot.detail
+
+
+# --- the same file, written the way windows writes it -------------------------
+
+
+def write_crlf(root: Path, relative: str, text: str) -> None:
+    """A file as an editor on windows leaves it."""
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(text.replace("\n", "\r\n").encode("utf-8"))
+
+
+def test_a_prompt_stored_with_windows_line_endings_still_merges(world):
+    """The three sides used to be read two different ways.
+
+    The user's file came through python's text mode, which turns CRLF into LF;
+    the other two came out of git as bytes, which does not. Every line then
+    differed from itself, so a clean merge was reported as a collision and the
+    engine's own improvements were dropped.
+    """
+    upstream, clone = world
+    write_crlf(upstream, OPERATING, ORIGINAL)
+    commit(upstream, "as windows wrote it")
+    git(clone, "pull", "-q", "origin", "main")
+
+    write_crlf(clone, OPERATING, ORIGINAL.replace("She is curious.", "She is sarcastic and tired."))
+    write_crlf(upstream, OPERATING,
+               ORIGINAL.replace("Use the speak tool.", "Use the speak tool, never narrate."))
+    commit(upstream, "improve the manual")
+
+    report = update(clone)
+
+    merged = read(clone, OPERATING)
+    assert "She is sarcastic and tired." in merged, "the user's character was dropped"
+    assert "Use the speak tool, never narrate." in merged, "the engine improvement was dropped"
+    assert [o.state for o in report.prompts] == [MERGED]
+
+
+def test_an_identical_edit_is_not_a_conflict_because_of_line_endings(world):
+    upstream, clone = world
+    write_crlf(upstream, OPERATING, ORIGINAL)
+    commit(upstream, "as windows wrote it")
+    git(clone, "pull", "-q", "origin", "main")
+
+    changed = ORIGINAL.replace("She is curious.", "She is curious and blunt.")
+    write_crlf(clone, OPERATING, changed)
+    write_crlf(upstream, OPERATING, changed)
+    commit(upstream, "same change")
+
+    assert [o.state for o in update(clone).prompts] == [UNTOUCHED]
+
+
+def test_a_merge_hands_the_file_back_written_the_way_it_was_found(world):
+    """Rewriting somebody's line endings behind their back is its own bug."""
+    upstream, clone = world
+    write_crlf(clone, OPERATING, ORIGINAL.replace("She is curious.", "She is sarcastic."))
+    replace(upstream, OPERATING, "Use the speak tool.", "Use the speak tool, briefly.")
+    commit(upstream, "an easy change")
+
+    update(clone)
+
+    raw = (clone / OPERATING).read_bytes()
+    assert b"\r\n" in raw
+    assert raw.count(b"\n") == raw.count(b"\r\n"), "half the file was converted"


### PR DESCRIPTION
## What this changes

Seven bugs, all of which made her look broken rather than saying what was wrong.
The first one is the reason she went silent on Windows.

**She could not answer a single message on Windows.** `now_block` built the date
with `%-d`, a unix extension. Windows does not ignore it — it raises
`ValueError: Invalid format string`. That line goes into every turn, so every
turn died in the loop's catch-all before the model was ever called, and the
dashboard showed "She heard it and chose not to answer" to everything. The date
is now assembled without the directive, and a test drives `now_block` with a
clock that refuses unix-only formats.

**The loop threw the traceback away.** `Consciousness loop error: Invalid format
string` named neither the file nor the skill, which is most of why the above took
so long to find. It now logs with `exc_info`, and each context contributor is
asked for its block separately: a skill that raises loses its own paragraph and
is named in the log, instead of costing the whole turn. Her context comes from a
dozen independent sources and any one of them could silence her completely.

**The dashboard microphone was handed to the discord surface**, for no better
reason than that being where voice was implemented first. So the owner arrived as
an unknown person speaking in a call she was not in — which the attention gate is
entitled to ignore, and did. The mic worked, the transcript came back, and she
said nothing. It now goes through `chat:ui` as a VOICE perception from the owner.

**Nothing ever installed the discord bot.** It is a node program of its own; the
installer built the dashboard, the updater rebuilt the dashboard, and the toggle
in the UI switched on a bot whose packages had never been fetched. `src/setup/node.py`
now lists every node project of hers in one place, `uv run bea --install-node`
(`make node`) installs all of them, and the updater has a step per project.

**npm is `npm.cmd` on Windows**, which `subprocess` cannot find by its bare name,
so every npm step failed saying npm was not installed on machines where it was.
`node` and `npm` are now resolved through `which` before being run.

**A bad token restarted the bot forever**, every three seconds, burying the one
line that said why. It now gives up after three starts that never reach the login
and says so once, on the dashboard as well as in the log.

**fastembed 0.6 began mean-pooling the model 0.5 read the CLS token of.** Same
model name, different vector space: every memory written before it was
incomparable to the queries made after, and the only sign was a `UserWarning` on
startup. The stored identity now carries the fastembed series, so this re-embeds
the way a changed model always has, and the warning is no longer printed as if
something were broken.

**CI ran on ubuntu only** — which is why a Windows-only date format shipped. It
now runs the suite on ubuntu, macos and windows; lint and types stay on one, since
they read the code rather than the machine. Free for public repos on standard
runners, and 5 concurrent jobs against a limit of 20.

`make frontend` is now `make node`, and the places that told you to run `make`
were given the `uv run` command underneath — Windows does not ship Make, which is
where this started.

## What breaks if it is wrong

The first start after this re-embeds the memory store once, because the embedder
identity changed. It is local and the text is stored in the clear, so nothing is
lost, but a large store will make one startup slow.

`make frontend` no longer exists. Anyone with it in a script gets an error rather
than a silent no-op.

If the mic change is wrong, spoken input stops reaching her at all rather than
being quietly dropped — which is the loud version of the bug being fixed.

Verified by hand against a running engine on macOS: typed and spoken input both
answered, no warning on startup, no loop errors. Windows is covered by the new CI
job rather than by a machine I could test on.

## Checks

- [x] `make test` passes (1741 tests)
- [x] `make lint` passes
- [x] New behaviour has a test named after the behaviour
- [x] `docs/` updated, if this changes something someone could be relying on
