### PR TITLE
Add a local Whisper she can hear with

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ touching the core.
 |---|---|---|
 | **LLM** | `LLMClient` (tool-aware) | OpenRouter, OpenAI, Groq |
 | **TTS** | `TTSInterface` | EdgeTTS (free), Kokoro (local ONNX), Orpheus (API) |
-| **STT** | `STTInterface` | Groq, OpenRouter (Whisper) |
+| **STT** | `STTInterface` | Local Whisper (faster-whisper), Groq, OpenRouter |
 | **Avatar** | `AvatarInterface` | Images (OBS), 3D model (VRM), VTube Studio |
 | **Caption** | `CaptionInterface` | OBS text source, browser source, off |
 | **OBS** | `OBSInterface` | OBS WebSocket |
@@ -435,7 +435,7 @@ make test          # uv run pytest -q
 make lint          # uv run ruff check src tests
 ```
 
-1867 tests, and they run without network access or API keys: every model
+1886 tests, and they run without network access or API keys: every model
 client, surface and transport is faked. CI runs exactly `make test` and `make lint`.
 
 > [!TIP]

--- a/config.example.json
+++ b/config.example.json
@@ -140,6 +140,10 @@
     },
     "stt_provider": "groq",
     "stt_model": "whisper-large-v3-turbo",
+    "faster_whisper_device": "auto",
+    "faster_whisper_compute_type": "auto",
+    "faster_whisper_download_root": "data/models/whisper",
+    "faster_whisper_vad": true,
     "consciousness": {
         "enabled": true,
         "idle_after": 240.0,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ ProjectBEA/
 │   ├── pngs/               # avatars per mood (idle/talking)
 │   └── prompts/            # soul · operating · monologue · minecraft · chat
 ├── docs/                   # this documentation, rendered by the docs site
-├── tests/                  # 63 files, no network
+├── tests/                  # 91 files, no network
 └── src/
     ├── cli.py              # argument parsing and composition
     ├── core/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,10 @@ This is `config.example.json` verbatim; it matches the dataclass defaults in
     },
     "stt_provider": "groq",
     "stt_model": "whisper-large-v3-turbo",
+    "faster_whisper_device": "auto",
+    "faster_whisper_compute_type": "auto",
+    "faster_whisper_download_root": "data/models/whisper",
+    "faster_whisper_vad": true,
     "consciousness": {
         "enabled": true,
         "idle_after": 240.0,
@@ -359,8 +363,18 @@ continues. [OBS module →](modules/obs.md)
 
 | Key | Default | Description |
 |---|---|---|
-| `stt_provider` | `"groq"` | `groq` or `openrouter`. Anything else disables speech input |
-| `stt_model` | `"whisper-large-v3-turbo"` | Rewritten to `openai/whisper-large-v3-turbo` on OpenRouter |
+| `stt_provider` | `"groq"` | `faster_whisper`, `groq` or `openrouter`. Anything else disables speech input |
+| `stt_model` | `"whisper-large-v3-turbo"` | Rewritten to `openai/whisper-large-v3-turbo` on OpenRouter, and to `large-v3-turbo` on `faster_whisper` |
+
+`faster_whisper` runs Whisper on this machine and needs no key. Its four extra
+knobs are only read when it is the chosen provider:
+
+| Key | Default | Description |
+|---|---|---|
+| `faster_whisper_device` | `"auto"` | `auto`, `cpu` or `cuda` |
+| `faster_whisper_compute_type` | `"auto"` | Auto is `int8` on a CPU, `float16` on a GPU |
+| `faster_whisper_download_root` | `"data/models/whisper"` | Where the weights are cached. Gitignored |
+| `faster_whisper_vad` | `true` | Drops silence, which Whisper otherwise invents words for |
 
 [STT module →](modules/stt.md)
 
@@ -492,7 +506,7 @@ uv run bea --web --llm-provider openrouter --tts-provider kokoro --device-id 22
 | `--host` / `--port` | Default `127.0.0.1:8000`. See below before changing the host |
 | `--llm-provider` | `openrouter`, `openai`, `groq`. Only affects the legacy single-model path |
 | `--openrouter-key` / `--openrouter-model` | and the same pair for `--openai-*` and `--groq-*` |
-| `--stt-provider` / `--stt-model` | `groq` or `openrouter` |
+| `--stt-provider` / `--stt-model` | `faster_whisper`, `groq` or `openrouter` |
 | `--tts-provider` / `--tts-voice` | `edge`, `kokoro`, `orpheus` |
 | `--orpheus-key` / `--orpheus-endpoint` / `--orpheus-voice` | |
 | `--kokoro-file` / `--kokoro-voices` | |

--- a/docs/modules/stt.md
+++ b/docs/modules/stt.md
@@ -17,8 +17,9 @@ entrypoints where audio arrives already decoded as WAV:
 
 ```
 src/modules/STT/
-├── groq_stt.py        Groq Whisper
-└── openrouter_stt.py  OpenRouter Whisper
+├── faster_whisper_stt.py  Whisper on this machine
+├── groq_stt.py            Groq Whisper
+└── openrouter_stt.py      OpenRouter Whisper
 ```
 
 The provider is chosen by `stt_provider` in config and instantiated in
@@ -40,6 +41,50 @@ Returns the transcript, or an empty string on failure. Both methods are
 
 `language` falls back to `config.language`, which measurably improves accuracy
 on non-English speech.
+
+---
+
+## Local Whisper (`faster_whisper_stt.py`)
+
+Whisper through [faster-whisper](https://github.com/SYSTRAN/faster-whisper),
+running on the machine she runs on. No key, no account, no per-minute bill, and
+the audio never leaves the room — which is the whole reason to prefer it for a
+Discord call with people who did not agree to be sent anywhere.
+
+- **Config:** `stt_provider: "faster_whisper"`, `stt_model` (default `small`)
+- **Key:** none
+
+| Field | Default | What it does |
+|---|---|---|
+| `faster_whisper_device` | `"auto"` | `auto`, `cpu` or `cuda`. Auto takes the GPU when there is one |
+| `faster_whisper_compute_type` | `"auto"` | Auto is `int8` on a CPU and `float16` on a GPU. `int8_float16` and `float32` also work |
+| `faster_whisper_download_root` | `"data/models/whisper"` | Where the weights are cached. Gitignored |
+| `faster_whisper_vad` | `true` | Drops silence before transcribing. Whisper invents words for silence, so leave it on |
+
+The weights are downloaded on first use, not at install time:
+
+| `stt_model` | On disk | Notes |
+|---|---|---|
+| `tiny` | ~75 MB | Instant, and it will mishear you |
+| `base` | ~145 MB | Usable on an old laptop |
+| `small` | ~480 MB | The default, and the balance most people want |
+| `large-v3-turbo` | ~1.6 GB | Best, and it wants a GPU |
+
+Any faster-whisper model on Hugging Face works too — a repo id with a slash in
+it (`Systran/faster-distil-whisper-large-v3`) is passed through untouched.
+
+**Two things it normalises, so the same config.json works on every provider:**
+
+- `stt_model`. The hosted spelling `whisper-large-v3-turbo`, or
+  `openai/whisper-large-v3-turbo`, becomes `large-v3-turbo` — switching
+  `stt_provider` does not also mean editing the model.
+- `language`. Whisper raises on a code it does not know, where the hosted
+  providers shrug. `jp` — one of the dashboard's own choices — becomes `ja`, and
+  anything else it has never heard of falls back to auto-detection with a
+  warning, rather than taking the transcript down to an empty string.
+
+> Nothing else about her becomes local by choosing this. The mind is still a
+> hosted model, and it is still sent what she heard.
 
 ---
 
@@ -84,5 +129,10 @@ turn, one answer.
 `reload_config()` updates the model and re-creates the client if the key
 changed. Switching `stt_provider` itself needs a restart — the object type
 changes.
+
+Local Whisper compares the whole set — model, device, precision, cache — and
+rebuilds only when one of them actually moved. Loading it is seconds and
+possibly a download, and an unrelated save from the dashboard must not pay for
+that.
 
 [Discord Skill →](../skills/discord.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -193,6 +193,36 @@ To use a different path, update `kokoro_model` and `kokoro_voices_file` in `conf
 
 ---
 
