### PR TITLE
Download her models during setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,6 @@ OPENAI_MODEL="gpt-4o"
 GROQ_API_KEY="gsk_..."
 GROQ_MODEL="openai/gpt-oss-120b"
 
-
 # ------------------------------------------
 # 2. VOICE SYNTHESIS (TTS)
 # ------------------------------------------
@@ -92,3 +91,16 @@ OBS_PORT=4455
 # OBS WebSocket Password
 # Leave empty if disable in OBS, but recommended to set one.
 OBS_PASSWORD=""
+
+
+# ------------------------------------------
+# 6. MODELS THAT RUN ON THIS MACHINE
+# ------------------------------------------
+# Whisper for her ears and the embedder for her memory are downloaded from
+# Hugging Face on first use, or by `bea --setup`. Both repos are public: no
+# account and no key.
+
+# Optional, and almost nobody needs it. Set a token only if a download is
+# refused, which means a shared or office IP hitting Hugging Face's anonymous
+# rate limit. Get one: https://huggingface.co/settings/tokens
+# HF_TOKEN=""

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ out to matter, and conclusions she reaches about herself overnight.
 
 > [!IMPORTANT]
 > One command. It installs `uv` if you don't have it, pulls the dependencies,
-> builds the dashboard and then asks you five questions.
+> builds the dashboard, asks you five questions and downloads the two models
+> that run on your own machine.
 > 
 > **macOS / Linux**
 > ```bash
@@ -435,7 +436,7 @@ make test          # uv run pytest -q
 make lint          # uv run ruff check src tests
 ```
 
-1886 tests, and they run without network access or API keys: every model
+1904 tests, and they run without network access or API keys: every model
 client, surface and transport is faked. CI runs exactly `make test` and `make lint`.
 
 > [!TIP]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -487,6 +487,7 @@ everywhere.
 | `TELEGRAM_TOKEN` | The Telegram bot |
 | `TWITCH_OAUTH_TOKEN` | Writing in Twitch chat. Reading needs nothing |
 | `DONATION_SECRET` | Shared secret on the donation webhook |
+| `HF_TOKEN` | Optional. Only for a refused Hugging Face download — the whisper and embedding models are public |
 | `BEA_ALLOWED_ORIGINS` | Extra CORS origins, comma-separated |
 | `LOG_LEVEL` | `DEBUG` for verbose output |
 

--- a/docs/modules/stt.md
+++ b/docs/modules/stt.md
@@ -73,6 +73,11 @@ The weights are downloaded on first use, not at install time:
 Any faster-whisper model on Hugging Face works too — a repo id with a slash in
 it (`Systran/faster-distil-whisper-large-v3`) is passed through untouched.
 
+The weights come from a public repo: no account, no key. `uv run bea --setup`
+offers to download them at the end rather than leaving the wait to her first
+sentence, and a refusal — a shared IP against Hugging Face's anonymous rate
+limit — is logged with what would fix it, `HF_TOKEN` in `.env`.
+
 **Two things it normalises, so the same config.json works on every provider:**
 
 - `stt_model`. The hosted spelling `whisper-large-v3-turbo`, or

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -80,6 +80,11 @@ TWITCH_OAUTH_TOKEN=oauth:...
 # Donations — shared secret checked on the webhook. Set this before exposing the server
 DONATION_SECRET=...
 