+## 7b. Local Whisper Setup (optional)
+
+The same deal for her ears. `faster_whisper` transcribes on this machine, so
+voice input needs no key and no account, and nothing you say is uploaded
+anywhere to be turned into text.
+
+Set `stt_provider` to `faster_whisper` in `config.json` — or pick **Local
+Whisper** in the wizard or on the dashboard's Hearing page — and choose a size:
+
+| `stt_model` | On disk | Notes |
+|---|---|---|
+| `tiny` | ~75 MB | Instant, and it will mishear you |
+| `base` | ~145 MB | Usable on an old laptop |
+| `small` | ~480 MB | The default, and the balance most people want |
+| `large-v3-turbo` | ~1.6 GB | Best, and it wants a GPU |
+
+The weights download on first use into `data/models/whisper`, which is
+gitignored. The first transcription after a fresh install therefore takes as
+long as that download; `uv run bea --doctor` allows for it and will not call it
+a failure.
+
+On a machine with an NVIDIA GPU, set `faster_whisper_device` to `cuda` — this
+needs the CUDA and cuDNN runtimes on the system, which `uv sync` does not
+install. Leave it on `auto` if you would rather not deal with that; the CPU
+path runs `int8` and is fast enough for `small`.
+
+[STT module →](modules/stt.md)
+
+---
+
 ## 8. Orpheus TTS Setup (optional)
 
 Orpheus is a high-quality expressive voice API hosted on [Baseten](https://baseten.co). It requires a manual deployment step before use:
@@ -356,6 +386,9 @@ costs a handful of provider requests and never runs on its own.
 |---|---|
 | `OBS not connected` warning on start | OBS is not running or WebSocket creds are wrong — the engine continues without it |
 | `No audio device` error | Run the sounddevice query above and update `audio_device_id` |
+| Local Whisper: `Could not load local whisper` | `stt_model` is not a size it knows or a Hugging Face repo that exists, or `faster_whisper_download_root` is not writable. She keeps running; only voice input is lost |
+| Local Whisper: the first voice line takes minutes | The weights are being downloaded, once. Watch `data/models/whisper` grow |
+| Local Whisper on a GPU fails to load | `faster_whisper_device: "cuda"` needs the CUDA and cuDNN runtimes, which `uv sync` does not install. Set it back to `auto` |
 | Discord bot fails with `node_modules not found` | Run `npm install` in `src/core/skills/voice/bot/` |
 | `Embedder unavailable` on start | The embedding model could not be downloaded. Everything else keeps working — only long-term recall is lost until it can |
 | `No usable model for role 'mind'` | The `models.mind` pool is empty or none of its keys are set. Check `models` in `config.json` and the matching `*_API_KEY` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-dotenv",
     "websocket-client",
     "kokoro-onnx",
+    "faster-whisper>=1.1",
     "groq",
     "fastembed>=0.3,<0.9",
     "sqlite-vec>=0.1.1",

--- a/src/cli.py
+++ b/src/cli.py
@@ -68,7 +68,7 @@ def parse_args(argv=None):
     parser.add_argument("--groq-model", default=None, help="Groq Model")
 
     # stt
-    parser.add_argument("--stt-provider", choices=["groq", "openrouter"], default=None, help="STT Provider")
+    parser.add_argument("--stt-provider", choices=["groq", "openrouter", "faster_whisper"], default=None, help="STT Provider")
     parser.add_argument("--stt-model", default=None, help="STT Model")
 
     # obs

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -297,6 +297,13 @@ class BrainConfig:
     stt_provider: str = "openrouter"
     stt_model: str = "whisper-large-v3-turbo"
 
+    # local whisper. Only read when stt_provider is "faster_whisper"; the model
+    # id comes from stt_model like everywhere else, hosted spellings included
+    faster_whisper_device: str = "auto"       # auto | cpu | cuda
+    faster_whisper_compute_type: str = "auto" # auto picks int8 on cpu, float16 on cuda
+    faster_whisper_download_root: str = "data/models/whisper"
+    faster_whisper_vad: bool = True           # drops silence, which whisper otherwise invents words for
+
     def __post_init__(self):
         self.load_from_file()
 

--- a/src/modules/STT/factory.py
+++ b/src/modules/STT/factory.py
@@ -22,10 +22,19 @@ def _openrouter(config) -> STTInterface:
     return OpenRouterSTT(config)
 
 
+def _faster_whisper(config) -> STTInterface:
+    from src.modules.STT.faster_whisper_stt import FasterWhisperSTT
+    return FasterWhisperSTT(config)
+
+
 BUILDERS: Dict[str, Callable[..., STTInterface]] = {
     "groq": _groq,
     "openrouter": _openrouter,
+    "faster_whisper": _faster_whisper,
 }
+
+# providers that run on this machine, so nothing above should look for a key
+LOCAL = frozenset({"faster_whisper"})
 
 
 def build_stt(config) -> Optional[STTInterface]:

--- a/src/modules/STT/faster_whisper_stt.py
+++ b/src/modules/STT/faster_whisper_stt.py
@@ -1,0 +1,153 @@
+"""Whisper on this machine, through faster-whisper.
+
+The other two transcribers send the audio somewhere. This one does not: the
+weights live under `data/models/whisper`, nothing leaves the room, and there is
+no key and no per-minute bill. The cost is the first run, which downloads the
+model, and a CPU that is busy while she listens.
+"""
+
+import os
+from typing import Optional
+
+from src.core.config import BrainConfig
+from src.interfaces.base_interfaces import STTInterface
+from src.utils.logger import get_logger
+
+logger = get_logger("bea.stt.faster_whisper")
+
+DEFAULT_MODEL = "small"
+
+# the hosted providers name the same weights differently, and a model id copied
+# from a groq or openrouter config is the most likely thing to arrive here
+ALIASES = {
+    "whisper-large-v3-turbo": "large-v3-turbo",
+    "whisper-large-v3": "large-v3",
+    "whisper-large-v2": "large-v2",
+    "whisper-1": "large-v3",
+}
+
+
+def normalize_model(name: str) -> str:
+    """A faster-whisper model id, from whatever spelling the config carries."""
+    name = (name or "").strip()
+    if not name:
+        return DEFAULT_MODEL
+    if "/" in name:
+        owner, _, tail = name.partition("/")
+        # openai/whisper-large-v3-turbo is the hosted spelling; anything else
+        # with a slash is a real huggingface repo and is left alone
+        if owner.lower() == "openai" and tail in ALIASES:
+            return ALIASES[tail]
+        return name
+    return ALIASES.get(name, name)
+
+
+# `language` reaches the hosted providers as free text and they shrug at a code
+# they do not know. Whisper raises, so the same config must not be able to
+# break only this backend — `jp` is one of the dashboard's own choices
+LANGUAGE_ALIASES = {"jp": "ja", "cn": "zh", "gr": "el", "kr": "ko"}
+
+
+def normalize_language(code: Optional[str]) -> Optional[str]:
+    """A language whisper knows, or None to let it work the language out itself."""
+    code = (code or "").strip().lower()
+    if not code:
+        return None
+    code = LANGUAGE_ALIASES.get(code, code)
+
+    from faster_whisper.tokenizer import _LANGUAGE_CODES
+
+    if code not in _LANGUAGE_CODES:
+        logger.warning(f"Whisper does not know the language {code!r}; detecting instead.")
+        return None
+    return code
+
+
+class FasterWhisperSTT(STTInterface):
+    def __init__(self, config: BrainConfig):
+        self.config = config
+        self.model_name = normalize_model(config.stt_model)
+        self.device = config.faster_whisper_device or "auto"
+        self.compute_type = config.faster_whisper_compute_type or "auto"
+        self.download_root = config.faster_whisper_download_root or None
+        self.vad = bool(config.faster_whisper_vad)
+        self.model = None
+        self._load()
+
+    def _load(self) -> None:
+        """Builds the model, or leaves it None and says why.
+
+        A missing model must not take the whole engine down on startup: she is
+        still perfectly usable typed at, exactly as with no transcriber at all.
+        """
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError:
+            logger.error("faster-whisper is not installed — run `uv sync`.")
+            return
+
+        if self.download_root:
+            os.makedirs(self.download_root, exist_ok=True)
+
+        try:
+            self.model = WhisperModel(self.model_name, device=self.device,
+                                      compute_type=self._compute_type(),
+                                      download_root=self.download_root)
+            logger.info(f"Local whisper ready: {self.model_name} on {self.device}")
+        except Exception as e:
+            logger.error(f"Could not load local whisper {self.model_name!r}: {e}")
+
+    def _compute_type(self) -> str:
+        """`auto` means int8 on a cpu and float16 on a gpu, which is what you want.
+
+        ctranslate2's own `default` keeps the weights at full precision, and on
+        the cpu most people run this on that is several times slower for no
+        accuracy anyone can hear.
+        """
+        if self.compute_type != "auto":
+            return self.compute_type
+        return "float16" if self.device == "cuda" else "int8"
+
+    def transcribe(self, audio_path: str, language: Optional[str] = None) -> str:
+        lang = language if language else self.config.language
+
+        if not self.model:
+            logger.error("Local whisper is not loaded.")
+            return ""
+
+        if not os.path.exists(audio_path):
+            logger.error(f"Audio file not found at {audio_path}")
+            return ""
+
+        try:
+            segments, _ = self.model.transcribe(audio_path,
+                                                language=normalize_language(lang),
+                                                temperature=0.0,
+                                                vad_filter=self.vad)
+            text = "".join(segment.text for segment in segments).strip()
+            logger.info(f"Local transcription result: '{text}'")
+            return text
+        except Exception as e:
+            logger.error(f"Local transcription failed: {e}")
+            return ""
+
+    def reload_config(self, config) -> None:
+        """Rebuilds the model, but only when something about it actually changed.
+
+        Loading is seconds and a possible download, so an unrelated save from
+        the dashboard must not pay for it.
+        """
+        self.config = config
+        wanted = (normalize_model(config.stt_model),
+                  config.faster_whisper_device or "auto",
+                  config.faster_whisper_compute_type or "auto",
+                  config.faster_whisper_download_root or None)
+        self.vad = bool(config.faster_whisper_vad)
+
+        if wanted == (self.model_name, self.device, self.compute_type, self.download_root):
+            return
+
+        self.model_name, self.device, self.compute_type, self.download_root = wanted
+        logger.info(f"Reloading local whisper: {self.model_name} on {self.device}")
+        self.model = None
+        self._load()

--- a/src/setup/config_plan.py
+++ b/src/setup/config_plan.py
@@ -21,9 +21,6 @@ PROVIDER_MODELS = {
     "groq": ("groq_model", "openai/gpt-oss-120b"),
 }
 
-# only these two can transcribe, so voice input needs a key for one of them
-STT_PROVIDERS = ("groq", "openrouter")
-
 # secrets that belong to a skill rather than to a provider
 SKILL_SECRETS = {
     "discord": "DISCORD_TOKEN",
@@ -56,6 +53,8 @@ def apply_answers(config, answers: Dict[str, Any]):
 
     if answers.get("stt_provider"):
         config.stt_provider = answers["stt_provider"]
+    if answers.get("stt_model"):
+        config.stt_model = answers["stt_model"]
 
     config.tts_provider = answers.get("tts_provider", "edge")
     if answers.get("tts_voice"):
@@ -103,8 +102,9 @@ def env_updates(answers: Dict[str, Any]) -> Dict[str, str]:
         updates[env_var] = answers["llm_key"]
 
     # voice input may use a provider the mind does not, so it carries its own key
+    # — a local transcriber has none, and is not in PROVIDER_KEYS at all
     stt = answers.get("stt_provider")
-    if stt and answers.get("stt_key"):
+    if stt in PROVIDER_KEYS and answers.get("stt_key"):
         updates[PROVIDER_KEYS[stt][1]] = answers["stt_key"]
 
     if answers.get("orpheus_key"):

--- a/src/setup/doctor.py
+++ b/src/setup/doctor.py
@@ -36,14 +36,18 @@ from src.core.expression.tags import DIRECTIONS
 from src.core.mind.operating import missing_tools
 from src.core.stage import installed_clips
 
+# the module itself is cheap; only the builders inside it import a backend
+from src.modules.STT.factory import LOCAL as STT_LOCAL
+
 ENV_FILE = Path(".env")
 
 # the built dashboard, which is also the page her 3D body is drawn on
 DASHBOARD = Path("src/web/frontend/dist/index.html")
 
 # a line short enough to synthesise quickly and distinctive enough that hearing
-# it back is evidence rather than a coincidence
-TEST_LINE = "one two three"
+# it back is evidence rather than a coincidence. Words, not numbers: whisper
+# writes "one two three" back as "1, 2, 3" and a working install looked broken
+TEST_LINE = "the quick brown fox"
 
 # where the dashboard listens unless it is told otherwise
 DEFAULT_PORT = 8000
@@ -52,6 +56,9 @@ DEFAULT_PORT = 8000
 # that hangs on one cold provider is worse than one that says so.
 PROVIDER_CALL_TIMEOUT = 30.0
 EARS_ROUND_TRIP_TIMEOUT = 60.0
+# a local transcriber's first run downloads a few hundred MB before it hears
+# anything, and calling that a failure would be a lie about a working install
+LOCAL_EARS_ROUND_TRIP_TIMEOUT = 900.0
 
 
 @dataclass(frozen=True)
@@ -137,7 +144,8 @@ async def check_keys(config: BrainConfig) -> Finding:
     if not wanted:
         wanted.add(config.llm_provider)
     # her ears run on the same key namespace as the llm, and are as keyed as it
-    if config.stt_provider:
+    # — unless they run on this machine, where there is nothing to key
+    if config.stt_provider and config.stt_provider not in STT_LOCAL:
         wanted.add(config.stt_provider)
 
     missing = [name for name in sorted(wanted) if not _key_for(config, name)]
@@ -280,22 +288,23 @@ async def check_ears(config: BrainConfig) -> Finding:
                       "She cannot hear voice input. Set `stt_provider` if you "
                       "want to talk to her rather than type.")
 
+    budget = (LOCAL_EARS_ROUND_TRIP_TIMEOUT if config.stt_provider in STT_LOCAL
+              else EARS_ROUND_TRIP_TIMEOUT)
     try:
         # one thread for the whole journey: build_stt can download a model and
         # the transcriber can hang, and either must be counted down, not waited on
         heard = await asyncio.wait_for(asyncio.to_thread(_round_trip, config),
-                                       timeout=EARS_ROUND_TRIP_TIMEOUT)
+                                       timeout=budget)
     except asyncio.TimeoutError:
         return failed(f"{config.stt_provider} did not answer in time",
-                      "Check the STT key and model in config.json, and its "
-                      "network reach from this machine.")
+                      _ears_fix(config))
     except Exception as e:
         return failed(f"{config.stt_provider} could not transcribe ({e})",
-                      "Check the STT key and model in config.json.")
+                      _ears_fix(config))
 
     if not heard:
         return failed(f"{config.stt_provider} heard nothing at all",
-                      "Check the STT key and model in config.json.")
+                      _ears_fix(config))
     words = {w.strip(".,!?").lower() for w in heard.split()}
     if not words & set(TEST_LINE.split()):
         return warned(f"it heard {heard!r} instead of {TEST_LINE!r}",
@@ -600,6 +609,16 @@ def _model_of(client) -> str:
         return name
     pool = getattr(client, "clients", None)
     return getattr(pool[0], "model_name", "the mind") if pool else "the mind"
+
+
+def _ears_fix(config: BrainConfig) -> str:
+    if config.stt_provider in STT_LOCAL:
+        return (f"Check `stt_model` in config.json is a whisper size it knows "
+                f"(tiny, base, small, medium, large-v3, large-v3-turbo), and that "
+                f"{config.faster_whisper_download_root or 'the model cache'} is "
+                f"writable — the first run downloads the weights.")
+    return ("Check the STT key and model in config.json, and its network reach "
+            "from this machine.")
 
 
 def _voice_fix(config: BrainConfig) -> str:

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -18,11 +18,12 @@ from rich.panel import Panel
 from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
+# which transcribers need no account, asked of the one place that builds them
+from src.modules.STT.factory import LOCAL as STT_LOCAL
 from src.setup.config_plan import (
     PLATFORM_SKILLS,
     PROVIDER_KEYS,
     PROVIDER_MODELS,
-    STT_PROVIDERS,
     apply_answers,
     env_updates,
 )
@@ -53,6 +54,21 @@ CAPTIONS: List[Tuple[str, str, str]] = [
     ("stage", "Browser source", "Typed in the page. One message per line instead of one per letter."),
     ("obs", "OBS text source", "Typed into a text source over WebSocket."),
     ("off", "Nothing", "She speaks; nothing is written on screen."),
+]
+
+STT_ENGINES: List[Tuple[str, str, str]] = [
+    ("faster_whisper", "Local Whisper", "Runs on this machine. No key, no bill, nothing leaves the room."),
+    ("groq", "Groq Whisper", "Hosted and very fast. Needs a Groq key."),
+    ("openrouter", "OpenRouter", "The same Whisper models on your OpenRouter key."),
+]
+
+# what the local transcriber costs to run, smallest first. Anything huggingface
+# serves works in config.json; these are the four worth offering blind
+WHISPER_SIZES: List[Tuple[str, str, str]] = [
+    ("tiny", "tiny", "~75 MB. Instant, and it will mishear you."),
+    ("base", "base", "~145 MB. Usable on an old laptop."),
+    ("small", "small", "~480 MB. The balance most people want."),
+    ("large-v3-turbo", "large-v3-turbo", "~1.6 GB. Best, and it wants a GPU."),
 ]
 
 TTS_ENGINES: List[Tuple[str, str, str]] = [
@@ -248,23 +264,28 @@ def _ask_voice(console: Console, answers: Dict[str, Any]) -> None:
 
 def _ask_ears(console: Console, answers: Dict[str, Any]) -> None:
     _rule(console, "3/5", "Her ears")
-    console.print("  Voice input needs Whisper, which only Groq and OpenRouter serve here.\n")
+    console.print("  Voice input runs Whisper, either on this machine or on someone else's.\n")
 
     if not Confirm.ask("  Enable voice input?", default=True):
         return
 
-    provider = answers["llm_provider"]
-    if provider in STT_PROVIDERS:
-        answers["stt_provider"] = provider
-        console.print(f"  [green]✓[/green] Reusing your {provider} key.")
+    console.print()
+    engine = _choose(console, "Transcriber", STT_ENGINES, "faster_whisper")
+    answers["stt_provider"] = engine
+
+    if engine in STT_LOCAL:
+        console.print("\n  [dim]The weights are downloaded once into data/models/whisper, "
+                      "the first time she hears anything.[/dim]\n")
+        answers["stt_model"] = _choose(console, "Model size", WHISPER_SIZES, "small")
+        return
+
+    # the mind's key already covers it when both sides are the same provider
+    if engine == answers["llm_provider"]:
+        console.print(f"  [green]✓[/green] Reusing your {engine} key.")
         return
 
     console.print()
-    choices = [option for option in PROVIDERS if option[0] in STT_PROVIDERS]
-    stt_provider = _choose(console, "Transcription provider", choices, "groq")
-    console.print()
-    answers["stt_provider"] = stt_provider
-    answers["stt_key"] = _ask_key(console, "API key", PROVIDER_KEYS[stt_provider][1])
+    answers["stt_key"] = _ask_key(console, "API key", PROVIDER_KEYS[engine][1])
 
 
 def needs_obs(avatar: str, caption: str) -> bool:
@@ -398,7 +419,10 @@ def _summary(console: Console, answers: Dict[str, Any]) -> None:
 
     table.add_row("Mind", f"{answers['llm_provider']} · {answers['llm_model']}")
     table.add_row("Voice", answers.get("tts_voice") or answers.get("tts_provider", "edge"))
-    table.add_row("Ears", answers.get("stt_provider") or "off")
+    ears = answers.get("stt_provider") or "off"
+    if answers.get("stt_model"):
+        ears = f"{ears} · {answers['stt_model']}"
+    table.add_row("Ears", ears)
     stage = answers.get("stage", {})
     table.add_row("Avatar", dict((a[0], a[1]) for a in AVATARS).get(stage.get("avatar_backend", "png"), "Images"))
     table.add_row("Speech bubble", dict((c[0], c[1]) for c in CAPTIONS).get(stage.get("caption_backend", "obs"), "OBS text source"))

--- a/src/web/frontend/src/pages/settings/sections.jsx
+++ b/src/web/frontend/src/pages/settings/sections.jsx
@@ -273,26 +273,81 @@ function VoiceSection({ config, update, secrets, devices }) {
 
 // --- how she hears ----------------------------------------------------------
 
+const STT_PLACEHOLDERS = {
+    groq: 'whisper-large-v3-turbo',
+    openrouter: 'openai/whisper-large-v3-turbo',
+    faster_whisper: 'small',
+};
+
 function HearingSection({ config, update }) {
+    const provider = config.stt_provider;
+    const local = provider === 'faster_whisper';
+
     return (
-        <Group title="Speech to text" description="Changing the provider needs the engine restarted.">
-            <ProviderChoice
-                value={config.stt_provider}
-                onChange={(id) => update('stt_provider', id)}
-                options={[
-                    { id: 'groq', label: 'Groq Whisper', blurb: 'whisper-large-v3-turbo, very fast.' },
-                    { id: 'openrouter', label: 'OpenRouter', blurb: 'openai/whisper-large-v3-turbo.' },
-                ]}
-            />
-            <Field label="Model" help="Leave empty to use the provider's default.">
-                <TextInput
-                    value={config.stt_model || ''}
-                    onChange={(e) => update('stt_model', e.target.value)}
-                    placeholder={config.stt_provider === 'openrouter' ? 'openai/whisper-large-v3-turbo' : 'whisper-large-v3-turbo'}
-                    className="font-mono"
+        <>
+            <Group title="Speech to text" description="Changing the provider needs the engine restarted.">
+                <ProviderChoice
+                    value={provider}
+                    onChange={(id) => update('stt_provider', id)}
+                    columns={3}
+                    options={[
+                        { id: 'faster_whisper', label: 'Local Whisper', blurb: 'Runs here. No key, nothing leaves the room.' },
+                        { id: 'groq', label: 'Groq Whisper', blurb: 'whisper-large-v3-turbo, very fast.' },
+                        { id: 'openrouter', label: 'OpenRouter', blurb: 'openai/whisper-large-v3-turbo.' },
+                    ]}
                 />
-            </Field>
-        </Group>
+                <Field
+                    label="Model"
+                    help={local
+                        ? 'tiny, base, small, medium, large-v3, large-v3-turbo — or any faster-whisper model on Hugging Face. Downloaded on first use.'
+                        : "Leave empty to use the provider's default."}
+                >
+                    <TextInput
+                        value={config.stt_model || ''}
+                        onChange={(e) => update('stt_model', e.target.value)}
+                        placeholder={STT_PLACEHOLDERS[provider] || ''}
+                        className="font-mono"
+                    />
+                </Field>
+            </Group>
+
+            {local && (
+                <Group title="Local Whisper" description="How it runs on this machine. Changing any of these reloads the model.">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <Field label="Device" help="Auto uses the GPU when there is one.">
+                            <Select value={config.faster_whisper_device || 'auto'} onChange={(e) => update('faster_whisper_device', e.target.value)}>
+                                <option value="auto">Auto</option>
+                                <option value="cpu">CPU</option>
+                                <option value="cuda">CUDA</option>
+                            </Select>
+                        </Field>
+                        <Field label="Precision" help="Auto means int8 on a CPU and float16 on a GPU.">
+                            <Select value={config.faster_whisper_compute_type || 'auto'} onChange={(e) => update('faster_whisper_compute_type', e.target.value)}>
+                                <option value="auto">Auto</option>
+                                <option value="int8">int8</option>
+                                <option value="int8_float16">int8_float16</option>
+                                <option value="float16">float16</option>
+                                <option value="float32">float32</option>
+                            </Select>
+                        </Field>
+                    </div>
+                    <Field label="Where the weights live">
+                        <TextInput
+                            value={config.faster_whisper_download_root || ''}
+                            onChange={(e) => update('faster_whisper_download_root', e.target.value)}
+                            placeholder="data/models/whisper"
+                            className="font-mono"
+                        />
+                    </Field>
+                    <CheckRow
+                        checked={config.faster_whisper_vad ?? true}
+                        onChange={(value) => update('faster_whisper_vad', value)}
+                        title="Drop silence before transcribing"
+                        help="Whisper invents words for silence. Leave this on unless it is clipping quiet speech."
+                    />
+                </Group>
+            )}
+        </>
     );
 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,9 +143,17 @@ def test_no_flag_overrides_a_field_that_does_not_exist():
     assert dests - process_flags <= fields
 
 
+def test_the_stt_flag_offers_every_transcriber_the_factory_can_build():
+    """A backend you can configure but not pass on the command line is a trap."""
+    from src.modules.STT.factory import BUILDERS
+
+    for name in BUILDERS:
+        assert parsed("--stt-provider", name).stt_provider == name
+
+
 @pytest.mark.parametrize("flag,value,field", [
     ("--llm-provider", "groq", "llm_provider"),
-    ("--stt-provider", "groq", "stt_provider"),
+    ("--stt-provider", "faster_whisper", "stt_provider"),
     ("--obs-port", "4460", "obs_port"),
     ("--typing-delay", "0.5", "typing_delay"),
     ("--png-dir", "somewhere/else", "png_dir"),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -202,6 +202,17 @@ async def test_the_stt_provider_gets_its_key_checked_too(monkeypatch):
     assert found.stops and "OPENROUTER_API_KEY" in found.fix
 
 
+async def test_a_local_transcriber_is_not_asked_for_a_key_it_cannot_have(monkeypatch):
+    """Nothing issues a key for whisper on your own laptop."""
+    monkeypatch.delenv("FASTER_WHISPER_API_KEY", raising=False)
+    settings = config(models={"mind": ["groq:a/model"], "background": []},
+                      llm_provider="groq", stt_provider="faster_whisper",
+                      groq_key="k")
+
+    found = await check_keys(settings)
+    assert found.ok and "faster_whisper" not in found.detail
+
+
 async def test_the_provider_is_checked_when_no_pool_names_one(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     settings = config(models={"mind": [], "background": []},

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -207,11 +207,17 @@ def test_every_backend_the_wizard_offers_is_one_the_engine_can_build():
     """A wizard that offers a name the factory has never heard of is a dead end."""
     from src.modules.avatar.factory import BUILDERS as AVATARS
     from src.modules.caption.factory import BUILDERS as CAPTIONS
+    from src.modules.STT.factory import BUILDERS as TRANSCRIBERS
+    from src.modules.tts.factory import BUILDERS as VOICES
     from src.setup.wizard import AVATARS as OFFERED_AVATARS
     from src.setup.wizard import CAPTIONS as OFFERED_CAPTIONS
+    from src.setup.wizard import STT_ENGINES as OFFERED_TRANSCRIBERS
+    from src.setup.wizard import TTS_ENGINES as OFFERED_VOICES
 
     assert {a[0] for a in OFFERED_AVATARS} <= set(AVATARS)
     assert {c[0] for c in OFFERED_CAPTIONS} <= set(CAPTIONS)
+    assert {e[0] for e in OFFERED_TRANSCRIBERS} <= set(TRANSCRIBERS)
+    assert {e[0] for e in OFFERED_VOICES} <= set(VOICES)
 
 
 def test_saved_config_carries_no_secret(tmp_path, monkeypatch):
@@ -236,6 +242,18 @@ def test_env_updates_carries_a_separate_stt_key_when_the_provider_differs():
     updates = env_updates(base_answers(stt_provider="groq", stt_key="gsk-live"))
     assert updates["GROQ_API_KEY"] == "gsk-live"
     assert updates["OPENROUTER_API_KEY"] == "sk-or-live"
+
+
+def test_a_local_transcriber_writes_no_secret_of_its_own():
+    """It has no account, so nothing about it belongs in `.env`."""
+    updates = env_updates(base_answers(stt_provider="faster_whisper", stt_model="small"))
+    assert list(updates) == ["OPENROUTER_API_KEY"]
+
+
+def test_the_chosen_whisper_size_lands_in_the_config():
+    cfg = apply_answers(BrainConfig(), base_answers(stt_provider="faster_whisper",
+                                                    stt_model="small"))
+    assert (cfg.stt_provider, cfg.stt_model) == ("faster_whisper", "small")
 
 
 def test_env_updates_carries_every_skill_token():

--- a/tests/test_stt_local.py
+++ b/tests/test_stt_local.py
@@ -1,0 +1,152 @@
+"""Local whisper: the model id it ends up asking for, the precision it picks,
+and the promise that a model it could not load degrades instead of crashing."""
+
+import pytest
+
+from src.core.config import BrainConfig
+from src.modules.STT.factory import BUILDERS, LOCAL, build_stt
+from src.modules.STT.faster_whisper_stt import (
+    DEFAULT_MODEL,
+    FasterWhisperSTT,
+    normalize_language,
+    normalize_model,
+)
+
+
+def config(tmp_path, monkeypatch, **overrides) -> BrainConfig:
+    monkeypatch.chdir(tmp_path)
+    settings = BrainConfig()
+    for key, value in overrides.items():
+        setattr(settings, key, value)
+    return settings
+
+
+@pytest.fixture
+def loaded(monkeypatch):
+    """Records what WhisperModel was asked for, without loading anything."""
+    calls = []
+
+    class FakeModel:
+        def __init__(self, name, device=None, compute_type=None, download_root=None):
+            calls.append({"name": name, "device": device,
+                          "compute_type": compute_type, "download_root": download_root})
+
+        def transcribe(self, path, **kwargs):
+            calls.append({"path": path, **kwargs})
+            return ([], None)
+
+    import faster_whisper
+    monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
+    return calls
+
+
+# --- model ids -------------------------------------------------------------
+
+
+def test_an_empty_model_falls_back_to_one_that_exists():
+    assert normalize_model("") == DEFAULT_MODEL
+    assert normalize_model(None) == DEFAULT_MODEL
+
+
+def test_a_hosted_spelling_becomes_the_local_one():
+    """config.json ships the groq id, and switching provider must not break it."""
+    assert normalize_model("whisper-large-v3-turbo") == "large-v3-turbo"
+    assert normalize_model("openai/whisper-large-v3-turbo") == "large-v3-turbo"
+
+
+def test_a_real_huggingface_repo_is_left_alone():
+    assert normalize_model("Systran/faster-distil-whisper-large-v3") == \
+        "Systran/faster-distil-whisper-large-v3"
+
+
+def test_a_size_it_already_knows_passes_through():
+    assert normalize_model("small") == "small"
+
+
+# --- languages -------------------------------------------------------------
+
+
+def test_the_dashboards_own_japanese_is_translated_for_whisper():
+    """The language picker offers `jp`, which whisper would refuse outright."""
+    assert normalize_language("jp") == "ja"
+
+
+def test_a_language_whisper_does_not_know_becomes_detection():
+    assert normalize_language("klingon") is None
+    assert normalize_language("") is None
+
+
+# --- how it runs -----------------------------------------------------------
+
+
+def test_auto_means_int8_on_a_cpu_and_float16_on_a_gpu(tmp_path, monkeypatch, loaded):
+    FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="base"))
+    assert loaded[0]["compute_type"] == "int8"
+
+    FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="base",
+                            faster_whisper_device="cuda"))
+    assert loaded[1]["compute_type"] == "float16"
+
+
+def test_a_chosen_precision_is_not_second_guessed(tmp_path, monkeypatch, loaded):
+    FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="base",
+                            faster_whisper_compute_type="float32"))
+    assert loaded[0]["compute_type"] == "float32"
+
+
+def test_the_weights_go_where_the_config_says(tmp_path, monkeypatch, loaded):
+    FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="base"))
+    assert loaded[0]["download_root"] == "data/models/whisper"
+    assert (tmp_path / "data" / "models" / "whisper").is_dir()
+
+
+# --- degrading -------------------------------------------------------------
+
+
+def test_a_model_that_will_not_load_does_not_take_the_engine_down(tmp_path, monkeypatch):
+    import faster_whisper
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("no such model")
+
+    monkeypatch.setattr(faster_whisper, "WhisperModel", explode)
+    stt = FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="nonsense"))
+    assert stt.model is None
+    assert stt.transcribe("whatever.wav") == ""
+
+
+def test_audio_that_is_not_there_is_an_empty_transcript(tmp_path, monkeypatch, loaded):
+    stt = FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="base"))
+    assert stt.transcribe(str(tmp_path / "gone.wav")) == ""
+
+
+# --- reloading -------------------------------------------------------------
+
+
+def test_an_unrelated_save_does_not_reload_the_model(tmp_path, monkeypatch, loaded):
+    """Loading is seconds and possibly a download; a saved OBS port is not."""
+    settings = config(tmp_path, monkeypatch, stt_model="base")
+    stt = FasterWhisperSTT(settings)
+    settings.obs_port = 4456
+    stt.reload_config(settings)
+    assert len(loaded) == 1
+
+
+def test_a_new_model_does_reload(tmp_path, monkeypatch, loaded):
+    settings = config(tmp_path, monkeypatch, stt_model="base")
+    stt = FasterWhisperSTT(settings)
+    settings.stt_model = "small"
+    stt.reload_config(settings)
+    assert [call["name"] for call in loaded] == ["base", "small"]
+
+
+# --- the factory -----------------------------------------------------------
+
+
+def test_the_factory_builds_it(tmp_path, monkeypatch, loaded):
+    settings = config(tmp_path, monkeypatch, stt_provider="faster_whisper", stt_model="base")
+    assert isinstance(build_stt(settings), FasterWhisperSTT)
+
+
+def test_every_local_provider_is_one_the_factory_can_build():
+    assert LOCAL <= set(BUILDERS)

--- a/uv.lock
+++ b/uv.lock
@@ -174,6 +174,57 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "17.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/e3/477fa20578c284abeda08d91b63ee9abaebc93445d8feeb989d3d444bae1/av-17.1.0.tar.gz", hash = "sha256:7f1e71ff621b66253333926f948e00faae11d855b2442133c65128bca64cdeb3", size = 4288546, upload-time = "2026-06-07T05:52:55.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/92/c9d0cea4f6f8f93f5b15a39f99d2d593f922484f22a2d98a8d482283e15b/av-17.1.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:19c84fd72af5ef81a20f18fbc6f9aedff9e1455e53a7062c1d4c95926d73da4e", size = 22622703, upload-time = "2026-06-07T05:51:40.405Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/57/74399770aa103ee4b5ff6da1781440c91a41901d89abb2433fe88773246e/av-17.1.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:19264c9bb4bee404accc7ce9ec461f2044b7f577a70234d29aafde31ed17de46", size = 18273538, upload-time = "2026-06-07T05:51:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/27c85b12e9ffa8f3f6854358b3eabcd91f3c29c7dac36843fa1376e833f4/av-17.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:22dff0ae582d10ef08c75c2150a4fd27cfc26653b54930c7c27b9f7b3aa20723", size = 34519101, upload-time = "2026-06-07T05:51:45.305Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/542d4bfd9f4aec5f3265985b9dbc6b259d45c2e668f9714e5f4e05b71e64/av-17.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:90c49bc9608377d01e82e747377505419a229464873341db18202d5dddecce5a", size = 36647600, upload-time = "2026-06-07T05:51:48.57Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1e/63bd5c59580f38109fa4c452b29b715a20c9a5eb3a078b3c447484593c40/av-17.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cc5a5247622cb77e24c342364eb68f88c1442ddfaab60c1f1f483359d3cc7879", size = 25786289, upload-time = "2026-06-07T05:51:51.674Z" },
+    { url = "https://files.pythonhosted.org/packages/70/30/78155cef0c9f8bc13f044130192c58bf962f2c9066982ff3593afe8d27f1/av-17.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ff457ed419348e5b8e8c811d341389b052c5e4d5839da3794d019b125b9fe830", size = 35599848, upload-time = "2026-06-07T05:51:54.207Z" },
+    { url = "https://files.pythonhosted.org/packages/76/cb/ae1d7a735a5ad9dc502dba864c51d605cbe932a769218352fd570254c38e/av-17.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:1370b11a697eb3f2555906f8ab3519b0cfe48425d7830a3996ad42e6bffafda5", size = 26776479, upload-time = "2026-06-07T05:51:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/40/128429b9eb0c4a2beb122ed8d04b189515df68967987c2654a2e262a5c43/av-17.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3dcd41e53f53f9a3260751d9c3c11d34e93d70d61e506c81f13dbc1e3606e07b", size = 37763744, upload-time = "2026-06-07T05:51:59.222Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6a/5980e7bbeeadfd7a9db8e38e9f1140a3e0c392fccc31bd7b1e4a75cf5a96/av-17.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:3453b06075c7bb973fdb6de52563f7692ff05cbc64c0bb45f4fd6e8709131f2f", size = 28126516, upload-time = "2026-06-07T05:52:01.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/87/8036b5c781bc3639ea04ef42d4e26da253bd4bd4311d8705b6a1c8824047/av-17.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ad7b4aa011093324b7118245f50ac6db244cfe9900d4072508a5245a2b0d3f41", size = 22460847, upload-time = "2026-06-07T05:52:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/dfdf6fc7b17814b50d0aa9e7a7e37b87be91be3890f44b0d525433cd1fd1/av-17.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:43ebbe977f19a7f2d2bd1a4e119675a0b15e05852cf7309846b6ab922ba7ffe9", size = 18159115, upload-time = "2026-06-07T05:52:06.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/13/64f6c466471cea225b8b2f4cdc51a571f8a286984b55a08d169b932fda5d/av-17.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a20658ec7d96a70e14b1196eff00b7cdd8831ac3b99868e16b8ba8b24090847", size = 33224427, upload-time = "2026-06-07T05:52:09.165Z" },
+    { url = "https://files.pythonhosted.org/packages/77/43/96b35170bf2e64e00a41748c6400ff73232dc0fc62ded283679fb07c7fe0/av-17.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f9a65d1f48b818323fb411e80358f89d77dec340b01d27c6b2dfbb9cbf4b779f", size = 35370183, upload-time = "2026-06-07T05:52:11.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b3/8e8b4b6498731bfbd88e8399a756543f8088f1bd33d08eab678b5aebe728/av-17.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:58f7593726437cda5bd19793027e027768450b5c4a594777bf487798a33db702", size = 24459265, upload-time = "2026-06-07T05:52:14.66Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ac/ceb84b7553db21f1143d817245c560d9267168e1e58b1a8eeae2b62c4d04/av-17.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bbab058bd965309f39962e53caac8126987c68c0be094fc4f9427e5615b0218f", size = 34283709, upload-time = "2026-06-07T05:52:17.389Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f9/4115fd84148c9a1cf365096694be6ac882fd3cd3cdb7a2f35e71fecf1631/av-17.1.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9514cfda85180554c430695282faf4be3ffdf95775d8519733821244eecb58e0", size = 25397573, upload-time = "2026-06-07T05:52:20.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ac/92e52d5ed0e0b84d9d93e52b4338c2713d8a44082b8696e6516fdae7c4e4/av-17.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e1c90f85cd7431ede95b11e8e711571a896ebea433f298849c2c0f1594c8d86e", size = 36451495, upload-time = "2026-06-07T05:52:22.581Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f2/53a7cd34adb6a971d7e6d99663e74db286966c9db8afdca17472fdf0f98e/av-17.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:5df5c1172ef1cf65a1529d612f7da7798ce2cf82c1ff7212466b538a6cc7214c", size = 28036393, upload-time = "2026-06-07T05:52:25.657Z" },
+    { url = "https://files.pythonhosted.org/packages/66/47/cd9ae0edf2206351c1251bb94b5ec58728e42c5f6ee16c03c412f3a1bb3e/av-17.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:ee98534242a74da847af78624779ac5a3177dc7c69f956a4da9e6f0fdb37d7f6", size = 21174601, upload-time = "2026-06-07T05:52:28.077Z" },
+]
+
+[[package]]
+name = "av"
+version = "18.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/f4/f22114d30d3435e38c6af2b4870f37b864403dca6ae7af747a289ce0a18e/av-18.1.0.tar.gz", hash = "sha256:47bfc286e1bc9de7ab4681fc2b575cd2460a66919d31ffe1bd5aa54fae531a28", size = 4451061, upload-time = "2026-08-12T22:28:18.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/d4/d7cdc8bff143c17a6d35924375ae28dd692cacde38700a7d419fde54f44a/av-18.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ae75d8bb6467895ed1f8572ededf7ffa49eac07f6e483222f5d7d62a41d12f04", size = 22546147, upload-time = "2026-08-12T22:27:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c9/37a619297492256b77d5ed906e7d8166c10a26ed251dccf1ae03ab19bff6/av-18.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:b30a4e8d934558e19602b68998a4d9ac9f250fa0dacef216f7e8e40153b13316", size = 18217603, upload-time = "2026-08-12T22:27:14.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/84/2464ffb64c08c5ce8b522c8e74594714414e3b0575267652c5c51c0574b9/av-18.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6fc837cc51adf80331ac850779cd53b5d4c4460b0ebe9057a02a921c6736f19d", size = 33640142, upload-time = "2026-08-12T22:27:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700", size = 35786210, upload-time = "2026-08-12T22:27:20.984Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/99/b0d04ec553ff9a7e00455458dfa3a39c8a8f627b273056b4e5fe57d590de/av-18.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:3c8b1f8b46f99d52e2d8b0ed5d0cdadf172d24794d46e2077b16e44ed08e26ff", size = 39379798, upload-time = "2026-08-12T22:27:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b1/e00d4feae59160149df6126585e726fdc6300798fd40c5dd324879e81f68/av-18.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab5ac081bc9eaf54109120d4e56284674fecfbe520d9aa1707c7fa911ec5f4d2", size = 34690321, upload-time = "2026-08-12T22:27:27.769Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/836fa987e3084d11a21489f11357fb24843ef3aa8faf74ddddfc603d5062/av-18.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:191224788d87af06c31784a395bb73f14b72f33d7f4871ace0157de2abdc6276", size = 36859932, upload-time = "2026-08-12T22:27:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b4/76ba21e46704f632004276b85289a1582e95f5eff760436d6149875a1881/av-18.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ea1480b7a8d5405cb5f382b344731bf125fd2c1c6fae3964f6c48595628387ff", size = 27595679, upload-time = "2026-08-12T22:27:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ad/a3135884c5753b09773176b97201ae602f67ad14206c395ff838d66bf9b0/av-18.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5509ec12aaa19fd6601de13cfa6f4cdad450da07982118510592875d970454d6", size = 20257584, upload-time = "2026-08-12T22:27:38.472Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +444,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/20/87da5148a435f3bafe4caeff722e7ce03034fea34a9ee03c420102804b3f/ctranslate2-4.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f87f29d4b1c26ec7437f147d70cc52a53465acfcd2e754d3a59c12fdb932ae7", size = 1270795, upload-time = "2026-08-31T19:36:55.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8b/a538f793bfdfcbc6d6b1bc7fa7dc010ccea5ef5b46390eb65d702fae35cd/ctranslate2-4.8.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:e563497eafeebb6417678d4fc948edb7995d02cb8d1ef479bdabc4496edd7558", size = 11928091, upload-time = "2026-08-31T19:36:56.967Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b0/8e418a29335f8c96f7ed1e9c5d4377862e01d656d5f33d895fb7fa83ce14/ctranslate2-4.8.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0e55a43e68762bcac3529aa469ea6d2af0d35b84f9187212a8a1079acc9b00f5", size = 16568826, upload-time = "2026-08-31T19:36:59.044Z" },
+    { url = "https://files.pythonhosted.org/packages/be/64/494ff713e9b8633043d443f67be5a521d960c12672c3f83918079b5b063e/ctranslate2-4.8.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43adddac06f387b12ec921bcdd8fb50525eae4f43672fe64e15ebeea9854b040", size = 39179308, upload-time = "2026-08-31T19:37:01.993Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/73680b494bb48158332a5d6e13f4b07fe7e38fe799ae2d760753ec2b9e5a/ctranslate2-4.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:8ad4ee86fb93e8d7456fbcf77735d33c51eda4f363e15db4151b0e56e8633677", size = 19219507, upload-time = "2026-08-31T19:37:05.219Z" },
+    { url = "https://files.pythonhosted.org/packages/43/17/f22fbbb0723891704af803e1e7af5541bb46013adb347f870cbd8c4834d3/ctranslate2-4.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cb2a5b4c206b3bd1f7f4b44d07e86e42050af6753053cdc86444f8d0ead9d6d8", size = 1271641, upload-time = "2026-08-31T19:37:07.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/af/cfe767012a0809c15155ecae3125ca66a16aeee4669bae146220cc631a76/ctranslate2-4.8.2-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:8221875b09ef982e3579a5165f8c9fcfb3d5de0f710af228eca2f73d69635ace", size = 11929414, upload-time = "2026-08-31T19:37:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2e/2d08b1219303af7256aeb78b98ee847ffb229c5fe4815e6d3a1b6483846a/ctranslate2-4.8.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3823c9883c2c410a76b2f19feda9da628a3c112cedfd912db815e0055c8235e2", size = 16720002, upload-time = "2026-08-31T19:37:11.957Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3d/75c029ffb484957f1d2be0f9c3b9b1474955bb16c22df85bcba50c48df11/ctranslate2-4.8.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a24e0a95151b970941867fec94c983df978630f1996242a587c072d455607d28", size = 39378274, upload-time = "2026-08-31T19:37:14.898Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/86/21926da682103a20d4f4833b389131b801c71e6b8d6047be5f0a28fe673a/ctranslate2-4.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:995938fcd24a1174a7abf9765e7fa216b5b91a1d8e8c4c8f383c7a186e8bab2e", size = 19220522, upload-time = "2026-08-31T19:37:17.845Z" },
+    { url = "https://files.pythonhosted.org/packages/12/97/9c63a51a8c8e13e95ec2aec639460fb0f271b0421e1a365b8aad440385c4/ctranslate2-4.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fedda669421a57f8164568ee86ea265727016988d310fcc2e24ca30e9ec457cd", size = 1271613, upload-time = "2026-08-31T19:37:19.958Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/27/e419389fb6040a8170bb30c3dcd50c29b70638852a264acc5bf804bf8800/ctranslate2-4.8.2-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5385f15493e7b6f41377da83d0d5afeb8e0f36188260722f3800c3c7121455af", size = 11931717, upload-time = "2026-08-31T19:37:21.897Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/bfa42114fd583b0ef30b67113486ab72d3ff466e60a824739257bcc533bd/ctranslate2-4.8.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:781f835da7fdc4adcc38f9d674dbe9b37eaf3c9aee3b2bc17d684342ff59d549", size = 16894628, upload-time = "2026-08-31T19:37:24.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/23/d72e70cac2b7c5c832a629c380235b53b20fac8c0921856bcf625b08ba44/ctranslate2-4.8.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:554a0b2abf098a11c66ef7930c0a05b3de683a455e8ea3f2e6ab6966aaabc136", size = 39555908, upload-time = "2026-08-31T19:37:27.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/23/e3b5322ff7368fcbed181ea4c209149416e7940b5b04971d5ee4084afe1a/ctranslate2-4.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:d94421d565d0de61c032998f737a18942b0f2bef40c0424b1846ec6f67300105", size = 19222069, upload-time = "2026-08-31T19:37:31.531Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -495,6 +572,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
+]
+
+[[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
 ]
 
 [[package]]
@@ -1395,6 +1490,7 @@ dependencies = [
     { name = "edge-tts" },
     { name = "fastapi" },
     { name = "fastembed" },
+    { name = "faster-whisper" },
     { name = "groq" },
     { name = "kokoro-onnx" },
     { name = "numpy" },
@@ -1426,6 +1522,7 @@ requires-dist = [
     { name = "edge-tts" },
     { name = "fastapi" },
     { name = "fastembed", specifier = ">=0.3,<0.9" },
+    { name = "faster-whisper", specifier = ">=1.1" },
     { name = "groq" },
     { name = "kokoro-onnx" },
     { name = "numpy", specifier = "<2.0.0" },


### PR DESCRIPTION
## What this changes

A third transcriber, `faster_whisper`, that runs Whisper on the machine she runs
on. Her ears were hosted-only: Groq or OpenRouter, both needing an account, a
key and a per-minute bill, and both sent every second of audio from a Discord
call to a third party. Kokoro has been the local answer on the TTS side since
the beginning; this is the same answer on the other side of the loop.

It is [faster-whisper](https://github.com/SYSTRAN/faster-whisper) — Whisper on
CTranslate2, no PyTorch — and it is a core dependency for the same reason
`kokoro-onnx` is: an extra that `uv sync` silently drops on every `make update`
is a support ticket waiting to happen. The weights are not: they download on
first use into `data/models/whisper`, which is gitignored, and `small` is the
default at ~480 MB.

**Two things it normalises, so one `config.json` works across all three
providers.** `stt_model` is shared, so `whisper-large-v3-turbo` (Groq's
spelling) and `openai/whisper-large-v3-turbo` (OpenRouter's) both become
`large-v3-turbo` — switching provider does not also mean editing the model.
A repo id with a slash in it is passed through untouched, so any faster-whisper
model on Hugging Face works. `language` is the sharper one: the hosted providers
shrug at a code they do not know, Whisper raises. `jp` is one of the dashboard's
own choices and is not a Whisper language, so it maps to `ja`, and anything else
unrecognised falls back to auto-detection with a warning instead of returning an
empty transcript.

**Wired everywhere a provider is chosen**, which was most of the work:
`--stt-provider` accepts it, the wizard's "Her ears" step now leads with it and
asks for a size instead of a key, the dashboard's Hearing page gained the
provider tile and a panel for device, precision, cache path and VAD, and
`check_keys` no longer demands an API key for a provider that cannot have one.
The ears check gets a 15-minute budget when the provider is local, because the
first run downloads a few hundred MB and calling that a failure is a lie about a
working install.

Also, while in there: the doctor's test line was `one two three`. Whisper writes
that back as `1, 2, 3`, so the word-overlap check found nothing in common and
warned that a working transcriber had misheard. It is `the quick brown fox` now.

## What breaks if it is wrong

Nothing, for anyone who does not choose it — `stt_provider` still defaults to a
hosted one and the other two modules are untouched. The exposure is the install:
this adds `faster-whisper` to the lockfile for everybody, including the people
who will never set `stt_provider` to it, and a wheel that fails to resolve on
Windows or on Python 3.10 breaks `uv sync` for a Discord bot that has nothing to
do with speech. CI runs `uv sync --locked` on all three platforms, which is the
check that matters here.

The other one is startup. Building a transcriber now means possibly loading a
model, so a bad `stt_model` must not be a crash on boot — it logs and leaves
`stt` unloaded, which is the state she is already designed for when nobody
configured a transcriber at all. There is a test for exactly that.

Verified against the real thing beyond the suite: `tiny` downloaded and
transcribed an EdgeTTS line correctly, `language: "jp"` reached Whisper as `ja`,
a nonsense language fell through to detection, and `uv run bea --doctor` reports
`faster_whisper heard 'The quick brown fox.'` with no key in `.env`.

## Checks

- [x] `make test` passes — 1886 tests, up from 1867
- [x] `make lint` passes
- [x] New behaviour has a test named after the behaviour
- [x] `docs/` updated, if this changes something someone could be relying on

`uvx pyright` is at zero, as CI requires.