+# Hugging Face — optional, and almost nobody needs it. The whisper and embedding
+# models are public. Set this only if a download is refused: a shared or office
+# IP hitting the anonymous rate limit. https://huggingface.co/settings/tokens
+HF_TOKEN=hf_...
+
 # Logging — optional, defaults to INFO
 LOG_LEVEL=DEBUG   # set to DEBUG to see verbose output (OBS, TTS, audio playback details)
 ```
@@ -209,10 +214,14 @@ Whisper** in the wizard or on the dashboard's Hearing page — and choose a size
 | `small` | ~480 MB | The default, and the balance most people want |
 | `large-v3-turbo` | ~1.6 GB | Best, and it wants a GPU |
 
-The weights download on first use into `data/models/whisper`, which is
-gitignored. The first transcription after a fresh install therefore takes as
-long as that download; `uv run bea --doctor` allows for it and will not call it
-a failure.
+The weights download into `data/models/whisper`, which is gitignored. The wizard
+offers to fetch them at the end of setup; decline it, or skip the wizard, and
+they arrive on first use instead — so the first transcription after a fresh
+install takes as long as that download. `uv run bea --doctor` allows for it and
+will not call it a failure.
+
+Nothing here needs a Hugging Face account. If a download is refused — a shared
+IP against the anonymous rate limit — set `HF_TOKEN` in `.env` and run it again.
 
 On a machine with an NVIDIA GPU, set `faster_whisper_device` to `cuda` — this
 needs the CUDA and cuDNN runtimes on the system, which `uv sync` does not

--- a/docs/skills/memory.md
+++ b/docs/skills/memory.md
@@ -100,10 +100,18 @@ Vectors from two different models are not comparable, so changing
 `embedding_model` re-embeds everything: `rag.ensure_model()` checks the recorded
 model at startup and rebuilds the store if it moved.
 
-The model (~100 MB) is downloaded on first use into `embedding_cache_dir`, not
-at startup. If it cannot be loaded at all, the brain logs the error and keeps
-going: the roster, the person cards and the hot facts still work — only recall
-is lost.
+The model (~220 MB) is downloaded from Hugging Face on first use into
+`embedding_cache_dir`, not at startup — so on a fresh install it is the first
+thing she remembers that pays for it. `uv run bea --setup` offers to fetch it at
+the end, which is the same download with a progress bar in front of it.
+
+No account and no key: the repo is public. When the download is refused anyway
+— a shared IP hitting Hugging Face's anonymous rate limit — the log says so once
+and names `HF_TOKEN`, which `.env` is read for like any other secret.
+
+If the model cannot be loaded at all, the brain logs the error and keeps going:
+the roster, the person cards and the hot facts still work — only recall is
+lost.
 
 ---
 

--- a/src/core/memory/embedder.py
+++ b/src/core/memory/embedder.py
@@ -1,7 +1,8 @@
 """Local, in-process embeddings (fastembed / ONNX on CPU).
 
-Lazy: the model (~100MB) is fetched on the first `embed`, so startup does not
-wait for it. Two methods only, so a test can inject a deterministic fake.
+Lazy: the model (~220MB) is fetched on the first `embed`, so startup does not
+wait for it — `bea --setup` offers to get it out of the way beforehand. Two
+methods only, so a test can inject a deterministic fake.
 
 The default is multilingual: with an English-only model, non-English sentences
 collapse into the same region and retrieval becomes close to random.

--- a/src/core/memory/embedder.py
+++ b/src/core/memory/embedder.py
@@ -11,6 +11,7 @@ import warnings
 from importlib import metadata
 from typing import Any, List, Optional, Sequence
 
+from src.utils.huggingface import download_hint
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.memory.embedder")
@@ -54,6 +55,7 @@ class FastEmbedEmbedder:
         self.cache_dir = cache_dir
         self._model: Optional[Any] = None
         self._dim: Optional[int] = None
+        self._explained = False
 
     def _ensure(self) -> Any:
         """The loaded model, loading it the first time. Returned, not just set,
@@ -63,13 +65,23 @@ class FastEmbedEmbedder:
         from fastembed import TextEmbedding  # lazy: heavy import
 
         logger.info(f"Loading embedding model '{self.model_name}'…")
-        with warnings.catch_warnings():
-            # fastembed warns that it pools this model differently than it used
-            # to. That is handled — `identity` carries the version, so the store
-            # re-embeds — and printing a raw traceback about it on every start
-            # reads like something is broken
-            warnings.filterwarnings("ignore", message=".*mean pooling.*")
-            self._model = TextEmbedding(model_name=self.model_name, cache_dir=self.cache_dir)
+        try:
+            with warnings.catch_warnings():
+                # fastembed warns that it pools this model differently than it
+                # used to. That is handled — `identity` carries the version, so
+                # the store re-embeds — and printing a raw traceback about it on
+                # every start reads like something is broken
+                warnings.filterwarnings("ignore", message=".*mean pooling.*")
+                self._model = TextEmbedding(model_name=self.model_name, cache_dir=self.cache_dir)
+        except Exception as error:
+            # the caller writes the memory anyway, without a vector, and comes
+            # back for another try — so the explanation is said once, not once
+            # per thing she remembers
+            hint = download_hint(error)
+            if hint and not self._explained:
+                self._explained = True
+                logger.error(hint)
+            raise
         return self._model
 
     @property

--- a/src/modules/STT/faster_whisper_stt.py
+++ b/src/modules/STT/faster_whisper_stt.py
@@ -11,23 +11,12 @@ from typing import Optional
 
 from src.core.config import BrainConfig
 from src.interfaces.base_interfaces import STTInterface
+from src.utils.huggingface import download_hint
 from src.utils.logger import get_logger
 
 logger = get_logger("bea.stt.faster_whisper")
 
 DEFAULT_MODEL = "small"
-
-TOKEN_HINT = (
-    "Hugging Face refused the download. The weights are public, so this is "
-    "almost always a shared or office IP being rate-limited: wait a few minutes, "
-    "or put HF_TOKEN=<your token> in .env (https://huggingface.co/settings/tokens) "
-    "and it will be used for the download."
-)
-
-OFFLINE_HINT = (
-    "The weights could not be reached. Check the connection, then start her "
-    "again — the download resumes where it stopped."
-)
 
 # the hosted providers name the same weights differently, and a model id copied
 # from a groq or openrouter config is the most likely thing to arrive here
@@ -73,24 +62,6 @@ def normalize_language(code: Optional[str]) -> Optional[str]:
         logger.warning(f"Whisper does not know the language {code!r}; detecting instead.")
         return None
     return code
-
-
-def download_hint(error: Exception) -> Optional[str]:
-    """A line the person reading the log can act on, for a download that failed.
-
-    The library raises whatever huggingface_hub raised, which says `401` at
-    someone who never knew an account was involved. Only the two cases with a
-    real answer get a hint; everything else is left to speak for itself.
-    """
-    text = f"{type(error).__name__}: {error}".lower()
-
-    if any(word in text for word in ("401", "403", "429", "gated", "rate limit",
-                                     "too many requests", "unauthorized")):
-        return TOKEN_HINT
-    if any(word in text for word in ("connection", "timeout", "timed out",
-                                     "network", "dns", "offline", "unreachable")):
-        return OFFLINE_HINT
-    return None
 
 
 class FasterWhisperSTT(STTInterface):

--- a/src/modules/STT/faster_whisper_stt.py
+++ b/src/modules/STT/faster_whisper_stt.py
@@ -17,6 +17,18 @@ logger = get_logger("bea.stt.faster_whisper")
 
 DEFAULT_MODEL = "small"
 
+TOKEN_HINT = (
+    "Hugging Face refused the download. The weights are public, so this is "
+    "almost always a shared or office IP being rate-limited: wait a few minutes, "
+    "or put HF_TOKEN=<your token> in .env (https://huggingface.co/settings/tokens) "
+    "and it will be used for the download."
+)
+
+OFFLINE_HINT = (
+    "The weights could not be reached. Check the connection, then start her "
+    "again — the download resumes where it stopped."
+)
+
 # the hosted providers name the same weights differently, and a model id copied
 # from a groq or openrouter config is the most likely thing to arrive here
 ALIASES = {
@@ -63,6 +75,24 @@ def normalize_language(code: Optional[str]) -> Optional[str]:
     return code
 
 
+def download_hint(error: Exception) -> Optional[str]:
+    """A line the person reading the log can act on, for a download that failed.
+
+    The library raises whatever huggingface_hub raised, which says `401` at
+    someone who never knew an account was involved. Only the two cases with a
+    real answer get a hint; everything else is left to speak for itself.
+    """
+    text = f"{type(error).__name__}: {error}".lower()
+
+    if any(word in text for word in ("401", "403", "429", "gated", "rate limit",
+                                     "too many requests", "unauthorized")):
+        return TOKEN_HINT
+    if any(word in text for word in ("connection", "timeout", "timed out",
+                                     "network", "dns", "offline", "unreachable")):
+        return OFFLINE_HINT
+    return None
+
+
 class FasterWhisperSTT(STTInterface):
     def __init__(self, config: BrainConfig):
         self.config = config
@@ -96,6 +126,9 @@ class FasterWhisperSTT(STTInterface):
             logger.info(f"Local whisper ready: {self.model_name} on {self.device}")
         except Exception as e:
             logger.error(f"Could not load local whisper {self.model_name!r}: {e}")
+            hint = download_hint(e)
+            if hint:
+                logger.error(hint)
 
     def _compute_type(self) -> str:
         """`auto` means int8 on a cpu and float16 on a gpu, which is what you want.

--- a/src/setup/prefetch.py
+++ b/src/setup/prefetch.py
@@ -1,0 +1,136 @@
+"""Pulling the weights down while someone is still watching.
+
+Two models arrive from Hugging Face on a fresh install: whisper, the first time
+she hears anything, and the embedder, the first time she remembers anything.
+Both are lazy on purpose — startup should not wait for a download — but on a
+fresh clone that means her first sentence, or her first memory, silently taking
+a minute. Doing it here costs the same minute in the one place where it looks
+like progress rather than a hang.
+
+Nothing here is required. Every failure is a warning: the engine fetches what
+is missing on first use exactly as it did before.
+"""
+
+import os
+import threading
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from src.core.memory.embedder import DEFAULT_CACHE_DIR, FastEmbedEmbedder, resolve_model
+from src.modules.STT.faster_whisper_stt import normalize_model
+
+# only ever used to size a progress bar, so being a little off is harmless
+WHISPER_MB = {
+    "tiny": 75,
+    "base": 145,
+    "small": 480,
+    "large-v3-turbo": 1600,
+}
+
+EMBEDDER_FALLBACK_MB = 220
+
+
+def directory_bytes(path: str) -> int:
+    """Everything under `path`, part-written files included.
+
+    huggingface_hub writes into `.cache/huggingface` inside the same folder
+    while it works, so this grows smoothly and lands on the real size.
+    """
+    root = Path(path)
+    if not root.is_dir():
+        return 0
+    return sum(file.stat().st_size for file in root.rglob("*") if file.is_file())
+
+
+def run(work: Callable[[], Any], root: str,
+        on_progress: Optional[Callable[[int], None]] = None,
+        tick: float = 0.3) -> Optional[Exception]:
+    """Runs a download, reporting how much of `root` exists as it goes.
+
+    Returns the error it failed on, or None. The work happens on a thread only
+    so that the bytes on disk can be watched while it does.
+    """
+    os.makedirs(root, exist_ok=True)
+    failure: list[Exception] = []
+
+    def attempt() -> None:
+        try:
+            work()
+        except Exception as error:
+            failure.append(error)
+
+    worker = threading.Thread(target=attempt, daemon=True)
+    worker.start()
+    while worker.is_alive():
+        worker.join(tick)
+        if on_progress:
+            on_progress(directory_bytes(root))
+    if on_progress:
+        on_progress(directory_bytes(root))
+
+    return failure[0] if failure else None
+
+
+# --- whisper ----------------------------------------------------------------
+
+
+def _download_whisper(model: str, root: str, local_files_only: bool = False) -> str:
+    from faster_whisper.utils import download_model
+
+    return download_model(model, output_dir=root, local_files_only=local_files_only)
+
+
+def whisper_here(model: str, root: str, downloader: Optional[Callable[..., Any]] = None) -> bool:
+    """Whether the weights are already on disk, asked of the library itself."""
+    downloader = downloader or _download_whisper
+    try:
+        downloader(normalize_model(model), root, local_files_only=True)
+        return True
+    except Exception:
+        return False
+
+
+def fetch_whisper(model: str, root: str, downloader: Optional[Callable[..., Any]] = None,
+                  on_progress: Optional[Callable[[int], None]] = None,
+                  tick: float = 0.3) -> Optional[Exception]:
+    downloader = downloader or _download_whisper
+    return run(lambda: downloader(normalize_model(model), root), root, on_progress, tick)
+
+
+# --- the embedder -----------------------------------------------------------
+
+
+def embedder_mb(model: Optional[str] = None) -> int:
+    """What the embedding model weighs, asked of fastembed's own catalogue."""
+    wanted = resolve_model(model)
+    try:
+        from fastembed import TextEmbedding
+
+        for known in TextEmbedding.list_supported_models():
+            if known["model"] == wanted:
+                return round(float(known["size_in_GB"]) * 1000)
+    except Exception:
+        pass
+    return EMBEDDER_FALLBACK_MB
+
+
+def embedder_here(cache_dir: str = DEFAULT_CACHE_DIR) -> bool:
+    """Whether an ONNX model is already cached.
+
+    fastembed has no offline probe and the layout of its cache is its own
+    business — but nothing else puts an .onnx file in there.
+    """
+    return any(Path(cache_dir).rglob("*.onnx")) if Path(cache_dir).is_dir() else False
+
+
+def fetch_embedder(model: Optional[str] = None, cache_dir: str = DEFAULT_CACHE_DIR,
+                   loader: Optional[Callable[[], Any]] = None,
+                   on_progress: Optional[Callable[[int], None]] = None,
+                   tick: float = 0.3) -> Optional[Exception]:
+    """Embeds one throwaway sentence, which is what downloads the model.
+
+    Going through `embed` rather than the loader alone means a model that
+    arrived but cannot run is found here, not at her first memory.
+    """
+    load = loader or (lambda: FastEmbedEmbedder(model, cache_dir).embed(["warm-up"]))
+    return run(load, cache_dir, on_progress, tick)

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -21,7 +21,6 @@ from rich.table import Table
 
 # which transcribers need no account, asked of the one place that builds them
 from src.modules.STT.factory import LOCAL as STT_LOCAL
-from src.modules.STT.faster_whisper_stt import download_hint
 from src.setup.config_plan import (
     PLATFORM_SKILLS,
     PROVIDER_KEYS,
@@ -38,6 +37,7 @@ from src.setup.prefetch import (
     fetch_whisper,
     whisper_here,
 )
+from src.utils.huggingface import download_hint
 
 ENV_FILE = Path(".env")
 CONFIG_FILE = Path("config.json")

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -11,15 +11,17 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from rich.console import Console
 from rich.panel import Panel
+from rich.progress import BarColumn, DownloadColumn, Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
 # which transcribers need no account, asked of the one place that builds them
 from src.modules.STT.factory import LOCAL as STT_LOCAL
+from src.modules.STT.faster_whisper_stt import download_hint
 from src.setup.config_plan import (
     PLATFORM_SKILLS,
     PROVIDER_KEYS,
@@ -28,6 +30,14 @@ from src.setup.config_plan import (
     env_updates,
 )
 from src.setup.env_file import merge_env
+from src.setup.prefetch import (
+    WHISPER_MB,
+    embedder_here,
+    embedder_mb,
+    fetch_embedder,
+    fetch_whisper,
+    whisper_here,
+)
 
 ENV_FILE = Path(".env")
 CONFIG_FILE = Path("config.json")
@@ -62,13 +72,24 @@ STT_ENGINES: List[Tuple[str, str, str]] = [
     ("openrouter", "OpenRouter", "The same Whisper models on your OpenRouter key."),
 ]
 
+
+def disk_size(megabytes: int) -> str:
+    """A size in the unit a person would say it in."""
+    if not megabytes:
+        return ""
+    if megabytes < 1000:
+        return f"~{megabytes} MB"
+    return f"~{megabytes / 1000:.1f} GB"
+
+
 # what the local transcriber costs to run, smallest first. Anything huggingface
 # serves works in config.json; these are the four worth offering blind
 WHISPER_SIZES: List[Tuple[str, str, str]] = [
-    ("tiny", "tiny", "~75 MB. Instant, and it will mishear you."),
-    ("base", "base", "~145 MB. Usable on an old laptop."),
-    ("small", "small", "~480 MB. The balance most people want."),
-    ("large-v3-turbo", "large-v3-turbo", "~1.6 GB. Best, and it wants a GPU."),
+    ("tiny", "tiny", f"{disk_size(WHISPER_MB['tiny'])}. Instant, and it will mishear you."),
+    ("base", "base", f"{disk_size(WHISPER_MB['base'])}. Usable on an old laptop."),
+    ("small", "small", f"{disk_size(WHISPER_MB['small'])}. The balance most people want."),
+    ("large-v3-turbo", "large-v3-turbo",
+     f"{disk_size(WHISPER_MB['large-v3-turbo'])}. Best, and it wants a GPU."),
 ]
 
 TTS_ENGINES: List[Tuple[str, str, str]] = [
@@ -274,8 +295,8 @@ def _ask_ears(console: Console, answers: Dict[str, Any]) -> None:
     answers["stt_provider"] = engine
 
     if engine in STT_LOCAL:
-        console.print("\n  [dim]The weights are downloaded once into data/models/whisper, "
-                      "the first time she hears anything.[/dim]\n")
+        console.print("\n  [dim]The weights are downloaded once into data/models/whisper. "
+                      "No key, no account.[/dim]\n")
         answers["stt_model"] = _choose(console, "Model size", WHISPER_SIZES, "small")
         return
 
@@ -286,6 +307,76 @@ def _ask_ears(console: Console, answers: Dict[str, Any]) -> None:
 
     console.print()
     answers["stt_key"] = _ask_key(console, "API key", PROVIDER_KEYS[engine][1])
+
+
+def _download(console: Console, label: str, root: str, megabytes: int,
+              work: Callable[[Callable[[int], None]], Optional[Exception]]) -> bool:
+    """One download, with a bar, and a warning instead of a stack trace.
+
+    Failing here costs nothing but the wait it was meant to take out of her
+    first sentence: the engine fetches whatever is missing on first use.
+    """
+    total = megabytes * 1_000_000 or None
+    with Progress(SpinnerColumn(), TextColumn("  [dim]{task.description}[/dim]"), BarColumn(),
+                  DownloadColumn(), console=console, transient=True) as progress:
+        task = progress.add_task(label, total=total)
+        error = work(lambda done: progress.update(
+            task, completed=min(done, total) if total else done))
+
+    if not error:
+        console.print(f"  [green]✓[/green] {label} — ready in {root}.")
+        return True
+
+    console.print(f"  [yellow]?[/yellow] {label} — the download did not finish ({error}).")
+    hint = download_hint(error)
+    if hint:
+        console.print(f"  [dim]{hint}[/dim]")
+    return False
+
+
+def _ask_downloads(console: Console, answers: Dict[str, Any]) -> None:
+    """Fetches the two models that would otherwise arrive mid-conversation.
+
+    Her memory needs the embedder whether or not anything else was armed, so
+    this step is not tied to any of the answers above.
+    """
+    from src.core.config import BrainConfig
+
+    config = BrainConfig()
+    jobs: List[Tuple[str, str, int, Any]] = []
+
+    model = answers.get("stt_model")
+    whisper_root = config.faster_whisper_download_root or "data/models/whisper"
+    if answers.get("stt_provider") in STT_LOCAL and model and not whisper_here(model, whisper_root):
+        jobs.append((f"whisper {model}", whisper_root, WHISPER_MB.get(model, 0),
+                     lambda report, model=model: fetch_whisper(model, whisper_root,
+                                                               on_progress=report)))
+
+    memory = config.skills.get("memory", {})
+    embedder = memory.get("embedding_model")
+    cache = memory.get("embedding_cache_dir") or "data/embeddings_cache"
+    if memory.get("enabled", True) and not embedder_here(cache):
+        jobs.append(("her memory's embedder", cache, embedder_mb(embedder),
+                     lambda report: fetch_embedder(embedder, cache, on_progress=report)))
+
+    if not jobs:
+        console.print("  [green]✓[/green] Everything she needs is already on this machine.")
+        return
+
+    what = "one model" if len(jobs) == 1 else f"{len(jobs)} models"
+    console.print(f"  She needs {what} from Hugging Face, {disk_size(sum(job[2] for job in jobs))} "
+                  "in all. No account and no key —\n  and fetching them now means her first "
+                  "sentence is not spent waiting for one.\n")
+
+    if not Confirm.ask("  Download them now?", default=True):
+        console.print("  [dim]They will be fetched the first time each one is needed.[/dim]")
+        return
+
+    console.print()
+    done = [_download(console, label, root, megabytes, work) for label, root, megabytes, work in jobs]
+    if not all(done):
+        console.print("  [dim]Setup is finished either way — she fetches whatever is still "
+                      "missing the first time she needs it.[/dim]")
 
 
 def needs_obs(avatar: str, caption: str) -> bool:
@@ -479,6 +570,16 @@ def run_setup(console: Optional[Console] = None) -> int:
         return 1
 
     _write(console, answers)
+
+    # after the write on purpose: a download interrupted here still leaves a
+    # configured install behind
+    _rule(console, "last", "What she needs on disk")
+    try:
+        _ask_downloads(console, answers)
+    except (KeyboardInterrupt, EOFError):
+        console.print("\n  [yellow]Stopped the download.[/yellow] "
+                      "[dim]She will fetch what is missing when she needs it.[/dim]")
+
     _summary(console, answers)
     console.print()
     return 0

--- a/src/utils/huggingface.py
+++ b/src/utils/huggingface.py
@@ -1,0 +1,37 @@
+"""What to tell someone whose model download did not happen.
+
+Two of her parts are fetched from Hugging Face on first use — whisper and the
+embedder — and both hand back whatever huggingface_hub raised, which says `401`
+at a person who never knew an account was involved.
+"""
+
+from typing import Optional
+
+TOKEN_HINT = (
+    "Hugging Face refused the download. The weights are public, so this is "
+    "almost always a shared or office IP being rate-limited: wait a few minutes, "
+    "or put HF_TOKEN=<your token> in .env (https://huggingface.co/settings/tokens) "
+    "and it will be used for the download."
+)
+
+OFFLINE_HINT = (
+    "The weights could not be reached. Check the connection, then start her "
+    "again — the download resumes where it stopped."
+)
+
+
+def download_hint(error: Exception) -> Optional[str]:
+    """A line the person reading the log can act on, or None.
+
+    Only the two cases with a real answer get a hint; everything else is left
+    to speak for itself rather than be guessed at.
+    """
+    text = f"{type(error).__name__}: {error}".lower()
+
+    if any(word in text for word in ("401", "403", "429", "gated", "rate limit",
+                                     "too many requests", "unauthorized")):
+        return TOKEN_HINT
+    if any(word in text for word in ("connection", "timeout", "timed out",
+                                     "network", "dns", "offline", "unreachable")):
+        return OFFLINE_HINT
+    return None

--- a/tests/test_hf_hint.py
+++ b/tests/test_hf_hint.py
@@ -1,0 +1,28 @@
+"""Both models she downloads come from the same place and fail the same ways.
+
+What is asserted here is that the two failures with a real answer get one, and
+that nothing else is guessed at — a wrong explanation is worse than none.
+"""
+
+from src.utils.huggingface import OFFLINE_HINT, TOKEN_HINT, download_hint
+
+
+def test_a_refusal_points_at_the_token_that_would_fix_it():
+    assert download_hint(OSError("401 Client Error: Unauthorized")) == TOKEN_HINT
+    assert download_hint(OSError("429 Too Many Requests")) == TOKEN_HINT
+    assert download_hint(OSError("Access to this gated repo is restricted")) == TOKEN_HINT
+
+
+def test_a_connection_that_died_says_so_instead():
+    assert download_hint(OSError("Connection reset by peer")) == OFFLINE_HINT
+    assert download_hint(TimeoutError("timed out")) == OFFLINE_HINT
+
+
+def test_an_error_with_no_answer_is_left_to_speak_for_itself():
+    assert download_hint(ValueError("Invalid model size 'nonsense'")) is None
+    assert download_hint(RuntimeError("no wheel for this platform")) is None
+
+
+def test_the_type_of_the_error_counts_too():
+    """huggingface_hub says it in the class name as often as in the message."""
+    assert download_hint(type("GatedRepoError", (Exception,), {})()) == TOKEN_HINT

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -464,3 +464,27 @@ def test_a_patch_release_is_not_worth_re_embedding_for(monkeypatch):
     first = embedder_module._fastembed_series()
     monkeypatch.setattr(embedder_module.metadata, "version", lambda _: "0.7.9")
     assert embedder_module._fastembed_series() == first
+
+
+# --- a model that could not be downloaded ------------------------------------
+
+
+def test_an_embedder_that_cannot_be_fetched_says_what_would_fix_it(monkeypatch, caplog):
+    """A `429` on first use is a silent loss of recall, not a crash."""
+    import fastembed
+
+    from src.core.memory.embedder import FastEmbedEmbedder
+    from src.utils.huggingface import TOKEN_HINT
+
+    def refused(**kwargs):
+        raise OSError("429 Too Many Requests")
+
+    monkeypatch.setattr(fastembed, "TextEmbedding", refused)
+    embedder = FastEmbedEmbedder("BAAI/bge-small-en-v1.5")
+
+    with caplog.at_level("ERROR"):
+        for _ in range(3):
+            with pytest.raises(OSError):
+                embedder.embed(["a line"])
+
+    assert caplog.text.count(TOKEN_HINT) == 1, "the same explanation on every memory she writes"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -5,7 +5,6 @@ did not ask for."""
 from pathlib import Path
 
 from src.core.config import BrainConfig
-from src.modules.STT.faster_whisper_stt import download_hint
 from src.setup.config_plan import apply_answers, env_updates
 from src.setup.env_file import merge_env, parse_env
 from src.setup.prefetch import (
@@ -17,6 +16,7 @@ from src.setup.prefetch import (
     whisper_here,
 )
 from src.setup.wizard import disk_size
+from src.utils.huggingface import download_hint
 
 
 def config(tmp_path, monkeypatch) -> BrainConfig:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,9 +2,21 @@
 clobber a hand-edited `.env`, and it may not leave a skill armed that the user
 did not ask for."""
 
+from pathlib import Path
+
 from src.core.config import BrainConfig
+from src.modules.STT.faster_whisper_stt import download_hint
 from src.setup.config_plan import apply_answers, env_updates
 from src.setup.env_file import merge_env, parse_env
+from src.setup.prefetch import (
+    directory_bytes,
+    embedder_here,
+    embedder_mb,
+    fetch_embedder,
+    fetch_whisper,
+    whisper_here,
+)
+from src.setup.wizard import disk_size
 
 
 def config(tmp_path, monkeypatch) -> BrainConfig:
@@ -265,3 +277,106 @@ def test_env_updates_carries_every_skill_token():
     assert updates["DISCORD_TOKEN"] == "discord-token"
     assert updates["TELEGRAM_TOKEN"] == "telegram-token"
     assert "TWITCH_OAUTH_TOKEN" not in updates
+
+
+# --- the models she downloads ----------------------------------------------
+
+
+def writing(payload: bytes, name: str = "model.onnx"):
+    """A download that puts a file where the real one would."""
+
+    def download(model, root, local_files_only=False):
+        path = Path(root) / name
+        path.write_bytes(payload)
+        return str(path)
+
+    return download
+
+
+def test_directory_bytes_counts_what_is_already_down(tmp_path):
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "model.bin").write_bytes(b"x" * 40)
+    (tmp_path / "config.json").write_bytes(b"y" * 2)
+    assert directory_bytes(str(tmp_path)) == 42
+
+
+def test_directory_bytes_of_a_folder_that_is_not_there_is_zero(tmp_path):
+    assert directory_bytes(str(tmp_path / "gone")) == 0
+
+
+def test_a_finished_download_reports_no_error_and_leaves_the_weights(tmp_path):
+    root = tmp_path / "whisper"
+    assert fetch_whisper("small", str(root), downloader=writing(b"weights"), tick=0) is None
+    assert (root / "model.onnx").read_bytes() == b"weights"
+
+
+def test_the_progress_of_a_download_is_reported(tmp_path):
+    seen = []
+    fetch_whisper("small", str(tmp_path), downloader=writing(b"x" * 9), tick=0,
+                  on_progress=seen.append)
+    assert seen and seen[-1] == 9
+
+
+def test_a_download_that_failed_comes_back_as_the_error(tmp_path):
+    """Setup must survive it: the engine downloads them again on first use."""
+
+    def explode(model, root, local_files_only=False):
+        raise OSError("429 Too Many Requests")
+
+    error = fetch_whisper("small", str(tmp_path), downloader=explode, tick=0)
+    assert isinstance(error, OSError)
+    assert download_hint(error) is not None
+
+
+def test_the_model_id_is_normalised_before_anything_is_fetched(tmp_path):
+    """A hosted spelling left in config.json is not a repo huggingface serves."""
+    asked = []
+
+    def record(model, root, local_files_only=False):
+        asked.append(model)
+
+    fetch_whisper("openai/whisper-large-v3-turbo", str(tmp_path), downloader=record, tick=0)
+    assert asked == ["large-v3-turbo"]
+
+
+def test_weights_already_on_disk_are_not_downloaded_again(tmp_path):
+    def local_only(model, root, local_files_only=False):
+        if not local_files_only:
+            raise AssertionError("asked the network for something already here")
+        return str(tmp_path)
+
+    assert whisper_here("small", str(tmp_path), downloader=local_only)
+
+
+def test_weights_that_are_missing_are_reported_as_missing(tmp_path):
+    def missing(model, root, local_files_only=False):
+        raise OSError("not cached")
+
+    assert not whisper_here("small", str(tmp_path), downloader=missing)
+
+
+def test_an_embedder_already_cached_is_not_fetched_again(tmp_path):
+    """Her memory downloads one too, the first time she remembers anything."""
+    assert not embedder_here(str(tmp_path))
+    (tmp_path / "models--x").mkdir()
+    (tmp_path / "models--x" / "model.onnx").write_bytes(b"onnx")
+    assert embedder_here(str(tmp_path))
+
+
+def test_an_embedder_that_will_not_load_is_a_warning_not_a_crash(tmp_path):
+    def explode():
+        raise RuntimeError("no wheel for this platform")
+
+    assert isinstance(fetch_embedder(loader=explode, cache_dir=str(tmp_path), tick=0),
+                      RuntimeError)
+
+
+def test_the_embedder_size_comes_from_fastembeds_own_catalogue():
+    """Hardcoding it here would mean a bar that lies after any model change."""
+    assert 100 < embedder_mb(None) < 1000
+
+
+def test_a_size_is_shown_in_the_unit_a_person_would_say_it_in():
+    assert disk_size(75) == "~75 MB"
+    assert disk_size(1600) == "~1.6 GB"
+    assert disk_size(0) == ""

--- a/tests/test_stt_local.py
+++ b/tests/test_stt_local.py
@@ -150,3 +150,40 @@ def test_the_factory_builds_it(tmp_path, monkeypatch, loaded):
 
 def test_every_local_provider_is_one_the_factory_can_build():
     assert LOCAL <= set(BUILDERS)
+
+
+# --- a download that failed -------------------------------------------------
+
+
+def test_a_refusal_points_at_the_token_that_would_fix_it():
+    """`401` means nothing to someone who never knew an account was involved."""
+    from src.modules.STT.faster_whisper_stt import TOKEN_HINT, download_hint
+
+    assert download_hint(OSError("401 Client Error")) == TOKEN_HINT
+    assert download_hint(OSError("429 Too Many Requests")) == TOKEN_HINT
+
+
+def test_a_connection_that_died_says_so_instead():
+    from src.modules.STT.faster_whisper_stt import OFFLINE_HINT, download_hint
+
+    assert download_hint(OSError("Connection reset by peer")) == OFFLINE_HINT
+
+
+def test_an_error_with_no_answer_is_left_to_speak_for_itself():
+    from src.modules.STT.faster_whisper_stt import download_hint
+
+    assert download_hint(ValueError("Invalid model size 'nonsense'")) is None
+
+
+def test_the_hint_reaches_the_log_when_the_download_is_refused(tmp_path, monkeypatch, caplog):
+    import faster_whisper
+
+    from src.modules.STT.faster_whisper_stt import TOKEN_HINT
+
+    def refused(*args, **kwargs):
+        raise OSError("401 Client Error: Unauthorized")
+
+    monkeypatch.setattr(faster_whisper, "WhisperModel", refused)
+    with caplog.at_level("ERROR"):
+        FasterWhisperSTT(config(tmp_path, monkeypatch, stt_model="base"))
+    assert TOKEN_HINT in caplog.text

--- a/tests/test_stt_local.py
+++ b/tests/test_stt_local.py
@@ -155,30 +155,11 @@ def test_every_local_provider_is_one_the_factory_can_build():
 # --- a download that failed -------------------------------------------------
 
 
-def test_a_refusal_points_at_the_token_that_would_fix_it():
-    """`401` means nothing to someone who never knew an account was involved."""
-    from src.modules.STT.faster_whisper_stt import TOKEN_HINT, download_hint
-
-    assert download_hint(OSError("401 Client Error")) == TOKEN_HINT
-    assert download_hint(OSError("429 Too Many Requests")) == TOKEN_HINT
-
-
-def test_a_connection_that_died_says_so_instead():
-    from src.modules.STT.faster_whisper_stt import OFFLINE_HINT, download_hint
-
-    assert download_hint(OSError("Connection reset by peer")) == OFFLINE_HINT
-
-
-def test_an_error_with_no_answer_is_left_to_speak_for_itself():
-    from src.modules.STT.faster_whisper_stt import download_hint
-
-    assert download_hint(ValueError("Invalid model size 'nonsense'")) is None
-
-
 def test_the_hint_reaches_the_log_when_the_download_is_refused(tmp_path, monkeypatch, caplog):
+    """`401` means nothing to someone who never knew an account was involved."""
     import faster_whisper
 
-    from src.modules.STT.faster_whisper_stt import TOKEN_HINT
+    from src.utils.huggingface import TOKEN_HINT
 
     def refused(*args, **kwargs):
         raise OSError("401 Client Error: Unauthorized")


### PR DESCRIPTION
## What this changes

Two models arrive from Hugging Face on a fresh install: whisper, the first time
she hears anything, and the embedder, the first time she remembers anything.
Both were lazy, which on a fresh clone means her first sentence — or her first
memory — silently taking a minute with nothing on screen to say why.

The wizard now ends with a step that fetches whatever is missing, with a
progress bar, while the person is still sitting there. It is one question,
default yes, and declining it changes nothing: the engine downloads what it
needs on first use exactly as before. It runs after `config.json` and `.env`
are written, so a download interrupted halfway still leaves a configured
install behind.

And when a download is refused, both paths now say what would fix it.
`huggingface_hub` answers `401` at someone who never knew an account was
involved; the log now names `HF_TOKEN` and the page to get one, once, and only
for the two failures that have a real answer — a refusal and a dead connection.
Anything else is left to speak for itself.

No new question about a token: the repos are public, a token does not make the
download faster, and asking a consumer for one would contradict the "no key, no
bill" reason to pick the local transcriber in the first place. It is documented
as the fix for a rate-limited IP and nothing else.

## What breaks if it is wrong

Nothing she does at runtime — the prefetch is a wizard step and every failure
in it is a warning. The risk is the opposite: a setup that now appears to hang
on a slow connection. The bar is fed from the bytes on disk, Ctrl-C leaves a
resumable partial download and a written config, and a model already cached is
skipped rather than fetched again.

## Checks

- [x] `make test` passes — 1904 tests
- [x] `make lint` passes
- [x] New behaviour has a test named after the behaviour
- [x] `docs/` updated, if this changes something someone could be relying on